### PR TITLE
CP-1124 Fix browser file detection (dart2js output changed)

### DIFF
--- a/lib/src/tasks/coverage/api.dart
+++ b/lib/src/tasks/coverage/api.dart
@@ -395,7 +395,8 @@ class CoverageTask extends Task {
       // TODO: When dart2js has fixed the issue with their exitcode we should
       //       rely on the exitcode instead of the stdout.
       isBrowserTest = pr.stdout != null &&
-          (pr.stdout as String).contains('Error: Library not found');
+          (pr.stdout as String)
+              .contains(new RegExp(r'Error: Library not (found|supported)'));
     }
 
     String _observatoryFailPattern = 'Could not start Observatory HTTP server';

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -46,8 +46,9 @@ TestTask test(
   StreamController stdoutc = new StreamController();
   process.stdout.listen((line) {
     stdoutc.add(line);
-    if (line.contains('All tests passed!') ||
-        line.contains('Some tests failed.')) {
+    if ((line.contains('All tests passed!') ||
+            line.contains('Some tests failed.')) &&
+        !outputProcessed.isCompleted) {
       task.testSummary = line;
       outputProcessed.complete();
     }

--- a/test/integration/coverage_test.dart
+++ b/test/integration/coverage_test.dart
@@ -22,8 +22,8 @@ import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:test/test.dart';
 
 const String projectWithDartFile = 'test/fixtures/coverage/non_test_file';
-const String projectWithVmTests = 'test/fixtures/coverage/browser';
-const String projectWithBrowserTests = 'test/fixtures/coverage/vm';
+const String projectWithBrowserTests = 'test/fixtures/coverage/browser';
+const String projectWithVmTests = 'test/fixtures/coverage/vm';
 const String projectWithoutCoveragePackage =
     'test/fixtures/coverage/no_coverage_package';
 


### PR DESCRIPTION
## Issue
- The dart2js analyze output that we use to detect whether or not a dart file imports `dart:html` changed from "Error: library not found" to "Error: library not supported"
- Also, the project paths for browser/vm test fixtures were swapped

## Changes
**Source:**
- Use a regex to detect either the old error message or the new one so that this detection works on pre-1.13 and 1.13
- Fix the project fixture paths

**Tests:**
- Current tests already cover this (which is why our CI started failing)

## Areas of Regression
- Coverage collection on browser tests without a custom HTML file

## Testing
- CI (which is on 1.13 now) passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 