### PR TITLE
CP-1318 Add ability to pass in test name as a parameter to test task

### DIFF
--- a/README.md
+++ b/README.md
@@ -463,6 +463,11 @@ object.
 ddev test path/to/test_name path/to/another/test_name
 ```
 
+* Individual tests can be executed by passing in a test name or regex pattern of a test that would be loaded by the test runner
+```
+ddev test -n 'run only this test'
+```
+
 
 ## CLI Usage
 This package comes with a single executable: `dart_dev`. To run this executable:

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -89,8 +89,7 @@ class TestCli extends TaskCli {
 
     bool unit = parsedArgs['unit'];
     bool integration = parsedArgs['integration'];
-    bool testNamed;
-    parsedArgs['name'] != null ? testNamed = true : '';
+    bool testNamed = parsedArgs['name'] != null;
     List<String> tests = [];
     int individualTests = 0;
 

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -47,7 +47,7 @@ class TestCli extends TaskCli {
         allowMultiple: true,
         help:
             'The platform(s) on which to run the tests.\n[vm (default), dartium, content-shell, chrome, phantomjs, firefox, safari]')
-    ..addOption('test-name',
+    ..addOption('name',
         abbr: 'n',
         help:
             'A substring of the name of the test to run.\nRegular expression syntax is supported.');
@@ -90,7 +90,7 @@ class TestCli extends TaskCli {
     bool unit = parsedArgs['unit'];
     bool integration = parsedArgs['integration'];
     bool testNamed;
-    parsedArgs['test-name'] != null ? testNamed = true : '';
+    parsedArgs['name'] != null ? testNamed = true : '';
     List<String> tests = [];
     int individualTests = 0;
 
@@ -165,7 +165,7 @@ class TestCli extends TaskCli {
     }
 
     if (testNamed) {
-      additionalArgs.addAll(['-n', '${parsedArgs['test-name']}']);
+      additionalArgs.addAll(['-n', '${parsedArgs['name']}']);
     }
 
     TestTask task = test(

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -46,7 +46,11 @@ class TestCli extends TaskCli {
         abbr: 'p',
         allowMultiple: true,
         help:
-            'The platform(s) on which to run the tests.\n[vm (default), dartium, content-shell, chrome, phantomjs, firefox, safari]');
+            'The platform(s) on which to run the tests.\n[vm (default), dartium, content-shell, chrome, phantomjs, firefox, safari]')
+    ..addOption('test-name',
+        abbr: 'n',
+        help:
+            'A substring of the name of the test to run.\nRegular expression syntax is supported.');
 
   final String command = 'test';
 
@@ -85,6 +89,8 @@ class TestCli extends TaskCli {
 
     bool unit = parsedArgs['unit'];
     bool integration = parsedArgs['integration'];
+    bool testNamed;
+    parsedArgs['test-name'] != null ? testNamed = true : '';
     List<String> tests = [];
     int individualTests = 0;
 
@@ -156,6 +162,10 @@ class TestCli extends TaskCli {
               error: stdErr);
         }
       });
+    }
+
+    if (testNamed) {
+      additionalArgs.addAll(['-n', '${parsedArgs['test-name']}']);
     }
 
     TestTask task = test(

--- a/test/fixtures/analyze/warnings/lib/warnings.dart
+++ b/test/fixtures/analyze/warnings/lib/warnings.dart
@@ -1,0 +1,9 @@
+library analyze_warnings;
+
+analysis_method(param){
+
+}
+
+void main() {
+  analysis_method(1, 1);
+}

--- a/test/fixtures/analyze/warnings/pubspec.yaml
+++ b/test/fixtures/analyze/warnings/pubspec.yaml
@@ -1,0 +1,5 @@
+name: analyze_warnings
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -25,6 +25,7 @@ const String projectWithErrors = 'test/fixtures/analyze/errors';
 const String projectWithHints = 'test/fixtures/analyze/hints';
 const String projectWithNoIssues = 'test/fixtures/analyze/no_issues';
 const String projectWithStaticTypingIssues = 'test/fixtures/analyze/strong';
+const String projectWithWarnings = 'test/fixtures/analyze/warnings';
 
 Future<Analysis> analyzeProject(String projectPath,
     {bool fatalWarnings: true,
@@ -130,9 +131,10 @@ void main() {
     });
 
     test('should report warnings as fatal if configured to do so', () async {
-      Analysis analysis = await analyzeProject(projectWithErrors);
-      expect(analysis.numErrors, equals(2));
-      expect(analysis.numWarnings, equals(0));
+      Analysis analysis = await analyzeProject(projectWithWarnings);
+      expect(analysis.numErrors, equals(0));
+      expect(analysis.numWarnings, equals(1));
+      expect(analysis.exitCode, equals(1));
     });
 
     test('should not report warnings as fatal if not configured to do so',

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -27,7 +27,10 @@ const String projectWithPassingTests = 'test/fixtures/test/passing';
 const String projectThatNeedsPubServe = 'test/fixtures/test/needs_pub_serve';
 
 Future<bool> runTests(String projectPath,
-    {bool unit: true, bool integration: false, List<String> files}) async {
+    {bool unit: true,
+    bool integration: false,
+    List<String> files,
+    String testName: ''}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   List args = ['run', 'dart_dev', 'test'];
@@ -43,6 +46,10 @@ Future<bool> runTests(String projectPath,
         args.add(files[i]);
       }
     }
+  }
+
+  if (testName.isNotEmpty) {
+    args.addAll(['-n', testName]);
   }
 
   TaskProcess process =
@@ -119,6 +126,18 @@ void main() {
 
     test('should run tests that require a Pub server', () async {
       expect(await runTests(projectThatNeedsPubServe), isTrue);
+    });
+
+    test('should run tests with test name specified', () async {
+      expect(
+          await runTests(projectWithPassingTests, testName: 'passes'), isTrue);
+    });
+
+    test('should fail if named test does not exist', () async {
+      expect(
+          await runTests(projectWithPassingTests,
+              testName: 'non-existent test'),
+          isFalse);
     });
   });
 }


### PR DESCRIPTION
## Issue
- https://github.com/Workiva/dart_dev/issues/55 (master currently address part of this by a user being able to add in individual test files)

## Changes
**Source:**
- added the ability to pass in a test name through the CLI
- updated analyze test due to changes in dart 1.14.0

**Tests:**
- added

## Areas of Regression
- test execution

## Testing
- `ddev test` works as expected with and without a named test

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf