### PR TITLE
CP-925 Coverage: wait for "open" command

### DIFF
--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -95,7 +95,7 @@ class CoverageCli extends TaskCli {
     }
 
     if (result.successful && html && open) {
-      Process.run('open', [result.reportIndex.path]);
+      await Process.run('open', [result.reportIndex.path]);
     }
     return result.successful
         ? new CliResult.success('Coverage collected.')


### PR DESCRIPTION
## Issue
#59 

## Changes
**Source:**
- Need to add an `await` when running the "open" command after generating coverage report

**Tests:**
- n/a

## Areas of Regression
- n/a

## Testing
- This is sort of hard to test, but on master you should see inconsistent behavior on whether or not the coverage report is automatically opened after generation.
- With this change, the report should always open (as long as `--open` flag is set to true)

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf