### PR TITLE
CP-1069 Copy License: trim leading/trailing empty lines

### DIFF
--- a/lib/src/tasks/copy_license/api.dart
+++ b/lib/src/tasks/copy_license/api.dart
@@ -30,6 +30,8 @@ CopyLicenseTask copyLicense(
       'License file "$licensePath" does not exist.');
 
   String licenseContents = license.readAsStringSync();
+  licenseContents = trimLeadingAndTrailingEmptyLines(licenseContents);
+
   directories.forEach((path) {
     Directory dir = new Directory(path);
     if (!dir.existsSync()) return;
@@ -98,6 +100,17 @@ String licenseForFileType(File file, String license) {
   String l =
       license.split('\n').map((l) => '$linePrefix$l'.trimRight()).join('\n');
   return '$opening$l$closing\n';
+}
+
+String trimLeadingAndTrailingEmptyLines(String input) {
+  var lines = input.split('\n');
+  while (lines.first.trim().isEmpty) {
+    lines.removeAt(0);
+  }
+  while (lines.last.trim().isEmpty) {
+    lines.removeLast();
+  }
+  return lines.join('\n');
 }
 
 class CopyLicenseTask extends Task {

--- a/test/fixtures/copy_license/license_with_empty_lines/LICENSE
+++ b/test/fixtures/copy_license/license_with_empty_lines/LICENSE
@@ -1,0 +1,6 @@
+
+
+This license has empty leading and trailing lines.
+
+They should be trimmed to avoid empty leading and trailing comment lines.
+

--- a/test/fixtures/copy_license/license_with_empty_lines/lib/main.dart
+++ b/test/fixtures/copy_license/license_with_empty_lines/lib/main.dart
@@ -1,0 +1,5 @@
+library copy_license_no_licenses;
+
+class Obj extends Object {
+  // Useful.
+}

--- a/test/fixtures/copy_license/license_with_empty_lines/pubspec.yaml
+++ b/test/fixtures/copy_license/license_with_empty_lines/pubspec.yaml
@@ -1,0 +1,5 @@
+name: copy_license_has_licenses
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/integration/copy_license_test.dart
+++ b/test/integration/copy_license_test.dart
@@ -25,6 +25,8 @@ const String projectWithLicenses = 'test/fixtures/copy_license/has_licenses';
 const String projectWithoutLicenseFile =
     'test/fixtures/copy_license/no_license_file';
 const String projectWithoutLicenses = 'test/fixtures/copy_license/no_licenses';
+const String projectWithUntrimmedLicense =
+    'test/fixtures/copy_license/license_with_empty_lines';
 
 Future<String> createTemporaryProject(String source) async {
   String tempProject = '${source}_temp';
@@ -93,6 +95,18 @@ void main() {
         'lib/style.css'
       ];
       expect(await copyLicense(projectPath), unorderedEquals(expectedFiles));
+      deleteTemporaryProject(projectPath);
+    });
+
+    test('should trim leading and trailing empty lines from license', () async {
+      String projectPath =
+          await createTemporaryProject(projectWithUntrimmedLicense);
+      expect(await copyLicense(projectPath), isNotEmpty);
+      String contents =
+          new File('$projectPath/lib/main.dart').readAsStringSync();
+      var lines = contents.split('\n');
+      var licenseLines = lines.where((line) => line.startsWith('//'));
+      expect(licenseLines.length, equals(3));
       deleteTemporaryProject(projectPath);
     });
   });


### PR DESCRIPTION
## Issue
#75 

## Changes
**Source:**
- Copy License API now strips off empty lines from the beginning or end of the license contents before applying them to files. Addresses #75.

**Tests:**
- Added an integration test to test this functionality.

## Areas of Regression
- Copy License task

## Testing
- Integration tests pass.

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 