### PR TITLE
CP-1070 Format: allow exclusions

### DIFF
--- a/lib/src/tasks/format/config.dart
+++ b/lib/src/tasks/format/config.dart
@@ -18,10 +18,12 @@ import 'package:dart_dev/src/tasks/config.dart';
 
 const bool defaultCheck = false;
 const List<String> defaultDirectories = const ['lib/'];
+const List<String> defaultExclude = const [];
 const int defaultLineLength = 80;
 
 class FormatConfig extends TaskConfig {
   bool check = defaultCheck;
   List<String> directories = defaultDirectories;
+  List<String> exclude = defaultExclude;
   int lineLength = defaultLineLength;
 }

--- a/test/fixtures/format/exclusions/lib/clean.dart
+++ b/test/fixtures/format/exclusions/lib/clean.dart
@@ -1,0 +1,3 @@
+library clean;
+
+const String clean = 'clean';

--- a/test/fixtures/format/exclusions/lib/main.dart
+++ b/test/fixtures/format/exclusions/lib/main.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test/fixtures/format/exclusions/pubspec.yaml
+++ b/test/fixtures/format/exclusions/pubspec.yaml
@@ -1,0 +1,6 @@
+name: exclusions
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  dart_style: ">=0.1.8 <0.3.0"

--- a/test/fixtures/format/exclusions/tool/dev.dart
+++ b/test/fixtures/format/exclusions/tool/dev.dart
@@ -1,0 +1,8 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.format.exclude = ['lib/main.dart'];
+  await dev(args);
+}

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -22,6 +22,7 @@ import 'package:dart_dev/util.dart' show TaskProcess, copyDirectory;
 import 'package:test/test.dart';
 
 const String projectWithChangesNeeded = 'test/fixtures/format/changes_needed';
+const String projectWithExclusions = 'test/fixtures/format/exclusions';
 const String projectWithNoChangesNeeded =
     'test/fixtures/format/no_changes_needed';
 const String projectWithoutDartStyle = 'test/fixtures/format/no_dart_style';
@@ -88,6 +89,14 @@ void main() {
     test('should warn if "dart_style" is not an immediate dependency',
         () async {
       expect(await formatProject(projectWithoutDartStyle), isFalse);
+    });
+
+    test('should allow files/directories to be excluded', () async {
+      File file = new File('$projectWithExclusions/lib/main.dart');
+      String contentsBefore = file.readAsStringSync();
+      expect(await formatProject(projectWithExclusions), isTrue);
+      String contentsAfter = file.readAsStringSync();
+      expect(contentsBefore, equals(contentsAfter));
     });
   });
 }


### PR DESCRIPTION
## Issue
- Addresses #66 

## Changes
**Source:**
- Format config now has an `exclude` option that takes a list of string paths (directories, files, or both)
- If exclusions are specified, the list of files to format will be expanded manually (instead of letting dartfmt do it) and will skip any file that matches one of the given exclusion paths
- The CLI output will include a warning that lists all files that were excluded from being formatted

**Tests:**
- Integration test added to verify that an unclean file that is excluded does not get formatted

## Areas of Regression
- Format task

## Testing
- Integration tests pass
- Play around with different values in the `exclude` list and verify that the files you'd expect to be excluded are indeed skipped

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 

fyi: @aaronlademann-wf @greglittlefield-wf @clairesarsam-wf 