### PR TITLE
CP-847 Add all required dependencies to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,10 @@ static analysis - you just need to know how to use the `dart_dev` tool.
 Add the following to your `pubspec.yaml`:
 ```yaml
 dev_dependencies:
-  dart_dev: any
+  coverage: "^0.7.2"
+  dart_dev: "^1.0.0"
+  dart_style: "^0.2.0"
+  test: "^0.12.0"
 ```
 
 ###### Create an Alias (optional)


### PR DESCRIPTION
## Issue
#24 Since we require that `coverage`, `dart_style`, and `test` be immediate dependencies so that we can run their executables, we should add those to the install instructions in the readme.

## Changes
- Update recommended dart_dev version to "^1.0.0" in anticipation of first release
- Require `coverage` "^0.7.2" since that is the first version that supports the `--report-on` flag
- Require `dart_style` "^0.2.0" since that is the latest minor version
- Require `test` "^0.12.0" since that is the test runner that our test/coverage tasks were built on

## Areas of Regression
- n/a

## Testing
- n/a

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf