### PR TITLE
CP-1129 Add flag to automatically start `pub serve` when running tests/coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ pubspec.lock
 
 # generated assets in test fixtures
 /test/fixtures/coverage/browser/coverage/
+/test/fixtures/coverage/browser_needs_pub_serve/coverage/
 /test/fixtures/coverage/non_test_file/coverage/
 /test/fixtures/coverage/vm/coverage/
 /test/fixtures/docs/docs/doc/api/

--- a/README.md
+++ b/README.md
@@ -302,6 +302,12 @@ configuration from the `config.test` object.
             <td><code>['lib/']</code></td>
             <td>List of paths to include in the generated coverage report (LCOV and HTML).</td>
         </tr>
+        <tr>
+            <td><code>pubServe</code></td>
+            <td><code>bool</code></td>
+            <td><code>false</code></td>
+            <td>Whether or not to serve browser tests using a Pub server.<br>If <code>true</code>, make sure to follow the <code>test</code> package's <a href="https://github.com/dart-lang/test#testing-with-barback">setup instructions</a> and include the <code>test/pub_serve</code> transformer.</td>
+        </tr>
     </tbody>
 </table>
 
@@ -412,6 +418,12 @@ object.
             <td><code>List&lt;String&gt;</code></td>
             <td><code>['test/']</code></td>
             <td>Unit test locations. Items in this list can be directories and/or files.</td>
+        </tr>
+        <tr>
+            <td><code>pubServe</code></td>
+            <td><code>bool</code></td>
+            <td><code>false</code></td>
+            <td>Whether or not to serve browser tests using a Pub server.<br>If <code>true</code>, make sure to follow the <code>test</code> package's <a href="https://github.com/dart-lang/test#testing-with-barback">setup instructions</a> and include the <code>test/pub_serve</code> transformer.</td>
         </tr>
     </tbody>
 </table>

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -44,24 +44,31 @@ class Reporter {
     _log(stdout, message, shout: shout);
   }
 
