### PR TITLE
CP-1063 Running coverage on non_test dart files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,6 @@ pubspec.lock
 
 # generated assets in test fixtures
 /test/fixtures/coverage/browser/coverage/
+/test/fixtures/coverage/non_test_file/coverage/
 /test/fixtures/coverage/vm/coverage/
 /test/fixtures/docs/docs/doc/api/

--- a/lib/src/tasks/coverage/api.dart
+++ b/lib/src/tasks/coverage/api.dart
@@ -26,6 +26,7 @@ import 'package:dart_dev/src/tasks/coverage/config.dart';
 import 'package:dart_dev/src/tasks/coverage/exceptions.dart';
 import 'package:dart_dev/src/tasks/task.dart';
 
+const String _dartFilePattern = '.dart';
 const String _testFilePattern = '_test.dart';
 
 class CoverageResult extends TaskResult {
@@ -140,7 +141,7 @@ class CoverageTask extends Task {
         _reportOn = reportOn {
     // Build the list of test files.
     tests.forEach((path) {
-      if (path.endsWith(_testFilePattern) &&
+      if (path.endsWith(_dartFilePattern) &&
           FileSystemEntity.isFileSync(path)) {
         _files.add(new File(path));
       } else if (FileSystemEntity.isDirectorySync(path)) {

--- a/test/fixtures/coverage/non_test_file/lib/non_test_file.dart
+++ b/test/fixtures/coverage/non_test_file/lib/non_test_file.dart
@@ -1,0 +1,9 @@
+library non_test_file;
+
+import 'dart:io';
+
+void notCovered() {
+  print('nope');
+}
+
+bool works() => stdout is IOSink;

--- a/test/fixtures/coverage/non_test_file/pubspec.yaml
+++ b/test/fixtures/coverage/non_test_file/pubspec.yaml
@@ -1,0 +1,7 @@
+name: non_test_file
+version: 0.0.0
+dev_dependencies:
+  coverage: "^0.7.2"
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"

--- a/test/fixtures/coverage/non_test_file/test/file.dart
+++ b/test/fixtures/coverage/non_test_file/test/file.dart
@@ -1,0 +1,11 @@
+@TestOn('vm')
+library coverage.non_test_file.test.file;
+
+import 'package:non_test_file/non_test_file.dart' as lib;
+import 'package:test/test.dart';
+
+main() {
+  test('non_test_file', () {
+    expect(lib.works(), isTrue);
+  });
+}

--- a/test/fixtures/coverage/non_test_file/tool/dev.dart
+++ b/test/fixtures/coverage/non_test_file/tool/dev.dart
@@ -1,0 +1,9 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.test.unitTests = ['test/file.dart'];
+
+  await dev(args);
+}

--- a/test/integration/coverage_test.dart
+++ b/test/integration/coverage_test.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:test/test.dart';
 
+const String projectWithDartFile = 'test/fixtures/coverage/non_test_file';
 const String projectWithVmTests = 'test/fixtures/coverage/browser';
 const String projectWithBrowserTests = 'test/fixtures/coverage/vm';
 const String projectWithoutCoveragePackage =
@@ -59,6 +60,12 @@ void main() {
     test('should fail if "coverage" package is missing', () async {
       expect(await runCoverage(projectWithoutCoveragePackage), isFalse);
     });
+
+    test('should create coverage with non_test file specified', () async {
+      expect(await runCoverage(projectWithDartFile), isTrue);
+      File lcov = new File('$projectWithDartFile/coverage/coverage.lcov');
+      expect(lcov.existsSync(), isTrue);
+    }, timeout: new Timeout(new Duration(seconds: 60)));
 
 //    TODO: Will need to mock out the `genhtml` command as well.
 //    test('should not fail if "lcov" is installed and --html is set', () async {


### PR DESCRIPTION
## Issue
- #76

## Changes
**Source:**
- Updated file check to just verify that file being passed in is a `.dart` file

**Tests:**
- Added test to verify updated functionality

## Areas of Regression
- Coverage

## Testing
- Passing CI
- That coverage will work when a non_test dart file is specified.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf