### PR TITLE
CP-958 Prevent pub serve errors from examples task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.packages
 .pub
 packages
 pubspec.lock

--- a/lib/src/tasks/examples/api.dart
+++ b/lib/src/tasks/examples/api.dart
@@ -52,8 +52,8 @@ ExamplesTask serveExamples(
       '$pubServeExecutable ${pubServeArgs.join(' ')}',
       Future.wait([dartiumProcess.done, pubServeProcess.done]));
 
-  pubServeProcess.stdout.listen(task._pubServeOutput.add);
-  pubServeProcess.stderr.listen(task._pubServeOutput.addError);
+  pubServeProcess.stdout.listen(task._pubServeStdOut.add);
+  pubServeProcess.stderr.listen(task._pubServeStdErr.add);
   pubServeProcess.exitCode.then((code) {
     task.successful = code <= 0;
   });
@@ -70,16 +70,19 @@ class ExamplesTask extends Task {
   final String pubServeCommand;
 
   StreamController<String> _dartiumOutput = new StreamController();
-  StreamController<String> _pubServeOutput = new StreamController();
+  StreamController<String> _pubServeStdOut = new StreamController();
+  StreamController<String> _pubServeStdErr = new StreamController();
 
   ExamplesTask(String this.dartiumCommand, String this.pubServeCommand,
       Future this.done) {
     done.then((_) {
       _dartiumOutput.close();
-      _pubServeOutput.close();
+      _pubServeStdOut.close();
+      _pubServeStdErr.close();
     });
   }
 
   Stream<String> get dartiumOutput => _dartiumOutput.stream;
-  Stream<String> get pubServeOutput => _pubServeOutput.stream;
+  Stream<String> get pubServeStdOut => _pubServeStdOut.stream;
+  Stream<String> get pubServeStdErr => _pubServeStdErr.stream;
 }

--- a/lib/src/tasks/examples/cli.dart
+++ b/lib/src/tasks/examples/cli.dart
@@ -47,7 +47,8 @@ class ExamplesCli extends TaskCli {
         'This project does not have any examples.');
 
     ExamplesTask task = serveExamples(hostname: hostname, port: port);
-    reporter.logGroup(task.pubServeCommand, outputStream: task.pubServeOutput);
+    reporter.logGroup(task.pubServeCommand,
+        outputStream: task.pubServeStdOut, errorStream: task.pubServeStdErr);
     await task.done;
     reporter.logGroup(task.dartiumCommand, outputStream: task.dartiumOutput);
     return task.successful ? new CliResult.success() : new CliResult.fail();


### PR DESCRIPTION
## Issue
Fix #52

Currently if `pub serve` has any output on stderr during the examples task, it will cause the dart_dev process to exit. This happens any time there is a dart2js warning, or even a 404 (even for favicon.ico!)

## Changes
**Source:**
- Expose additional output stream for pubServeStdErr from ExamplesTask
- Log pubSeveStdErr as the error stream, making it yellow. Screenshot:

![sc](https://dl.dropbox.com/s/uq67hl9pnv8huy4/Screenshot%202015-09-03%2000.12.00.png)

## Areas of Regression
- None, bugfix only.

## Testing
- Target this version of dart_dev in some project that uses it and has examples
- Run `pub run dart_dev examples`
- In the browser, cause a 404. A force refresh would request the favicon.ico, for example.
- Pub serve should continue running after the 404, and the 404 should show up as yellow in the console like the screenshot above.

@trentgrover-wf 
@evanweible-wf 
@dustinlessard-wf 
FYI @jayudey-wf