+  static String _indent(String lines) {
+    return '    ' + lines.replaceAll('\n', '\n    ');
+  }
+
   void logGroup(String title,
       {String output,
+      String error,
       Stream<String> outputStream,
       Stream<String> errorStream}) {
-    log(colorBlue('\n::: $title'));
-    if (output != null) {
-      log('${output.split('\n').join('\n    ')}');
-      return;
-    }
+    var formattedTitle = colorBlue('\n::: $title');
 
-    if (outputStream != null) {
-      outputStream.listen((line) {
-        log('    $line');
+    if (output != null) {
+      log(formattedTitle);
+      log(_indent(output));
+    } else if (error != null) {
+      warning(formattedTitle);
+      warning(_indent(error));
+    } else {
+      log(formattedTitle);
+
+      outputStream?.listen((line) {
+        log(_indent(line));
       });
-    }
-    if (errorStream != null) {
-      errorStream.listen((line) {
-        warning('    $line');
+      errorStream?.listen((line) {
+        warning(_indent(line));
       });
     }
   }

--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -40,6 +40,10 @@ class CoverageCli extends TaskCli {
         negatable: true,
         defaultsTo: defaultHtml,
         help: 'Generate and open an HTML report.')
+    ..addFlag('pub-serve',
+        negatable: true,
+        defaultsTo: defaultPubServe,
+        help: 'Serves browser tests using a Pub server.')
     ..addFlag('open',
         negatable: true,
         defaultsTo: true,
@@ -61,6 +65,8 @@ class CoverageCli extends TaskCli {
     }
 
     bool html = TaskCli.valueOf('html', parsedArgs, config.coverage.html);
+    bool pubServe =
+        TaskCli.valueOf('pub-serve', parsedArgs, config.coverage.pubServe);
     bool open = TaskCli.valueOf('open', parsedArgs, true);
 
     List<String> tests = [];
@@ -85,6 +91,7 @@ class CoverageCli extends TaskCli {
     try {
       CoverageTask task = CoverageTask.start(tests,
           html: html,
+          pubServe: pubServe,
           output: config.coverage.output,
           reportOn: config.coverage.reportOn);
       reporter.logGroup('Collecting coverage',

--- a/lib/src/tasks/coverage/config.dart
+++ b/lib/src/tasks/coverage/config.dart
@@ -15,6 +15,7 @@
 library dart_dev.src.tasks.coverage.config;
 
 import 'package:dart_dev/src/tasks/config.dart';
+import 'package:dart_dev/src/tasks/test/config.dart';
 
 const bool defaultHtml = true;
 const String defaultOutput = 'coverage/';
@@ -22,6 +23,7 @@ const List<String> defaultReportOn = const ['lib/'];
 
 class CoverageConfig extends TaskConfig {
   bool html = defaultHtml;
+  bool pubServe = defaultPubServe;
   String output = defaultOutput;
   List<String> reportOn = defaultReportOn;
 }

--- a/lib/src/tasks/serve/api.dart
+++ b/lib/src/tasks/serve/api.dart
@@ -1,0 +1,114 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library dart_dev.src.tasks.serve.api;
+
+import 'dart:async';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+
+/// A regular expression that matches the output of "pub serve".
+final RegExp _servingRegExp =
+    new RegExp(r'^Serving [^ ]+ +([^ ]+) +on http://localhost:(\d+)$');
+
+/// Starts a Pub server on the specified [port] and returns the associated
+/// [PubServeTask].
+///
+/// If [port] is 0, `pub serve` will pick its own port automatically.
+PubServeTask startPubServe({int port: 0, List additionalArgs}) {
+  var pubServeExecutable = 'pub';
+  var pubServeArgs = ['serve', '--port=$port'];
+  if (additionalArgs != null) {
+    pubServeArgs.addAll(additionalArgs);
+  }
+
+  TaskProcess pubServeProcess =
+      new TaskProcess(pubServeExecutable, pubServeArgs);
+
+  var pubServeInfos = new StreamController<PubServeInfo>();
+
+  var task = new PubServeTask('$pubServeExecutable ${pubServeArgs.join(' ')}',
+      pubServeInfos.stream, pubServeProcess.done, pubServeProcess.kill);
+
+  pubServeProcess.stdout.listen((String line) {
+    task._pubServeStdOut.add(line);
+
+    var match = _servingRegExp.firstMatch(line);
+    if (match != null) {
+      var directory = match[1];
+      var port = int.parse(match[2]);
+      pubServeInfos.add(new PubServeInfo(directory, port));
+    }
+  });
+
+  pubServeProcess.stderr.listen(task._pubServeStdErr.add);
+
+  return task;
+}
+
+class PubServeInfo {
+  final int port;
+  final String directory;
+
+  PubServeInfo(String this.directory, int this.port);
+}
+
+class PubServeTask {
+  final String command;
+  final Stream<PubServeInfo> serveInfos;
+  final Future done;
+  final Function _stop;
+
+  StreamController<String> _pubServeStdOut = new StreamController.broadcast();
+  StreamController<String> _pubServeStdErr = new StreamController.broadcast();
+
+  PubServeTask(String this.command, Stream<PubServeInfo> this.serveInfos,
+      Future this.done, void this._stop()) {
+    done.then((_) {
+      _pubServeStdOut.close();
+      _pubServeStdErr.close();
+    });
+  }
+
+  void stop() {
+    _stop();
+  }
+
+  Stream<String> get stdOut => _pubServeStdOut.stream;
+  Stream<String> get stdErr => _pubServeStdErr.stream;
+}
+
+/// Returns a Stream that proxies [stream] until [cancelled] completes or [stream] closes.
+StreamTransformer<String, String> until(Future cancelled) {
+  return new StreamTransformer((Stream<String> input, bool cancelOnError) {
+    StreamController<String> controller;
+    StreamSubscription<String> subscription;
+    controller = new StreamController<String>(onListen: () {
+      subscription = input.listen(controller.add,
+          onError: controller.addError,
+          onDone: controller.close,
+          cancelOnError: cancelOnError);
+    },
+        onPause: () => subscription.pause(),
+        onResume: () => subscription.resume(),
+        onCancel: () => subscription.cancel(),
+        sync: true);
+
+    cancelled.then((_) {
+      controller.close();
+    });
+
+    return controller.stream.listen(null);
+  });
+}

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -22,6 +22,7 @@ import 'package:dart_dev/src/tasks/task.dart';
 
 TestTask test(
     {int concurrency,
+    List<String> additionalArgs: const [],
     List<String> platforms: const [],
     List<String> tests: const []}) {
   var executable = 'pub';
@@ -33,6 +34,7 @@ TestTask test(
     args.addAll(['-p', p]);
   });
   args.addAll(['--reporter=expanded']);
+  args.addAll(additionalArgs);
   args.addAll(tests);
 
   TaskProcess process = new TaskProcess(executable, args);

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -17,6 +17,7 @@ library dart_dev.src.tasks.test.config;
 import 'package:dart_dev/src/tasks/config.dart';
 
 const int defaultConcurrency = 4;
+const bool defaultPubServe = false;
 const bool defaultIntegration = false;
 const List<String> defaultIntegrationTests = const [];
 const bool defaultUnit = true;
@@ -25,6 +26,7 @@ const List<String> defaultPlatforms = const [];
 
 class TestConfig extends TaskConfig {
   int concurrency = defaultConcurrency;
+  bool pubServe = defaultPubServe;
   List<String> integrationTests = defaultIntegrationTests;
   List<String> platforms = defaultPlatforms;
   List<String> unitTests = defaultUnitTests;

--- a/test/fixtures/coverage/browser_needs_pub_serve/lib/coverage_browser.dart
+++ b/test/fixtures/coverage/browser_needs_pub_serve/lib/coverage_browser.dart
@@ -1,0 +1,11 @@
+library coverage_browser;
+
+import 'dart:html';
+
+void notCovered() {
+  print('nope');
+}
+
+final bool wasTransformed = false;
+
+bool works() => document is Document && wasTransformed;

--- a/test/fixtures/coverage/browser_needs_pub_serve/lib/transformer.dart
+++ b/test/fixtures/coverage/browser_needs_pub_serve/lib/transformer.dart
@@ -1,0 +1,20 @@
+library needs_pub_serve.transformer;
+
+import 'dart:async';
+
+import 'package:barback/barback.dart';
+
+class FalseToTrueTransformer extends Transformer {
+  FalseToTrueTransformer.asPlugin();
+
+  String get allowedExtensions => '.dart';
+
+  @override
+  Future apply(Transform transform) async {
+    var contents = await transform.primaryInput.readAsString();
+    var transformedContents = contents.replaceAll(
+        'bool wasTransformed = false', 'bool wasTransformed = true');
+    transform.addOutput(
+        new Asset.fromString(transform.primaryInput.id, transformedContents));
+  }
+}

--- a/test/fixtures/coverage/browser_needs_pub_serve/pubspec.yaml
+++ b/test/fixtures/coverage/browser_needs_pub_serve/pubspec.yaml
@@ -1,0 +1,15 @@
+name: coverage_browser_needs_pub_serve
+version: 0.0.0
+dev_dependencies:
+  coverage: "^0.7.2"
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"
+transformers:
+  # Add the necessary `test` package transformer
+  # See https://github.com/dart-lang/test#testing-with-barback
+  - test/pub_serve:
+      $include: test/**_test{.*,}.dart
+  # Add a custom transformer that makes the test pass.
+  - coverage_browser_needs_pub_serve:
+      $include: lib/coverage_browser.dart

--- a/test/fixtures/coverage/browser_needs_pub_serve/test/browser_custom_test.dart
+++ b/test/fixtures/coverage/browser_needs_pub_serve/test/browser_custom_test.dart
@@ -1,0 +1,14 @@
+@TestOn('browser')
+library coverage.browser_needs_pub_serve.test.browser_custom_test;
+
+import 'dart:js' show context;
+
+import 'package:coverage_browser_needs_pub_serve/coverage_browser.dart' as lib;
+import 'package:test/test.dart';
+
+main() {
+  test('browser test', () {
+    expect(lib.works(), isTrue);
+    expect(context['customScript'], isTrue);
+  });
+}

--- a/test/fixtures/coverage/browser_needs_pub_serve/test/browser_custom_test.html
+++ b/test/fixtures/coverage/browser_needs_pub_serve/test/browser_custom_test.html
@@ -1,0 +1,5 @@
+<script>
+    window.customScript = true;
+</script>
+<link rel="x-dart-test" href="browser_custom_test.dart">
+<script src="packages/test/dart.js"></script>

--- a/test/fixtures/coverage/browser_needs_pub_serve/test/browser_test.dart
+++ b/test/fixtures/coverage/browser_needs_pub_serve/test/browser_test.dart
@@ -1,0 +1,11 @@
+@TestOn('browser')
+library coverage.browser.test.browser_test;
+
+import 'package:coverage_browser_needs_pub_serve/coverage_browser.dart' as lib;
+import 'package:test/test.dart';
+
+main() {
+  test('browser test', () {
+    expect(lib.works(), isTrue);
+  });
+}

--- a/test/fixtures/coverage/browser_needs_pub_serve/tool/dev.dart
+++ b/test/fixtures/coverage/browser_needs_pub_serve/tool/dev.dart
@@ -1,0 +1,9 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.coverage..pubServe = true;
+
+  await dev(args);
+}

--- a/test/fixtures/test/needs_pub_serve/lib/transformer.dart
+++ b/test/fixtures/test/needs_pub_serve/lib/transformer.dart
@@ -1,0 +1,20 @@
+library needs_pub_serve.transformer;
+
+import 'dart:async';
+
+import 'package:barback/barback.dart';
+
+class FalseToTrueTransformer extends Transformer {
+  FalseToTrueTransformer.asPlugin();
+
+  String get allowedExtensions => '.dart';
+
+  @override
+  Future apply(Transform transform) async {
+    var contents = await transform.primaryInput.readAsString();
+    var transformedContents = contents.replaceAll(
+        'bool wasTransformed = false', 'bool wasTransformed = true');
+    transform.addOutput(
+        new Asset.fromString(transform.primaryInput.id, transformedContents));
+  }
+}

--- a/test/fixtures/test/needs_pub_serve/pubspec.yaml
+++ b/test/fixtures/test/needs_pub_serve/pubspec.yaml
@@ -1,0 +1,15 @@
+name: test_needs_pub_serve
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"
+  barback: "^0.15.2"
+transformers:
+  # Add the necessary `test` package transformer
+  # See https://github.com/dart-lang/test#testing-with-barback
+  - test/pub_serve:
+      $include: test/**_test{.*,}.dart
+  # Add a custom transformer that makes the test pass.
+  - test_needs_pub_serve:
+      $include: test/unit_test.dart

--- a/test/fixtures/test/needs_pub_serve/test/unit_test.dart
+++ b/test/fixtures/test/needs_pub_serve/test/unit_test.dart
@@ -1,0 +1,11 @@
+library test_failing.test.passing_unit_test;
+
+import 'package:test/test.dart';
+
+final bool wasTransformed = false;
+
+void main() {
+  test('passes', () {
+    expect(wasTransformed, isTrue);
+  });
+}

--- a/test/fixtures/test/needs_pub_serve/tool/dev.dart
+++ b/test/fixtures/test/needs_pub_serve/tool/dev.dart
@@ -1,0 +1,12 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.test
+    ..pubServe = true
+    ..unitTests = ['test/unit_test.dart']
+    ..platforms = ['content-shell'];
+
+  await dev(args);
+}

--- a/test/integration/coverage_test.dart
+++ b/test/integration/coverage_test.dart
@@ -24,6 +24,8 @@ import 'package:test/test.dart';
 const String projectWithDartFile = 'test/fixtures/coverage/non_test_file';
 const String projectWithBrowserTests = 'test/fixtures/coverage/browser';
 const String projectWithVmTests = 'test/fixtures/coverage/vm';
+const String projectWithBrowserTestsThatNeedsPubServe =
+    'test/fixtures/coverage/browser_needs_pub_serve';
 const String projectWithoutCoveragePackage =
     'test/fixtures/coverage/no_coverage_package';
 
@@ -48,6 +50,15 @@ void main() {
     test('should generate coverage for Browser tests', () async {
       expect(await runCoverage(projectWithBrowserTests), isTrue);
       File lcov = new File('$projectWithBrowserTests/coverage/coverage.lcov');
+      expect(lcov.existsSync(), isTrue);
+    }, timeout: new Timeout(new Duration(seconds: 60)));
+
+    test('should generate coverage for Browser tests that require a Pub server',
+        () async {
+      expect(
+          await runCoverage(projectWithBrowserTestsThatNeedsPubServe), isTrue);
+      File lcov = new File(
+          '$projectWithBrowserTestsThatNeedsPubServe/coverage/coverage.lcov');
       expect(lcov.existsSync(), isTrue);
     }, timeout: new Timeout(new Duration(seconds: 60)));
 

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -24,6 +24,7 @@ import 'package:test/test.dart';
 const String projectWithoutTestPackage = 'test/fixtures/test/no_test_package';
 const String projectWithFailingTests = 'test/fixtures/test/failing';
 const String projectWithPassingTests = 'test/fixtures/test/passing';
+const String projectThatNeedsPubServe = 'test/fixtures/test/needs_pub_serve';
 
 Future<bool> runTests(String projectPath,
     {bool unit: true, bool integration: false, List<String> files}) async {
@@ -113,6 +114,10 @@ void main() {
 
     test('should warn if "test" package is not immediate dependency', () async {
       expect(await runTests(projectWithoutTestPackage), isFalse);
+    });
+
+    test('should run tests that require a Pub server', () async {
+      expect(await runTests(projectThatNeedsPubServe), isTrue);
     });
   });
 }


### PR DESCRIPTION
## Ultimate Problem
Tests and coverage currently cannot be run with files served from a Pub server.

See #79.

## Solution
* Add `PubServeTask`
    * Allows creation and management of `pub serve` instances.
* Add `pub-serve` CLI option and `pubServe` config option to test/coverage tasks.
    * Automatically spins up a Pub server that is used to run the tests.
* Add integration tests for `dart_dev coverage`/`dart_dev test` in projects that require a Pub server.

#### Other changes
Tweak `Reporter.logGroup` code to be more flexible, and indent for multiline Stream events.


## Testing
* Verify that integration tests for `test`/`coverage` tasks pass.
* Verify that a real consumer package can run `dart_dev test`/`dart_dev coverage` using a pub server.
    * E.g., web_skin_dart with transformer code gen: https://ci.webfilings.com/build/417851
* Verify that `pub serve` output is well-formatted.

---

FYA: @evanweible-wf @trentgrover-wf 
FYI: @jacehensley-wf @aaronlademann-wf