### PR TITLE
CP-858 Travis CI, dart_dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: dart
+dart:
+  - stable
+with_content_shell: true
+before_install:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+script:
+  - pub run dart_dev format --check
+  - pub run dart_dev analyze
+  - pub run dart_dev test --integration
+  - pub run dart_dev coverage --integration --no-html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Dart Dev Tools
+[![Build Status](https://travis-ci.org/Workiva/dart_dev.svg?branch=master)](https://travis-ci.org/Workiva/dart_dev)
 
 > Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 
@@ -211,6 +212,7 @@ All configuration options for the `test` task are found on the `config.test` obj
 
 Name               | Type           | Default     | Description
 ------------------ | -------------- | ----------- | -----------
+`concurrency`      | `int`          | `4`         | Number of concurrent test suites run.
 `integrationTests` | `List<String>` | `[]`        | Integration test locations. Items in this list can be directories and/or files.
 `platforms`        | `List<String>` | `[]`        | Platforms on which to run the tests (handled by the Dart test runner). See https://github.com/dart-lang/test#platform-selector-syntax for a full list of supported platforms.
 `unitTests`        | `List<String>` | `['test/']` | Unit test locations. Items in this list can be directories and/or files.

--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -85,7 +85,7 @@ class CoverageCli extends TaskCli {
     reporter.logGroup('Collecting coverage',
         outputStream: task.output, errorStream: task.errorOutput);
     CoverageResult result = await task.done;
-    if (result.successful && open) {
+    if (result.successful && html && open) {
       Process.run('open', [result.reportIndex.path]);
     }
     return result.successful

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -21,14 +21,19 @@ import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:dart_dev/src/tasks/task.dart';
 
 TestTask test(
-    {List<String> platforms: const [], List<String> tests: const []}) {
+    {int concurrency,
+    List<String> platforms: const [],
+    List<String> tests: const []}) {
   var executable = 'pub';
   var args = ['run', 'test'];
+  if (concurrency != null) {
+    args.add('--concurrency=$concurrency');
+  }
   platforms.forEach((p) {
     args.addAll(['-p', p]);
   });
-  args.addAll(tests);
   args.addAll(['--reporter=expanded']);
+  args.addAll(tests);
 
   TaskProcess process = new TaskProcess(executable, args);
   Completer outputProcessed = new Completer();

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -32,6 +32,10 @@ class TestCli extends TaskCli {
     ..addFlag('integration',
         defaultsTo: defaultIntegration,
         help: 'Includes the integration test suite.')
+    ..addOption('concurrency',
+        abbr: 'j',
+        defaultsTo: '$defaultConcurrency',
+        help: 'The number of concurrent test suites run.')
     ..addOption('platform',
         abbr: 'p',
         allowMultiple: true,
@@ -46,6 +50,11 @@ class TestCli extends TaskCli {
 
     bool unit = parsedArgs['unit'];
     bool integration = parsedArgs['integration'];
+    var concurrency =
+        TaskCli.valueOf('concurrency', parsedArgs, config.test.concurrency);
+    if (concurrency is String) {
+      concurrency = int.parse(concurrency);
+    }
     List<String> platforms =
         TaskCli.valueOf('platform', parsedArgs, config.test.platforms);
 
@@ -72,7 +81,8 @@ class TestCli extends TaskCli {
       }
     }
 
-    TestTask task = test(platforms: platforms, tests: tests);
+    TestTask task =
+        test(tests: tests, concurrency: concurrency, platforms: platforms);
     reporter.logGroup(task.testCommand, outputStream: task.testOutput);
     await task.done;
     return task.successful

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -16,6 +16,7 @@ library dart_dev.src.tasks.test.config;
 
 import 'package:dart_dev/src/tasks/config.dart';
 
+const int defaultConcurrency = 4;
 const bool defaultIntegration = false;
 const List<String> defaultIntegrationTests = const [];
 const bool defaultUnit = true;
@@ -23,6 +24,7 @@ const List<String> defaultUnitTests = const ['test/'];
 const List<String> defaultPlatforms = const [];
 
 class TestConfig extends TaskConfig {
+  int concurrency = defaultConcurrency;
   List<String> integrationTests = defaultIntegrationTests;
   List<String> platforms = defaultPlatforms;
   List<String> unitTests = defaultUnitTests;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -17,7 +17,33 @@ library dart_dev.src.util;
 import 'dart:async';
 import 'dart:io';
 
+import 'package:path/path.dart' as path;
 import 'package:yaml/yaml.dart';
+
+void copyDirectory(Directory source, Directory dest) {
+  if (!dest.existsSync()) {
+    dest.createSync(recursive: true);
+  }
+
+  source.listSync(recursive: true).forEach((entity) {
+    if (FileSystemEntity.isDirectorySync(entity.path)) {
+      Directory orig = entity;
+      String p = path.relative(orig.path, from: source.path);
+      p = path.join(dest.path, p);
+      Directory copy = new Directory(p);
+      if (!copy.existsSync()) {
+        copy.createSync(recursive: true);
+      }
+    } else if (FileSystemEntity.isFileSync(entity.path)) {
+      File orig = entity;
+      String p = path.relative(orig.path, from: source.path);
+      p = path.join(dest.path, p);
+      File copy = new File(p);
+      copy.createSync(recursive: true);
+      copy.writeAsBytesSync(orig.readAsBytesSync());
+    }
+  });
+}
 
 /// Returns an open port by creating a temporary Socket.
 /// Borrowed from coverage package https://github.com/dart-lang/coverage/blob/master/lib/src/util.dart#L49-L66

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -18,6 +18,7 @@ export 'package:dart_dev/src/reporter.dart' show Reporter, reporter;
 export 'package:dart_dev/src/task_process.dart' show TaskProcess;
 export 'package:dart_dev/src/util.dart'
     show
+        copyDirectory,
         getOpenPort,
         hasImmediateDependency,
         parseArgsFromCommand,

--- a/test/integration/copy_license_test.dart
+++ b/test/integration/copy_license_test.dart
@@ -12,12 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+@TestOn('vm')
 library dart_dev.test.integration.copy_license_test;
 
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:dart_dev/util.dart' show TaskProcess, copyDirectory;
 import 'package:test/test.dart';
 
 const String projectWithLicenses = 'test/fixtures/copy_license/has_licenses';
@@ -28,8 +29,7 @@ const String projectWithoutLicenses = 'test/fixtures/copy_license/no_licenses';
 Future<String> createTemporaryProject(String source) async {
   String tempProject = '${source}_temp';
   Directory temp = new Directory(tempProject);
-  temp.createSync();
-  await Process.run('cp', ['-R', '$source/', tempProject]);
+  copyDirectory(new Directory(source), temp);
   return tempProject;
 }
 

--- a/test/integration/coverage_test.dart
+++ b/test/integration/coverage_test.dart
@@ -33,7 +33,7 @@ Future<bool> runCoverage(String projectPath) async {
     oldCoverage.deleteSync(recursive: true);
   }
 
-  List args = ['run', 'dart_dev', 'coverage', '--no-open'];
+  List args = ['run', 'dart_dev', 'coverage', '--no-html'];
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
 

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -18,7 +18,7 @@ library dart_dev.test.integration.format_test;
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:dart_dev/util.dart' show TaskProcess, copyDirectory;
 import 'package:test/test.dart';
 
 const String projectWithChangesNeeded = 'test/fixtures/format/changes_needed';
@@ -71,9 +71,7 @@ void main() {
       // testing purposes (necessary since formatter will make changes).
       String testProject = '${projectWithChangesNeeded}_temp';
       Directory temp = new Directory(testProject);
-      temp.createSync();
-      await Process.run(
-          'cp', ['-R', '$projectWithChangesNeeded/', testProject]);
+      copyDirectory(new Directory(projectWithChangesNeeded), temp);
 
       File dirtyFile = new File('$testProject/lib/main.dart');
       File cleanFile = new File('$projectWithNoChangesNeeded/lib/main.dart');

--- a/tool/dev.dart
+++ b/tool/dev.dart
@@ -23,8 +23,10 @@ main(args) async {
   config.coverage.reportOn = ['bin/', 'lib/'];
   config.format.directories = directories;
   config.test
-    ..unitTests = []
-    ..integrationTests = ['test/integration/'];
+    ..concurrency = 1
+    ..platforms = ['vm']
+    ..integrationTests = ['test/integration/']
+    ..unitTests = [];
 
   await dev(args);
 }


### PR DESCRIPTION
## Issue
#29 Setup CI build through Travis CI

## Changes
**Source:**
- Add `.travis.yml`
- Add travis badge to readme
- Add a `--concurrency` option to the Test task (simply forwarded to the `test` package executable)
- Use the `path` package to properly join paths (many paths erroneously included double slashes `//`)\
- Add a check to ensure the `coverage.lcov` file was properly created
- Listen to content-shell's stdout for the observatory port in addition to stderr - I noticed on a few Travis builds that the observatory port output to stderr was malformed, so watching both should catch the correct one
- Don't try to open the report if the `--no-html` option was set, because there would be no report to open
- Add a utility to copy a directory and its contents using Dart's File API instead of using an OS command
- Set the default concurrency to `1` since the integration tests are currently very intensive

**Tests:**
- n/a

## Areas of Regression
- coverage

## Testing
- Travis CI build should run and pass.
- The build should run..
  - a dart format check
  - dartanalyzer
  - all integration tests
  - a coverage run

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf