### PR TITLE
CP-1127 Release dart_dev 1.0.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.0.4
+version: 1.0.5
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1127

JIRA and PR's included in this release: 


 CP-1128  - Update CHANGELOG with 1.0.3, 1.0.4 releases  - https://github.com/Workiva/dart_dev/pull/100
 CP-1129  - Add flag to automatically start `pub serve` when running tests/coverage  - https://github.com/Workiva/dart_dev/pull/92
 CP-1140  - Initial implementation of failing on analyzer hints  - https://github.com/Workiva/dart_dev/pull/102

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.0.4...CP-1127_release_1.0.5

