### PR TITLE
CP-827 Add line-length option to format task.

### DIFF
--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -8,9 +8,13 @@ import 'package:dart_dev/src/tasks/format/config.dart';
 import 'package:dart_dev/src/tasks/task.dart';
 
 FormatTask format(
-    {bool check: defaultCheck, List<String> directories: defaultDirectories}) {
+    {bool check: defaultCheck,
+    List<String> directories: defaultDirectories,
+    int lineLength: defaultLineLength}) {
   var executable = 'pub';
   var args = ['run', 'dart_style:format'];
+
+  args.addAll(['-l', '$lineLength']);
 
   if (check) {
     args.add('-n');

--- a/lib/src/tasks/format/cli.dart
+++ b/lib/src/tasks/format/cli.dart
@@ -17,7 +17,9 @@ class FormatCli extends TaskCli {
         defaultsTo: defaultCheck,
         negatable: false,
         help:
-            'Dry-run; checks if formatter needs to be run and sets exit code accordingly.');
+            'Dry-run; checks if formatter needs to be run and sets exit code accordingly.')
+    ..addOption('line-length',
+        abbr: 'l', defaultsTo: '80', help: 'Wrap lines longer than this.');
 
   final String command = 'format';
 
@@ -35,8 +37,14 @@ class FormatCli extends TaskCli {
 
     bool check = TaskCli.valueOf('check', parsedArgs, config.format.check);
     List<String> directories = config.format.directories;
+    var lineLength =
+        TaskCli.valueOf('line-length', parsedArgs, config.format.lineLength);
+    if (lineLength is String) {
+      lineLength = int.parse(lineLength);
+    }
 
-    FormatTask task = format(check: check, directories: directories);
+    FormatTask task =
+        format(check: check, directories: directories, lineLength: lineLength);
     reporter.logGroup(task.formatterCommand,
         outputStream: task.formatterOutput);
     await task.done;

--- a/lib/src/tasks/format/config.dart
+++ b/lib/src/tasks/format/config.dart
@@ -4,8 +4,10 @@ import 'package:dart_dev/src/tasks/config.dart';
 
 const bool defaultCheck = false;
 const List<String> defaultDirectories = const ['lib/'];
+const int defaultLineLength = 80;
 
 class FormatConfig extends TaskConfig {
   bool check = defaultCheck;
   List<String> directories = defaultDirectories;
+  int lineLength = defaultLineLength;
 }


### PR DESCRIPTION
## Issue
- #14 
## Changes

**Source:**
- Add option to configure line length for dart formatter

**Tests:**
- n/a
## Areas of Regression
- default usage of dart_dev format task
## Testing
- `ddev format --check` should find no necessary changes
- `ddev format --check -l 150` should find quite a few necessary changes
## Code Review

@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
fyi: @jayudey-wf
