### PR TITLE
CP-1303 Fail coverage task if a unit tests fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ pubspec.lock
 # generated assets in test fixtures
 /test/fixtures/coverage/browser/coverage/
 /test/fixtures/coverage/browser_needs_pub_serve/coverage/
+/test/fixtures/coverage/failing_test/coverage/
 /test/fixtures/coverage/non_test_file/coverage/
 /test/fixtures/coverage/vm/coverage/
 /test/fixtures/docs/docs/doc/api/

--- a/lib/src/tasks/coverage/api.dart
+++ b/lib/src/tasks/coverage/api.dart
@@ -123,6 +123,8 @@ class CoverageTask extends Task {
   /// searching all directories for valid test files.
   List<File> _files = [];
 
+  bool _failingTest = false;
+
   /// Whether or not to generate the HTML report.
   bool _html = defaultHtml;
 
@@ -342,8 +344,13 @@ class CoverageTask extends Task {
       await _generateReport();
     }
 
-    _done.complete(
-        new CoverageResult.success(tests, collection, lcov, report: report));
+    if (_failingTest) {
+      _done.complete(
+          new CoverageResult.fail(tests, collection, lcov, report: report));
+    } else {
+      _done.complete(
+          new CoverageResult.success(tests, collection, lcov, report: report));
+    }
   }
 
   Future<int> _test(File file) async {
@@ -501,6 +508,7 @@ class CoverageTask extends Task {
             observatoryPort = int.parse(m.group(2));
           }
           if (line.contains(_testsFailedPattern)) {
+            _failingTest = true;
             throw new CoverageTestSuiteException(file.path);
           }
           if (line.contains(_testsPassedPattern)) {
@@ -531,6 +539,7 @@ class CoverageTask extends Task {
           throw new CoverageTestSuiteException(file.path);
         }
         if (line.contains(_testsFailedPattern)) {
+          _failingTest = true;
           throw new CoverageTestSuiteException(file.path);
         }
         if (line.contains(_testsPassedPattern)) {

--- a/lib/src/tasks/serve/api.dart
+++ b/lib/src/tasks/serve/api.dart
@@ -94,12 +94,13 @@ StreamTransformer<String, String> until(Future cancelled) {
   return new StreamTransformer((Stream<String> input, bool cancelOnError) {
     StreamController<String> controller;
     StreamSubscription<String> subscription;
-    controller = new StreamController<String>(onListen: () {
-      subscription = input.listen(controller.add,
-          onError: controller.addError,
-          onDone: controller.close,
-          cancelOnError: cancelOnError);
-    },
+    controller = new StreamController<String>(
+        onListen: () {
+          subscription = input.listen(controller.add,
+              onError: controller.addError,
+              onDone: controller.close,
+              cancelOnError: cancelOnError);
+        },
         onPause: () => subscription.pause(),
         onResume: () => subscription.resume(),
         onCancel: () => subscription.cancel(),

--- a/test/fixtures/coverage/failing_test/lib/coverage_failing_test.dart
+++ b/test/fixtures/coverage/failing_test/lib/coverage_failing_test.dart
@@ -1,0 +1,9 @@
+library coverage_failing_test.coverage_failing_test;
+
+import 'dart:html';
+
+void notCovered() {
+  print('nope');
+}
+
+bool works() => document is Document;

--- a/test/fixtures/coverage/failing_test/pubspec.yaml
+++ b/test/fixtures/coverage/failing_test/pubspec.yaml
@@ -1,0 +1,7 @@
+name: coverage_failing_test
+version: 0.0.0
+dev_dependencies:
+  coverage: "^0.7.2"
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"

--- a/test/fixtures/coverage/failing_test/test/failing_test.dart
+++ b/test/fixtures/coverage/failing_test/test/failing_test.dart
@@ -1,0 +1,11 @@
+@TestOn('browser')
+library coverage_failing_test.test.failing_test;
+
+import 'package:coverage_failing_test/coverage_failing_test.dart' as lib;
+import 'package:test/test.dart';
+
+main() {
+  test('fails', () {
+    expect(1, isTrue);
+  });
+}

--- a/test/fixtures/coverage/failing_test/test/passing_test.dart
+++ b/test/fixtures/coverage/failing_test/test/passing_test.dart
@@ -1,0 +1,11 @@
+@TestOn('browser')
+library coverage_failing_test.test.passing_testt;
+
+import 'package:coverage_failing_test/coverage_failing_test.dart' as lib;
+import 'package:test/test.dart';
+
+main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test/integration/coverage_test.dart
+++ b/test/integration/coverage_test.dart
@@ -28,6 +28,7 @@ const String projectWithBrowserTestsThatNeedsPubServe =
     'test/fixtures/coverage/browser_needs_pub_serve';
 const String projectWithoutCoveragePackage =
     'test/fixtures/coverage/no_coverage_package';
+const String projectWithFailingTests = 'test/fixtures/coverage/failing_test';
 
 Future<bool> runCoverage(String projectPath, {bool html: false}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
@@ -71,6 +72,10 @@ void main() {
     test('should fail if "coverage" package is missing', () async {
       expect(await runCoverage(projectWithoutCoveragePackage), isFalse);
     });
+
+    test('should fail if there is a test that fails', () async {
+      expect(await runCoverage(projectWithFailingTests), isFalse);
+    }, timeout: new Timeout(new Duration(seconds: 60)));
 
     test('should create coverage with non_test file specified', () async {
       expect(await runCoverage(projectWithDartFile), isTrue);


### PR DESCRIPTION
## Issue
- https://github.com/Workiva/dart_dev/issues/73

## Changes
**Source:**
- Added flag that gets set if coverage detects a failing test

**Tests:**
- added

## Areas of Regression
- coverage

## Testing
- passing CI
- verify that coverage passes and fails as expected

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf