### PR TITLE
Analyze: support strong mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 1.0.6
+
+- **Improvement:** `--strong` flag added to the Analyze task.
+- **Improvement:** The Analyze task's `--fatal-hints` flag is now implemented
+   by utilizing the `--fatal-hints` flag on `dartanalyzer` instead of parsing
+   the output.
+- **Documentation:** Add zsh completion instructions to the README.
+
+## 1.0.5
+
+### New Feature: pub server support for tests and coverage
+
+- The Test and Coverage tasks now take a `--pub-serve` flag that will
+  automatically spin up a pub server that is used to run the tests.
+- Tests that require a pub transformer can now be run by passing in this flag!
+
+### Changes
+
+- **Improvement:** `--fatal-hints` flag added to the Analyze task.
+
 ## 1.0.4
 
 - **Tooling:** Bash completions are available in the `tool/` directory! See the

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ need to know how to use the `dart_dev` tool.
 - **Coverage:** collects coverage over test suites (unit, integration, and functional) and generates a report. Uses the [`coverage` package](https://github.com/dart-lang/coverage).
 - **Code Formatting:** runs the [`dartfmt` tool from the `dart_style` package](https://github.com/dart-lang/dart_style) over source code.
 - **Static Analysis:** runs the [`dartanalyzer`](https://www.dartlang.org/tools/analyzer/) over source code.
-- **Documentation Generation:** runs the tool from [the `dartdoc` package](https://github.com/dart-lang/dartdoc) to generate docs. 
+- **Documentation Generation:** runs the tool from [the `dartdoc` package](https://github.com/dart-lang/dartdoc) to generate docs.
 - **Serving Examples:** uses [`pub serve`](https://www.dartlang.org/tools/pub/cmd/pub-serve.html) to serve the project examples.
 - **Applying a License to Source Files:** copies a LICENSE file to all applicable files.
 
@@ -253,10 +253,16 @@ All configuration options for the `analyze` task are found on the
             <td>Show hint results.</td>
         </tr>
         <tr>
-        	<td><code>fatalHints</code></td>
-        	<td><code>bool</code></td>
-        	<td><code>false</code></td>
-        	<td>Fail on hints (requests hints to be true).</td>
+          	<td><code>fatalHints</code></td>
+          	<td><code>bool</code></td>
+          	<td><code>false</code></td>
+          	<td>Fail on hints (requests hints to be true).</td>
+        </tr>
+        <tr>
+            <td><code>strong</code></td>
+            <td><code>bool</code></td>
+            <td><code>false</code></td>
+            <td>Enable strong static checks ([https://goo.gl/DqcBsw](Enable strong static checks (https://goo.gl/DqcBsw))</td>
         </tr>
     </tbody>
 </table>
@@ -431,7 +437,7 @@ object.
             <td><code>List&lt;String&gt;</code></td>
             <td><code>[]</code></td>
             <td>Platforms on which to run the tests (handled by the Dart test runner). See https://github.com/dart-lang/test#platform-selector-syntax for a full list of supported platforms.
-            <strong>* Not all platforms are supported by all continuous integration servers.  Please consult your CI server's documentation for more details.</strong> 
+            <strong>* Not all platforms are supported by all continuous integration servers.  Please consult your CI server's documentation for more details.</strong>
             </td>
         </tr>
         <tr>

--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -26,7 +26,8 @@ AnalyzeTask analyze(
     {List<String> entryPoints: defaultEntryPoints,
     bool fatalWarnings: defaultFatalWarnings,
     bool hints: defaultHints,
-    bool fatalHints: defaultFatalHints}) {
+    bool fatalHints: defaultFatalHints,
+    bool strong: defaultStrong}) {
   var executable = 'dartanalyzer';
   var args = [];
   if (fatalWarnings) {
@@ -36,6 +37,9 @@ AnalyzeTask analyze(
     args.add('--no-hints');
   } else if (fatalHints) {
     args.add('--fatal-hints');
+  }
+  if (strong) {
+    args.add('--strong');
   }
 
   args.addAll(_findFilesFromEntryPoints(entryPoints));

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -36,7 +36,11 @@ class AnalyzeCli extends TaskCli {
     ..addFlag('fatal-hints',
         defaultsTo: defaultFatalHints,
         negatable: true,
-        help: 'Treat hints as fatal.');
+        help: 'Treat hints as fatal.')
+    ..addFlag('strong',
+        defaultsTo: defaultStrong,
+        negatable: true,
+        help: 'Enable strong static checks (https://goo.gl/DqcBsw)');
 
   final String command = 'analyze';
 
@@ -47,6 +51,7 @@ class AnalyzeCli extends TaskCli {
     bool hints = TaskCli.valueOf('hints', parsedArgs, config.analyze.hints);
     bool fatalHints =
         TaskCli.valueOf('fatal-hints', parsedArgs, config.analyze.fatalHints);
+    bool strong = TaskCli.valueOf('strong', parsedArgs, config.analyze.strong);
 
     if (!hints && fatalHints) {
       return new CliResult.fail('You must enable hints to fail on hints.');
@@ -56,7 +61,8 @@ class AnalyzeCli extends TaskCli {
         entryPoints: entryPoints,
         fatalWarnings: fatalWarnings,
         hints: hints,
-        fatalHints: fatalHints);
+        fatalHints: fatalHints,
+        strong: strong);
     var title = task.analyzerCommand;
     if (fatalHints) title += ' (treating hints as fatal)';
 

--- a/lib/src/tasks/analyze/config.dart
+++ b/lib/src/tasks/analyze/config.dart
@@ -20,10 +20,12 @@ const List<String> defaultEntryPoints = const ['lib/'];
 const bool defaultFatalWarnings = true;
 const bool defaultHints = true;
 const bool defaultFatalHints = false;
+const bool defaultStrong = false;
 
 class AnalyzeConfig extends TaskConfig {
   List<String> entryPoints = defaultEntryPoints.toList();
   bool fatalWarnings = defaultFatalWarnings;
   bool hints = defaultHints;
   bool fatalHints = defaultFatalHints;
+  bool strong = defaultStrong;
 }

--- a/test/fixtures/analyze/strong/lib/strong.dart
+++ b/test/fixtures/analyze/strong/lib/strong.dart
@@ -1,0 +1,12 @@
+library analyze_strong;
+
+import 'dart:collection';
+
+class MyList extends ListBase<int> implements List {
+   Object length;
+
+   MyList(this.length);
+
+   operator[](index) => "world";
+   operator[]=(index, value) {}
+}

--- a/test/fixtures/analyze/strong/pubspec.yaml
+++ b/test/fixtures/analyze/strong/pubspec.yaml
@@ -1,0 +1,5 @@
+name: analyze_strong
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -24,16 +24,19 @@ import 'package:test/test.dart';
 const String projectWithErrors = 'test/fixtures/analyze/errors';
 const String projectWithHints = 'test/fixtures/analyze/hints';
 const String projectWithNoIssues = 'test/fixtures/analyze/no_issues';
+const String projectWithStaticTypingIssues = 'test/fixtures/analyze/strong';
 
 Future<Analysis> analyzeProject(String projectPath,
     {bool fatalWarnings: true,
     bool hints: true,
-    bool fatalHints: false}) async {
+    bool fatalHints: false,
+    bool strong: false}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   var args = ['run', 'dart_dev', 'analyze'];
   args.add(fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings');
   args.add(hints ? '--hints' : '--no-hints');
+  args.add(strong ? '--strong' : '--no-strong');
   args.add(fatalHints ? '--fatal-hints' : ' --no-fatal-hints');
 
   TaskProcess process =
@@ -138,6 +141,22 @@ void main() {
           await analyzeProject(projectWithErrors, fatalWarnings: false);
       expect(analysis.numErrors, equals(1));
       expect(analysis.numWarnings, equals(1));
+    });
+
+    test(
+        'should not report any issues on project with static typing issues if strong mode is off',
+        () async {
+      Analysis analysis =
+          await analyzeProject(projectWithStaticTypingIssues, strong: false);
+      expect(analysis.exitCode, equals(0));
+    });
+
+    test(
+        'should report issues on project with static typing issues if strong mode is on',
+        () async {
+      Analysis analysis =
+          await analyzeProject(projectWithStaticTypingIssues, strong: true);
+      expect(analysis.numErrors, greaterThan(0));
     });
   });
 }


### PR DESCRIPTION
## Issue
- Fixes #111 

## Changes
**Source:**
- Add `strong` option for analyze config
- Add `--strong` flag to analyze CLI
- Add `strong` param to analyze API

**Tests:**
- Integration test for project with static typing issues and `--no-strong`
- Integration test for project with static typing issues and `strong`

## Areas of Regression
- n/a

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 