### PR TITLE
CP-1149 Use dartanalyzer fatal hints instead of post-processing on our own

### DIFF
--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -114,7 +114,8 @@ void main() {
     test('should report hints as fatal if configured to do so', () async {
       Analysis analysis =
           await analyzeProject(projectWithHints, fatalHints: true);
-      expect(analysis.numHints, equals(2));
+      expect(analysis.numErrors, equals(2));
+      expect(analysis.numHints, equals(0));
       expect(analysis.exitCode, greaterThan(0));
     });
 


### PR DESCRIPTION
Major facepalm here - dartanalyzer added support for fatal hints without me realizing it.  So I am putting the analyze/api.dart back to how it was and adding the tag if fatalHints are enabled.

@evanweible-wf @maxwellpeterson-wf @trentgrover-wf 