### PR TITLE
CP-868 Release dart_dev 1.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.0.0
+version: 1.0.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-868

JIRA and PR's included in this release: 


 CP-958  - Prevent pub serve errors from examples task  - https://github.com/Workiva/dart_dev/pull/68
 CP-960  - Widen dart_style range to include ^0.1.8  - https://github.com/Workiva/dart_dev/pull/69
 CP-961  - Fix formatting of README, update CHANGELOG  - https://github.com/Workiva/dart_dev/pull/70
 CP-962  - Delete first temporary coverage file.  - https://github.com/Workiva/dart_dev/pull/71
 CP-917  - Add pub badge to readme.  - https://github.com/Workiva/dart_dev/pull/56
 CP-907  - Coverage: check for lcov dependency, fail helpfully  - https://github.com/Workiva/dart_dev/pull/53
 CP-924  - New Task: documentation generation via dartdoc.  - https://github.com/Workiva/dart_dev/pull/58
 CP-925  - Coverage: wait for "open" command  - https://github.com/Workiva/dart_dev/pull/60

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.0.0...CP-868_release_1.0.1

    