### PR TITLE
CP-1144 Release dart_dev 1.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.0.5
+version: 1.0.6
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1144

JIRA and PR's included in this release: 


 CP-1149  - Use dartanalyzer fatal hints instead of post-processing on our own  - https://github.com/Workiva/dart_dev/pull/108
 CP-1164  - Update readme with zsh instructions for completions.  - https://github.com/Workiva/dart_dev/pull/109
 CP-1167  - Dart formatter updates for dart_dev, dart_style 0.2.1.  - https://github.com/Workiva/dart_dev/pull/110
 CP-1172  - Analyze: support strong mode  - https://github.com/Workiva/dart_dev/pull/112

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.0.5...CP-1144_release_1.0.6

