### PR TITLE
CP-960 Widen dart_style range to include ^0.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Add the following to your `pubspec.yaml`:
 dev_dependencies:
   coverage: "^0.7.2"
   dart_dev: "^1.0.0"
-  dart_style: "^0.2.0"
+  dart_style: ">=0.1.8 <0.3.0"
   dartdoc: "^0.4.0"
   test: "^0.12.0"
 ```

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   ansicolor: "^0.0.9"
   args: "^0.13.0"
   coverage: "^0.7.2"
-  dart_style: "^0.2.0"
+  dart_style: ">=0.1.8 <0.3.0"
   dartdoc: "^0.4.0"
   path: "^1.3.6"
   test: "^0.12.0"

--- a/test/fixtures/format/changes_needed/pubspec.yaml
+++ b/test/fixtures/format/changes_needed/pubspec.yaml
@@ -3,4 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../../..
-  dart_style: "^0.2.0"
+  dart_style: ">=0.1.8 <0.3.0"

--- a/test/fixtures/format/no_changes_needed/pubspec.yaml
+++ b/test/fixtures/format/no_changes_needed/pubspec.yaml
@@ -3,4 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../../..
-  dart_style: "^0.2.0"
+  dart_style: ">=0.1.8 <0.3.0"


### PR DESCRIPTION
## Issue
Resolves #67. `dart_style` range is too narrow and causes dependency version conflicts when installed next to many other projects.

## Changes
- Update the pubspec.yaml to accept any dart_style version within `>=0.1.8 <0.3.0`
- Update the test fixtures accordingly
- Update the install instructions in the readme

## Areas of Regression
- Installation in other projects

## Testing
- CI passes.
- Try installing this branch of dart_dev along with web-skin-dart and ensure that no conflicts arise during installation.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 