### PR TITLE
CP-864 Explicitly exit process when dart_dev has finished

### DIFF
--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -62,6 +62,7 @@ dev(List<String> args) async {
   registerTask(new TestCli(), config.test);
 
   await _run(args);
+  exit(exitCode);
 }
 
 void registerTask(TaskCli cli, TaskConfig config) {


### PR DESCRIPTION
## Issue
When a project has a custom `tool/dev.dart` configuration, dart_dev has to spawn a process to take advantage of that. Dart_dev then waits for that process to complete before exiting the main process. It's possible that this sub process may fail to complete, even if the dart_dev task has completed successfully.

## Changes
**Source:**
- The `dev()` file that acts as the entry point for the executable (either through the default usage or through the sub-process scenario that runs a project's `tool/dev.dart` file) now explicitly exits the process to force completion of the parent task.

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- CI build passes.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf