### PR TITLE
CP-1091 Allow individual test files

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,11 @@ object.
         </tr>
     </tbody>
 </table>
+* Individual test files can be executed by appending their path to the end of the command.
+
+```
+ddev test path/to/test_name path/to/another/test_name
+```
 
 
 ## CLI Usage

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -15,6 +15,7 @@
 library dart_dev.src.tasks.test.cli;
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:args/args.dart';
 
@@ -71,6 +72,18 @@ class TestCli extends TaskCli {
     }
     if (integration) {
       tests.addAll(config.test.integrationTests);
+    }
+
+    int restLength = parsedArgs.rest.length;
+    if (restLength > 0) {
+      //verify this is a test-file and it exists.
+      for (var i = 0; i < restLength; i++) {
+        String filePath = parsedArgs.rest[i];
+        await new File(filePath).exists().then((bool exists){
+              if (exists) tests.add(filePath);
+              else print("Ignoring unknown argument");});
+      }
+
     }
     if (tests.isEmpty) {
       if (unit && config.test.unitTests.isEmpty) {

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -29,9 +29,7 @@ import 'package:dart_dev/src/tasks/test/config.dart';
 
 class TestCli extends TaskCli {
   final ArgParser argParser = new ArgParser()
-    ..addFlag('unit',
-        defaultsTo: null,
-        help: 'Includes the unit test suite.')
+    ..addFlag('unit', defaultsTo: null, help: 'Includes the unit test suite.')
     ..addFlag('integration',
         defaultsTo: defaultIntegration,
         help: 'Includes the integration test suite.')
@@ -51,23 +49,21 @@ class TestCli extends TaskCli {
     return parsedArgs.rest.length > 0;
   }
 
-  Future addToTestsFromRest(List<String> tests, List<String> rest) async{
+  Future addToTestsFromRest(List<String> tests, List<String> rest) async {
     int restLength = rest.length;
     int individualTests = 0;
     //verify this is a test-file and it exists.
-      for (var i = 0; i < restLength; i++) {
-        String filePath = rest[i];
-        print("filePath:" + filePath);
-        await new File(filePath).exists().then((bool exists) {
-          if (exists) {
-            individualTests++;
-            tests.add(filePath);
-          }
-          else {
-            print("Ignoring unknown argument");
-          }
-        });
-      }
+    for (var i = 0; i < restLength; i++) {
+      String filePath = rest[i];
+      await new File(filePath).exists().then((bool exists) {
+        if (exists) {
+          individualTests++;
+          tests.add(filePath);
+        } else {
+          print("Ignoring unknown argument");
+        }
+      });
+    }
     return individualTests;
   }
 
@@ -80,7 +76,7 @@ class TestCli extends TaskCli {
         .hasImmediateDependency('test')) return new CliResult.fail(
         'Package "test" must be an immediate dependency in order to run its executables.');
 
-    bool unit = parsedArgs['unit']; print("unit:"+unit.toString());
+    bool unit = parsedArgs['unit'];
     bool integration = parsedArgs['integration'];
     List<String> tests = [];
     int individualTests = 0;
@@ -93,19 +89,16 @@ class TestCli extends TaskCli {
     List<String> platforms =
         TaskCli.valueOf('platform', parsedArgs, config.test.platforms);
 
-    if(hasRestParams(parsedArgs)) {
+    if (hasRestParams(parsedArgs)) {
       individualTests = await addToTestsFromRest(tests, parsedArgs.rest);
     }
 
-    if (isExplicitlyFalse(unit) && !integration && individualTests==0) {
+    if (isExplicitlyFalse(unit) && !integration && individualTests == 0) {
       return new CliResult.fail(
           'No tests were selected. Include at least one of --unit or --integration.');
+    } else {
+      if (individualTests == 0) unit = true;
     }
-    else
-    {
-      if(individualTests==0) unit=true;
-    }
-
 
     if (unit) {
       tests.addAll(config.test.unitTests);
@@ -113,7 +106,6 @@ class TestCli extends TaskCli {
     if (integration) {
       tests.addAll(config.test.integrationTests);
     }
-
 
     if (tests.isEmpty) {
       if (unit && config.test.unitTests.isEmpty) {

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -26,12 +26,24 @@ const String projectWithFailingTests = 'test/fixtures/test/failing';
 const String projectWithPassingTests = 'test/fixtures/test/passing';
 
 Future<bool> runTests(String projectPath,
-    {bool unit: true, bool integration: false}) async {
+    {bool unit: true, bool integration: false, List<String> files}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   List args = ['run', 'dart_dev', 'test'];
-  args.add(unit ? '--unit' : '--no-unit');
-  args.add(integration ? '--integration' : '--no-integration');
+  if (unit != null) args.add(unit ? '--unit' : '--no-unit');
+  if (integration != null) args
+      .add(integration ? '--integration' : '--no-integration');
+  int i;
+
+  if (files != null) {
+    int filesLength = files.length;
+    if (filesLength > 0) {
+      for (i = 0; i < filesLength; i++) {
+        args.add(files[i]);
+      }
+    }
+  }
+
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
 
@@ -55,10 +67,33 @@ void main() {
           isFalse);
     });
 
+    test('should run individual unit test', () async {
+      expect(
+          await runTests(projectWithPassingTests, files:
+              ['test/fixtures/test/passing/test/passing_unit_test.dart']),
+          isTrue);
+    });
+
+    test('should run individual unit tests', () async {
+      expect(
+          await runTests(projectWithPassingTests, files: [
+            'test/fixtures/test/passing/test/passing_unit_test.dart',
+            'test/fixtures/test/passing/test/passing_unit_integration.dart'
+          ]),
+          isTrue);
+    });
+
     test('should run unit tests', () async {
       expect(
           await runTests(projectWithPassingTests,
               unit: true, integration: false),
+          isTrue);
+    });
+
+    test('should run unit tests by default', () async {
+      expect(
+          await runTests(projectWithPassingTests,
+              unit: null, integration: null),
           isTrue);
     });
 


### PR DESCRIPTION
<h3>FOR YOUR CONSIDERATION</h3>
<p>While developing, I like to run the individual test-file that I'm focussed on.  This proposed  change allows us to run one or more specific test-files.
</p>
<p><strong>Example with single test file:</strong></p>
```
ddev test path/to/tests/my_test.dart
```
<p><strong>Example with multiple test files:</strong></p>
```
ddev test path/to/tests/my_test.dart path/to/tests/another_test.dart
```
</p>
<p><strong>Example with integration + specific unit test file(s):</strong></p>
```
ddev test --integration path/to/tests/my_test.dart path/to/tests/another_test.dart
```
</p>
<h4>Preserved Functionality</h4>
<p><strong>Example with integration tests :</strong></p>
```
ddev test --integration
```
</p>
<p><strong>Example with unit-tests :</strong></p>
```
ddev test --unit

ddev test
```
</p>
<p><strong>Example with running unit + integration tests :</strong></p>
```
ddev test --unit --integration
```
</p>
<p><strong>Still need:</strong><br/>
</p>

 - [x] - integration test

<p><strong>Required:</strong><br/>
@trentgrover-wf @evanweible-wf @maxwellpeterson-wf @jayudey-wf 
</p>
<p><strong>FYI:</strong><br/>
</p>