### PR TITLE
CP-1102 Upgrade dartdoc dependency range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: "^0.13.0"
   coverage: "^0.7.2"
   dart_style: ">=0.1.8 <0.3.0"
-  dartdoc: "^0.4.0"
+  dartdoc: ">=0.4.0 <0.9.0"
   path: "^1.3.6"
   test: "^0.12.0"
   yaml: "^2.1.0"

--- a/test/fixtures/docs/docs/pubspec.yaml
+++ b/test/fixtures/docs/docs/pubspec.yaml
@@ -3,4 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../../..
-  dartdoc: "^0.4.0"
+  dartdoc: ">=0.4.0 <0.9.0"


### PR DESCRIPTION
## Issue
If consumers currently want to use a version of `dartdoc` newer than 0.4.0 alongside dart_dev, they'll need a dependency override

## Changes
**Source:**
- Relax the `dartdoc` dependency range to include any version between 0.4.0 and 0.9.0

**Tests:**
- Update docs integration test to include the same version range.

## Areas of Regression
- Doc generation

## Testing
- Integration tests pass

## Code Review
@trentgrover-wf
@evanweible-wf 
@dustinlessard-wf
FYI @jayudey-wf