### PR TITLE
CP-859 Codecov.io, dart_dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
   - pub run dart_dev analyze
   - pub run dart_dev test --integration
   - pub run dart_dev coverage --integration --no-html
+  - bash <(curl -s https://codecov.io/bash) -f coverage/coverage.lcov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Dart Dev Tools
-[![Build Status](https://travis-ci.org/Workiva/dart_dev.svg?branch=master)](https://travis-ci.org/Workiva/dart_dev)
+[![Build Status](https://travis-ci.org/Workiva/dart_dev.svg?branch=master)](https://travis-ci.org/Workiva/dart_dev) [![codecov.io](http://codecov.io/github/Workiva/dart_dev/coverage.svg?branch=master)](http://codecov.io/github/Workiva/dart_dev?branch=master)
 
 > Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 


### PR DESCRIPTION
_Dependent on #39._

## Issue
#30 Setup codecov.io reporting.

## Changes
- Add bash reporter step to travis CI build.
- Add codecov.io badge to readme

## Areas of Regression
- n/a

## Testing
- CI build runs and passes and the codecov bash reporter successfully found the `coverage.lcov` file and uploaded it to codecov.io (build logs should indicate this).
- Codecov report should show up here: https://codecov.io/github/Workiva/dart_dev

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf