### PR TITLE
CP-1164 Update readme with zsh instructions for completions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ fi
 Next time you load a Bash session you'll have basic completions for the `ddev`
 alias described above.
 
+#### Zsh Completion
+
+The Bash completion script will work for Zsh as well, but requires a little
+configuration. The following lines must all be found somewhere (and in this
+order, though they needn't be adjacent to one another) in your `.zshrc` file,
+or a file sourced from it:
+
+```
+autoload -U compinit
+compinit
+autoload -U bashcompinit
+bashcompinit
+source <path/to/ddev-completion.sh>
+```
+
 #### Configuration
 In order to configure `dart_dev` for a specific project, run `ddev init` or
 `pub run dart_dev init` to generate the configuration file. This should create a


### PR DESCRIPTION
## Problem

Completion only works on Bash but some people like Zsh!

## Solution

Add instructions for making the completions work with Zsh.

## FYI

@evanweible-wf - you might want to test this to be sure it works in real life, I tested it on my local Zsh from Homebrew, but since I don't use Zsh normally I don't actually have a `.zshrc` and such and I just punched everything in at a command line.