### PR TITLE
CP-823 Integration Tests, dart_dev

### DIFF
--- a/bin/dart_dev.dart
+++ b/bin/dart_dev.dart
@@ -15,6 +15,7 @@ main(List<String> args) async {
     process.stdout.listen(stdout.writeln);
     process.stderr.listen(stderr.writeln);
     await process.done;
+    exitCode = await process.exitCode;
   } else {
     // Otherwise, run with defaults.
     await dev(args);

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -127,6 +127,7 @@ Future _run(List<String> args) async {
     reporter.success(result.message, shout: true);
   } else {
     reporter.error(result.message, shout: true);
+    exitCode = 1;
   }
 }
 

--- a/lib/src/task_process.dart
+++ b/lib/src/task_process.dart
@@ -10,11 +10,17 @@ class TaskProcess {
   Completer _outc = new Completer();
   Completer<int> _procExitCode = new Completer();
 
+  Process _process;
+
   StreamController<String> _stdout = new StreamController();
   StreamController<String> _stderr = new StreamController();
 
-  TaskProcess(String executable, List<String> arguments) {
-    Process.start(executable, arguments).then((process) {
+  TaskProcess(String executable, List<String> arguments,
+      {String workingDirectory}) {
+    Process
+        .start(executable, arguments, workingDirectory: workingDirectory)
+        .then((process) {
+      _process = process;
       process.stdout
           .transform(UTF8.decoder)
           .transform(new LineSplitter())
@@ -37,4 +43,7 @@ class TaskProcess {
 
   Stream<String> get stderr => _stderr.stream;
   Stream<String> get stdout => _stdout.stream;
+
+  bool kill([ProcessSignal signal = ProcessSignal.SIGTERM]) =>
+      _process.kill(signal);
 }

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -42,18 +42,20 @@ class TestCli extends TaskCli {
 
     List<String> tests = [];
     if (unit) {
-      if (config.test.unitTests.isEmpty) {
-        return new CliResult.fail(
-            'This project does not specify any unit tests.');
-      }
       tests.addAll(config.test.unitTests);
     }
     if (integration) {
-      if (config.test.integrationTests.isEmpty) {
+      tests.addAll(config.test.integrationTests);
+    }
+    if (tests.isEmpty) {
+      if (unit && config.test.unitTests.isEmpty) {
+        return new CliResult.fail(
+            'This project does not specify any unit tests.');
+      }
+      if (integration && config.test.integrationTests.isEmpty) {
         return new CliResult.fail(
             'This project does not specify any integration tests.');
       }
-      tests.addAll(config.test.integrationTests);
     }
 
     TestTask task = test(platforms: platforms, tests: tests);

--- a/test/fixtures/analyze/errors/lib/errors.dart
+++ b/test/fixtures/analyze/errors/lib/errors.dart
@@ -1,0 +1,8 @@
+library analyze_errors;
+
+import 'package:nonexistant/nonexistant.dart';
+
+void main() {
+  UnknownClass thing = 'error';
+  print(thing);
+}

--- a/test/fixtures/analyze/errors/pubspec.yaml
+++ b/test/fixtures/analyze/errors/pubspec.yaml
@@ -1,0 +1,5 @@
+name: analyze_errors
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/analyze/hints/lib/hints.dart
+++ b/test/fixtures/analyze/hints/lib/hints.dart
@@ -1,0 +1,7 @@
+library analyze_hints;
+
+import 'dart:async';
+
+void hints() {
+  var unused = '';
+}

--- a/test/fixtures/analyze/hints/pubspec.yaml
+++ b/test/fixtures/analyze/hints/pubspec.yaml
@@ -1,0 +1,5 @@
+name: analyze_hints
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/analyze/no_issues/bin/executable.dart
+++ b/test/fixtures/analyze/no_issues/bin/executable.dart
@@ -1,0 +1,5 @@
+library no_issues.bin.executable;
+
+void main(args) {
+  print(args);
+}

--- a/test/fixtures/analyze/no_issues/lib/no_issues.dart
+++ b/test/fixtures/analyze/no_issues/lib/no_issues.dart
@@ -1,0 +1,3 @@
+library analyze_no_issues;
+
+bool noIssues() => true;

--- a/test/fixtures/analyze/no_issues/pubspec.yaml
+++ b/test/fixtures/analyze/no_issues/pubspec.yaml
@@ -1,0 +1,5 @@
+name: analyze_no_issues
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/analyze/no_issues/tool/dev.dart
+++ b/test/fixtures/analyze/no_issues/tool/dev.dart
@@ -1,0 +1,8 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.analyze.entryPoints = ['bin/', 'lib/', 'tool/'];
+  await dev(args);
+}

--- a/test/fixtures/examples/examples_dir/example/index.html
+++ b/test/fixtures/examples/examples_dir/example/index.html
@@ -1,0 +1,1 @@
+Example!

--- a/test/fixtures/examples/examples_dir/pubspec.yaml
+++ b/test/fixtures/examples/examples_dir/pubspec.yaml
@@ -1,0 +1,5 @@
+name: examples_dir
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/examples/no_examples_dir/pubspec.yaml
+++ b/test/fixtures/examples/no_examples_dir/pubspec.yaml
@@ -1,0 +1,5 @@
+name: no_examples_dir
+  version: 0.0.0
+  dev_dependencies:
+    dart_dev:
+    path: ../../../..

--- a/test/fixtures/format/changes_needed/lib/main.dart
+++ b/test/fixtures/format/changes_needed/lib/main.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test/fixtures/format/changes_needed/pubspec.yaml
+++ b/test/fixtures/format/changes_needed/pubspec.yaml
@@ -1,0 +1,6 @@
+name: format_changes_needed
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  dart_style: "^0.2.0"

--- a/test/fixtures/format/no_changes_needed/bin/executable.dart
+++ b/test/fixtures/format/no_changes_needed/bin/executable.dart
@@ -1,0 +1,1 @@
+library no_changes_needed.bin.executable;

--- a/test/fixtures/format/no_changes_needed/lib/main.dart
+++ b/test/fixtures/format/no_changes_needed/lib/main.dart
@@ -1,0 +1,18 @@
+library main;
+
+List longList = [
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten'
+];
+
+void doStuff(content) {
+  print(content);
+}

--- a/test/fixtures/format/no_changes_needed/pubspec.yaml
+++ b/test/fixtures/format/no_changes_needed/pubspec.yaml
@@ -1,0 +1,6 @@
+name: format_no_changes_needed
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  dart_style: "^0.2.0"

--- a/test/fixtures/format/no_changes_needed/tool/dev.dart
+++ b/test/fixtures/format/no_changes_needed/tool/dev.dart
@@ -1,0 +1,8 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.format.directories = ['bin/', 'lib/', 'tool/'];
+  await dev(args);
+}

--- a/test/fixtures/format/no_dart_style/pubspec.yaml
+++ b/test/fixtures/format/no_dart_style/pubspec.yaml
@@ -1,0 +1,5 @@
+name: format_no_dart_style
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/init/initialized/pubspec.yaml
+++ b/test/fixtures/init/initialized/pubspec.yaml
@@ -1,0 +1,5 @@
+name: init_initialized
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/init/initialized/tool/dev.dart
+++ b/test/fixtures/init/initialized/tool/dev.dart
@@ -1,0 +1,7 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart';
+
+main(args) async {
+  await dev(args);
+}

--- a/test/fixtures/init/uninitialized/pubspec.yaml
+++ b/test/fixtures/init/uninitialized/pubspec.yaml
@@ -1,0 +1,5 @@
+name: init_uninitialized
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/test/failing/pubspec.yaml
+++ b/test/fixtures/test/failing/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_failing
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"

--- a/test/fixtures/test/failing/test/failing_integration_test.dart
+++ b/test/fixtures/test/failing/test/failing_integration_test.dart
@@ -1,0 +1,9 @@
+library test_failing.test.failing_integration_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('fails', () {
+    expect(true, isFalse);
+  });
+}

--- a/test/fixtures/test/failing/test/failing_unit_test.dart
+++ b/test/fixtures/test/failing/test/failing_unit_test.dart
@@ -1,0 +1,9 @@
+library test_failing.test.failing_unit_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('fails', () {
+    expect(true, isFalse);
+  });
+}

--- a/test/fixtures/test/failing/tool/dev.dart
+++ b/test/fixtures/test/failing/tool/dev.dart
@@ -1,0 +1,11 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.test
+    ..unitTests = ['test/failing_unit_test.dart']
+    ..integrationTests = ['test/failing_integration_test.dart'];
+
+  await dev(args);
+}

--- a/test/fixtures/test/no_test_package/pubspec.yaml
+++ b/test/fixtures/test/no_test_package/pubspec.yaml
@@ -1,0 +1,5 @@
+name: test_no_test_package
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/fixtures/test/passing/pubspec.yaml
+++ b/test/fixtures/test/passing/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_passing
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"

--- a/test/fixtures/test/passing/test/passing_integration_test.dart
+++ b/test/fixtures/test/passing/test/passing_integration_test.dart
@@ -1,0 +1,9 @@
+library test_failing.test.passing_integration_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test/fixtures/test/passing/test/passing_unit_test.dart
+++ b/test/fixtures/test/passing/test/passing_unit_test.dart
@@ -1,0 +1,9 @@
+library test_failing.test.passing_unit_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test/fixtures/test/passing/tool/dev.dart
+++ b/test/fixtures/test/passing/tool/dev.dart
@@ -1,0 +1,11 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.test
+    ..unitTests = ['test/passing_unit_test.dart']
+    ..integrationTests = ['test/passing_integration_test.dart'];
+
+  await dev(args);
+}

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -1,0 +1,107 @@
+@TestOn('vm')
+library dart_dev.test.integration.analyze_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:test/test.dart';
+
+const String projectWithErrors = 'test/fixtures/analyze/errors';
+const String projectWithHints = 'test/fixtures/analyze/hints';
+const String projectWithNoIssues = 'test/fixtures/analyze/no_issues';
+
+Future<Analysis> analyzeProject(String projectPath,
+    {bool fatalWarnings: true, bool hints: true}) async {
+  await Process.run('pub', ['get'], workingDirectory: projectPath);
+
+  var args = ['run', 'dart_dev', 'analyze'];
+  args.add(fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings');
+  args.add(hints ? '--hints' : '--no-hints');
+  TaskProcess process =
+      new TaskProcess('pub', args, workingDirectory: projectPath);
+
+  List<String> files = [];
+  int numErrors = 0;
+  int numHints = 0;
+  int numWarnings = 0;
+
+  RegExp filesPattern = new RegExp(r'Analyzing \[(.*)\]');
+  RegExp errorsPattern = new RegExp(r'(\d+) error.* found');
+  RegExp hintsPattern = new RegExp(r'(\d+) hint.* found');
+  RegExp warningsPattern = new RegExp(r'(\d+) warning.* found');
+
+  process.stdout.listen((line) {
+    if (line.contains(filesPattern)) {
+      files = filesPattern.firstMatch(line).group(1).split(', ');
+    }
+    if (line.contains(errorsPattern)) {
+      numErrors += int.parse(errorsPattern.firstMatch(line).group(1));
+    }
+    if (line.contains(hintsPattern)) {
+      numHints += int.parse(hintsPattern.firstMatch(line).group(1));
+    }
+    if (line.contains(warningsPattern)) {
+      numWarnings += int.parse(warningsPattern.firstMatch(line).group(1));
+    }
+  });
+
+  await process.done;
+  return new Analysis(
+      await process.exitCode, files, numErrors, numHints, numWarnings);
+}
+
+class Analysis {
+  final int exitCode;
+  final List<String> files;
+  final int numErrors;
+  final int numHints;
+  final int numWarnings;
+  Analysis(this.exitCode, this.files, this.numErrors, this.numHints,
+      this.numWarnings);
+  bool get noIssues => numHints + numErrors == 0;
+}
+
+void main() {
+  group('Analyze Task', () {
+    test('should discover all top-level files of defined entry points',
+        () async {
+      Analysis analysis = await analyzeProject(projectWithNoIssues);
+      var expectedFiles = [
+        'bin/executable.dart',
+        'lib/no_issues.dart',
+        'tool/dev.dart'
+      ];
+      expect(analysis.files, unorderedEquals(expectedFiles));
+    });
+
+    test('should report no issues found', () async {
+      Analysis analysis = await analyzeProject(projectWithNoIssues);
+      expect(analysis.noIssues, isTrue);
+    });
+
+    test('should report hints if configured to do so', () async {
+      Analysis analysis = await analyzeProject(projectWithHints);
+      expect(analysis.numHints, equals(2));
+    });
+
+    test('should not report hints if configured to ignore them', () async {
+      Analysis analysis = await analyzeProject(projectWithHints, hints: false);
+      expect(analysis.numHints, equals(0));
+    });
+
+    test('should report warnings as fatal if configured to do so', () async {
+      Analysis analysis = await analyzeProject(projectWithErrors);
+      expect(analysis.numErrors, equals(2));
+      expect(analysis.numWarnings, equals(0));
+    });
+
+    test('should not report warnings as fatal if not configured to do so',
+        () async {
+      Analysis analysis =
+          await analyzeProject(projectWithErrors, fatalWarnings: false);
+      expect(analysis.numErrors, equals(1));
+      expect(analysis.numWarnings, equals(1));
+    });
+  });
+}

--- a/test/integration/examples_test.dart
+++ b/test/integration/examples_test.dart
@@ -1,0 +1,43 @@
+@TestOn('vm')
+library dart_dev.test.integration.examples_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:test/test.dart';
+
+const String projectWithExamples = 'test/fixtures/examples/examples_dir';
+const String projectWithoutExamples = 'test/fixtures/examples/no_examples_dir';
+
+Future<bool> serveExamplesFor(String projectPath) async {
+  await Process.run('pub', ['get'], workingDirectory: projectPath);
+
+  TaskProcess process = new TaskProcess('pub', ['run', 'dart_dev', 'examples'],
+      workingDirectory: projectPath);
+
+  bool served = false;
+
+  Pattern pubServePattern = new RegExp(r'pub serve .* example');
+  process.stdout.listen((line) {
+    if (line.contains(pubServePattern)) {
+      served = true;
+      process.kill();
+    }
+  });
+
+  await process.done;
+  return served;
+}
+
+void main() {
+  group('Examples Task', () {
+    test('should warn if no examples directory found', () async {
+      expect(await serveExamplesFor(projectWithoutExamples), isFalse);
+    });
+
+    test('should serve if examples directory found', () async {
+      expect(await serveExamplesFor(projectWithExamples), isTrue);
+    });
+  });
+}

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -1,0 +1,81 @@
+@TestOn('vm')
+library dart_dev.test.integration.format_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:test/test.dart';
+
+const String projectWithChangesNeeded = 'test/fixtures/format/changes_needed';
+const String projectWithNoChangesNeeded =
+    'test/fixtures/format/no_changes_needed';
+const String projectWithoutDartStyle = 'test/fixtures/format/no_dart_style';
+
+/// Runs dart formatter via dart_dev on given project.
+///
+/// If [check] is true, a dry-run only is run. Returns true if changes are
+/// needed, false if the project is well-formatted.
+///
+/// If [check] is false, an actual formatting run is run. Returns true if
+/// formatting was successful, false otherwise.
+Future<bool> formatProject(String projectPath, {bool check: false}) async {
+  await Process.run('pub', ['get'], workingDirectory: projectPath);
+  var args = ['run', 'dart_dev', 'format'];
+  if (check) {
+    args.add('--check');
+  }
+  TaskProcess process =
+      new TaskProcess('pub', args, workingDirectory: projectPath);
+
+  await process.done;
+  return (await process.exitCode) == 0;
+}
+
+void main() {
+  group('Format Task', () {
+    test('--check should succeed if no files need formatting', () async {
+      expect(
+          await formatProject(projectWithNoChangesNeeded, check: true), isTrue);
+    });
+
+    test('--check should fail if one or more files need formatting', () async {
+      expect(
+          await formatProject(projectWithChangesNeeded, check: true), isFalse);
+    });
+
+    test('should not make any changes to a well-formatted project', () async {
+      File file = new File('$projectWithNoChangesNeeded/lib/main.dart');
+      String contentsBefore = file.readAsStringSync();
+      expect(await formatProject(projectWithNoChangesNeeded), isTrue);
+      String contentsAfter = file.readAsStringSync();
+      expect(contentsBefore, equals(contentsAfter));
+    });
+
+    test('should format an ill-formatted project', () async {
+      // Copy the ill-formatted project fixture to a temporary directory for
+      // testing purposes (necessary since formatter will make changes).
+      String testProject = '${projectWithChangesNeeded}_temp';
+      Directory temp = new Directory(testProject);
+      temp.createSync();
+      await Process.run(
+          'cp', ['-R', '$projectWithChangesNeeded/', testProject]);
+
+      File dirtyFile = new File('$testProject/lib/main.dart');
+      File cleanFile = new File('$projectWithNoChangesNeeded/lib/main.dart');
+      String contentsBefore = dirtyFile.readAsStringSync();
+      expect(await formatProject(testProject), isTrue);
+      String contentsAfter = dirtyFile.readAsStringSync();
+      expect(contentsBefore, isNot(equals(contentsAfter)));
+      expect(contentsAfter, equals(cleanFile.readAsStringSync()));
+
+      // Clean up the temporary test project created for this test case.
+      temp.deleteSync(recursive: true);
+    });
+
+    test('should warn if "dart_style" is not an immediate dependency',
+        () async {
+      expect(await formatProject(projectWithoutDartStyle), isFalse);
+    });
+  });
+}

--- a/test/integration/init_test.dart
+++ b/test/integration/init_test.dart
@@ -1,0 +1,39 @@
+@TestOn('vm')
+library dart_dev.test.integration.init_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:test/test.dart';
+
+const String initializedProject = 'test/fixtures/init/initialized';
+const String uninitializedProject = 'test/fixtures/init/uninitialized';
+
+Future init(String projectPath) async {
+  await Process.run('pub', ['get'], workingDirectory: projectPath);
+
+  TaskProcess process = new TaskProcess('pub', ['run', 'dart_dev', 'init'],
+      workingDirectory: projectPath);
+  await process.done;
+}
+
+void main() {
+  group('Init Task', () {
+    test('should not overwrite tool/dev.dart if it already exists', () async {
+      File dartDev = new File('$initializedProject/tool/dev.dart');
+      String contentsBefore = dartDev.readAsStringSync();
+      await init(initializedProject);
+      String contentsAfter = dartDev.readAsStringSync();
+      expect(contentsBefore, equals(contentsAfter));
+    });
+
+    test('should generate a tool/dev.dart', () async {
+      File dartDev = new File('$uninitializedProject/tool/dev.dart');
+      expect(dartDev.existsSync(), isFalse);
+      await init(uninitializedProject);
+      expect(dartDev.existsSync(), isTrue);
+      dartDev.deleteSync();
+    });
+  });
+}

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -1,0 +1,69 @@
+@TestOn('vm')
+library dart_dev.test.integration.test_test;
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:test/test.dart';
+
+const String projectWithoutTestPackage = 'test/fixtures/test/no_test_package';
+const String projectWithFailingTests = 'test/fixtures/test/failing';
+const String projectWithPassingTests = 'test/fixtures/test/passing';
+
+Future<bool> runTests(String projectPath,
+    {bool unit: true, bool integration: false}) async {
+  await Process.run('pub', ['get'], workingDirectory: projectPath);
+
+  List args = ['run', 'dart_dev', 'test'];
+  args.add(unit ? '--unit' : '--no-unit');
+  args.add(integration ? '--integration' : '--no-integration');
+  TaskProcess process =
+      new TaskProcess('pub', args, workingDirectory: projectPath);
+
+  await process.done;
+  return (await process.exitCode) == 0;
+}
+
+void main() {
+  group('Test Task', () {
+    test('should fail if some unit tests fail', () async {
+      expect(
+          await runTests(projectWithFailingTests,
+              unit: true, integration: false),
+          isFalse);
+    });
+
+    test('should fail if some integration tests fail', () async {
+      expect(
+          await runTests(projectWithFailingTests,
+              unit: false, integration: true),
+          isFalse);
+    });
+
+    test('should run unit tests', () async {
+      expect(
+          await runTests(projectWithPassingTests,
+              unit: true, integration: false),
+          isTrue);
+    });
+
+    test('should run integration tests', () async {
+      expect(
+          await runTests(projectWithPassingTests,
+              unit: false, integration: true),
+          isTrue);
+    });
+
+    test('should run unit and integration tests', () async {
+      expect(
+          await runTests(projectWithPassingTests,
+              unit: true, integration: true),
+          isTrue);
+    });
+
+    test('should warn if "test" package is not immediate dependency', () async {
+      expect(await runTests(projectWithoutTestPackage), isFalse);
+    });
+  });
+}

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -3,8 +3,11 @@ library dart_dev.dev;
 import 'package:dart_dev/dart_dev.dart';
 
 main(args) async {
-  config.analyze.entryPoints = ['bin/', 'lib/', 'tool/'];
-  config.format.directories = ['bin/', 'lib/', 'tool/'];
+  config.analyze.entryPoints = ['bin/', 'lib/', 'test/integration/', 'tool/'];
+  config.format.directories = ['bin/', 'lib/', 'test/integration/', 'tool/'];
+  config.test
+    ..unitTests = []
+    ..integrationTests = ['test/integration/'];
 
   await dev(args);
 }


### PR DESCRIPTION
## Issue
- Need some tests!
## Changes

**Source:**
- Ensure the exit code is set correctly
- Update `TaskProcess` to allow `workingDirectory` configuration and ability to kill process

**Tests:**
- Integration tests for all 5 currently supported tasks (analyze, examples, format, init, test)
  - Runs the dart_dev tasks on actual project fixtures designed to test various expectations
## Areas of Regression
- n/a
## Testing
- `ddev test --integration` (I will setup Travis CI once this repo is public)
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
fyi: @jayudey-wf
