### PR TITLE
CP-822 CLI improvements & cleanup.

### DIFF
--- a/bin/dart_dev.dart
+++ b/bin/dart_dev.dart
@@ -3,7 +3,7 @@ library dart_dev.bin.dart_dev;
 import 'dart:io';
 
 import 'package:dart_dev/dart_dev.dart' show dev;
-import 'package:dart_dev/process.dart' show TaskProcess;
+import 'package:dart_dev/util.dart' show TaskProcess;
 
 main(List<String> args) async {
   File devFile = new File('./tool/dev.dart');

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -1,4 +1,0 @@
-library dart_dev.io;
-
-export 'package:dart_dev/src/io.dart'
-    show parseArgsFromCommand, parseExecutableFromCommand, Reporter, reporter;

--- a/lib/process.dart
+++ b/lib/process.dart
@@ -1,3 +1,0 @@
-library dart_dev.process;
-
-export 'package:dart_dev/src/task_process.dart' show TaskProcess;

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -5,9 +5,12 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/io.dart'
-    show parseArgsFromCommand, parseExecutableFromCommand, reporter;
-import 'package:dart_dev/process.dart';
+import 'package:dart_dev/util.dart'
+    show
+        TaskProcess,
+        parseArgsFromCommand,
+        parseExecutableFromCommand,
+        reporter;
 
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
@@ -75,7 +78,16 @@ Future _run(List<String> args) async {
     _parser.addCommand(command, cli.argParser);
   });
 
-  ArgResults env = _parser.parse(args);
+  ArgResults env;
+  try {
+    env = _parser.parse(args);
+  } on FormatException catch (e) {
+    reporter.error('${e.message}\n', shout: true);
+    reporter.log(_generateUsage(), shout: true);
+    exitCode = 1;
+    return;
+  }
+
   String task;
   if (env.command != null) {
     task = env.command.name;

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -1,4 +1,4 @@
-library dart_dev.src.io;
+library dart_dev.src.reporter;
 
 import 'dart:async';
 import 'dart:io';
@@ -11,16 +11,6 @@ final AnsiPen _blue = new AnsiPen()..cyan();
 final AnsiPen _green = new AnsiPen()..green();
 final AnsiPen _red = new AnsiPen()..red();
 final AnsiPen _yellow = new AnsiPen()..yellow();
-
-String parseExecutableFromCommand(String command) {
-  return command.split(' ').first;
-}
-
-List<String> parseArgsFromCommand(String command) {
-  var parts = command.split(' ');
-  if (parts.length <= 1) return [];
-  return parts.getRange(1, parts.length).toList();
-}
 
 class Reporter {
   bool color = true;

--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -3,7 +3,7 @@ library dart_dev.src.tasks.analyze.api;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dart_dev/process.dart';
+import 'package:dart_dev/util.dart' show TaskProcess;
 
 import 'package:dart_dev/src/tasks/analyze/config.dart';
 import 'package:dart_dev/src/tasks/task.dart';

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/io.dart' show reporter;
+import 'package:dart_dev/util.dart' show reporter;
 
 import 'package:dart_dev/src/tasks/analyze/api.dart';
 import 'package:dart_dev/src/tasks/analyze/config.dart';

--- a/lib/src/tasks/examples/api.dart
+++ b/lib/src/tasks/examples/api.dart
@@ -1,14 +1,23 @@
 library dart_dev.src.tasks.examples.api;
 
 import 'dart:async';
+import 'dart:io';
 
-import 'package:dart_dev/process.dart';
+import 'package:dart_dev/util.dart' show TaskProcess;
 
 import 'package:dart_dev/src/tasks/examples/config.dart';
 import 'package:dart_dev/src/tasks/task.dart';
 
+bool hasExamples() {
+  Directory exampleDir = new Directory('example');
+  return exampleDir.existsSync();
+}
+
 ExamplesTask serveExamples(
     {String hostname: defaultHostname, int port: defaultPort}) {
+  if (!hasExamples()) throw new Exception(
+      'This project does not have any examples.');
+
   var dartiumExecutable = 'dartium';
   var dartiumArgs = ['http://$hostname:$port'];
 
@@ -50,7 +59,12 @@ class ExamplesTask extends Task {
   StreamController<String> _pubServeOutput = new StreamController();
 
   ExamplesTask(String this.dartiumCommand, String this.pubServeCommand,
-      Future this.done);
+      Future this.done) {
+    done.then((_) {
+      _dartiumOutput.close();
+      _pubServeOutput.close();
+    });
+  }
 
   Stream<String> get dartiumOutput => _dartiumOutput.stream;
   Stream<String> get pubServeOutput => _pubServeOutput.stream;

--- a/lib/src/tasks/examples/cli.dart
+++ b/lib/src/tasks/examples/cli.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/io.dart' show reporter;
+import 'package:dart_dev/util.dart' show reporter;
 
 import 'package:dart_dev/src/tasks/examples/api.dart';
 import 'package:dart_dev/src/tasks/examples/config.dart';
@@ -28,6 +28,9 @@ class ExamplesCli extends TaskCli {
     if (port is String) {
       port = int.parse(port);
     }
+
+    if (!hasExamples()) return new CliResult.fail(
+        'This project does not have any examples.');
 
     ExamplesTask task = serveExamples(hostname: hostname, port: port);
     reporter.logGroup(task.pubServeCommand, outputStream: task.pubServeOutput);

--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -2,7 +2,7 @@ library dart_dev.src.tasks.format.api;
 
 import 'dart:async';
 
-import 'package:dart_dev/process.dart';
+import 'package:dart_dev/util.dart' show TaskProcess;
 
 import 'package:dart_dev/src/tasks/format/config.dart';
 import 'package:dart_dev/src/tasks/task.dart';

--- a/lib/src/tasks/format/cli.dart
+++ b/lib/src/tasks/format/cli.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/io.dart' show reporter;
+import 'package:dart_dev/util.dart' show hasImmediateDependency, reporter;
 
 import 'package:dart_dev/src/tasks/format/api.dart';
 import 'package:dart_dev/src/tasks/format/config.dart';
@@ -22,6 +22,17 @@ class FormatCli extends TaskCli {
   final String command = 'format';
 
   Future<CliResult> run(ArgResults parsedArgs) async {
+    try {
+      if (!hasImmediateDependency('dart_style')) return new CliResult.fail(
+          'Package "dart_style" must be an immediate dependency in order to run its executables.');
+    } catch (e) {
+      // It's possible that this check may throw if the pubspec.yaml
+      // could not be found or if the yaml could not be parsed.
+      // We silence this error and let the task continue in case it
+      // was a false negative. If it was accurate, then the task will
+      // fail anyway and the error will be available in the output.
+    }
+
     bool check = TaskCli.valueOf('check', parsedArgs, config.format.check);
     List<String> directories = config.format.directories;
 

--- a/lib/src/tasks/init/api.dart
+++ b/lib/src/tasks/init/api.dart
@@ -10,6 +10,8 @@ const String _initialConfig = '''library tool.dev;
 import 'package:dart_dev/dart_dev.dart' show dev, config;
 
 main(List<String> args) async {
+  // https://github.com/Workiva/dart_dev
+
   // Perform task configuration here as necessary.
 
   // Available task configurations:

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -2,7 +2,7 @@ library dart_dev.src.tasks.test.api;
 
 import 'dart:async';
 
-import 'package:dart_dev/process.dart';
+import 'package:dart_dev/util.dart' show TaskProcess;
 
 import 'package:dart_dev/src/tasks/task.dart';
 

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/io.dart';
+import 'package:dart_dev/util.dart' show hasImmediateDependency, reporter;
 
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
@@ -27,6 +27,9 @@ class TestCli extends TaskCli {
   final String command = 'test';
 
   Future<CliResult> run(ArgResults parsedArgs) async {
+    if (!hasImmediateDependency('test')) return new CliResult.fail(
+        'Package "test" must be an immediate dependency in order to run its executables.');
+
     bool unit = parsedArgs['unit'];
     bool integration = parsedArgs['integration'];
     List<String> platforms =

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,0 +1,28 @@
+library dart_dev.src.util;
+
+import 'dart:io';
+
+import 'package:yaml/yaml.dart';
+
+bool hasImmediateDependency(String packageName) {
+  File pubspec = new File('pubspec.yaml');
+  Map pubspecYaml = loadYaml(pubspec.readAsStringSync());
+  List deps = [];
+  if (pubspecYaml.containsKey('dependencies')) {
+    deps.addAll((pubspecYaml['dependencies'] as Map).keys);
+  }
+  if (pubspecYaml.containsKey('dev_dependencies')) {
+    deps.addAll((pubspecYaml['dev_dependencies'] as Map).keys);
+  }
+  return deps.contains(packageName);
+}
+
+String parseExecutableFromCommand(String command) {
+  return command.split(' ').first;
+}
+
+List<String> parseArgsFromCommand(String command) {
+  var parts = command.split(' ');
+  if (parts.length <= 1) return [];
+  return parts.getRange(1, parts.length).toList();
+}

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -1,0 +1,9 @@
+library dart_dev.util;
+
+export 'package:dart_dev/src/reporter.dart' show Reporter, reporter;
+export 'package:dart_dev/src/task_process.dart' show TaskProcess;
+export 'package:dart_dev/src/util.dart'
+    show
+        hasImmediateDependency,
+        parseArgsFromCommand,
+        parseExecutableFromCommand;

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -3,8 +3,8 @@ library dart_dev.dev;
 import 'package:dart_dev/dart_dev.dart';
 
 main(args) async {
-  config.analyze.entryPoints = ['lib/', 'test/', 'tool/'];
-  config.format.directories = ['lib/', 'test/', 'tool/'];
+  config.analyze.entryPoints = ['bin/', 'lib/', 'tool/'];
+  config.format.directories = ['bin/', 'lib/', 'tool/'];
 
   await dev(args);
 }


### PR DESCRIPTION
## Issue
- Initial implementation could use some minor cleanup and improvements to the CLI.
## Changes
- Consolidated utils, reporter, and TaskProcess class into single `util.dart` entry point
- `init` task now includes a link to the `dart_dev` repo as a comment in the generated file
- `analyze` and `format` tasks updated to include `bin/` directory
- CLI Improvements:
  - Catch the `FormatException` when an unsupported arg is used and display a helpful message along with the usage text instead of the stack trace
  - `examples` task now checks for the `example/` directory and displays an error message if it doesn't exist
  - `format` task now verifies that `dart_style` is an immediate dependency and will display a helpful error message if that's not the case
  - `test` task now verifies that `test` is an immediate dependency and will display a helpful error message if that's not the case
## Areas of Regression
- n/a
## Testing
- `ddev --unsupported` should display an error message stating that the `--unsupported` option is not supported in addition to the standard usage text instead of displaying the FormatException stack trace
- `examples`
  - warns if `example/` directory doesn't exist
- `format`
  - warns if `dart_style` isn't an immediate dependency (remove `dart_style` line from pubspec.yaml to test)
- `init`
  - includes a link to `dart_dev` repo in generated `tool/dev.dart` file
- `test`
  - warns if `test` isn't an immediate dependency (remove `test` line from pubspec.yaml to test)
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
fyi: @jayudey-wf
