### PR TITLE
CP-1347 Parse args leniently, forward to underlying executables

### DIFF
--- a/lib/src/lenient_args/lenient_arg_results.dart
+++ b/lib/src/lenient_args/lenient_arg_results.dart
@@ -1,0 +1,92 @@
+import 'dart:collection';
+
+import 'package:args/args.dart';
+
+ArgResults newLenientArgResults(
+    ArgParser parser,
+    Map<String, dynamic> parsed,
+    List<String> unknown,
+    String name,
+    ArgResults command,
+    List<String> rest,
+    List<String> arguments) {
+  return new LenientArgResults._(
+      parser, parsed, unknown, name, command, rest, arguments);
+}
+
+class LenientArgResults implements ArgResults {
+  /// The [ArgParser] whose options were parsed for these results.
+  final ArgParser _parser;
+
+  /// The option values that were parsed from arguments.
+  final Map<String, dynamic> _parsed;
+
+  /// The options that were unknown but still parsed.
+  final List<String> _unknown;
+
+  /// If these are the results for parsing a command's options, this will be the
+  /// name of the command. For top-level results, this returns `null`.
+  final String name;
+
+  /// The command that was selected, or `null` if none was.
+  ///
+  /// This will contain the options that were selected for that command.
+  final ArgResults command;
+
+  /// The remaining command-line arguments that were not parsed as options or
+  /// flags.
+  ///
+  /// If `--` was used to separate the options from the remaining arguments,
+  /// it will not be included in this list unless parsing stopped before the
+  /// `--` was reached.
+  final List<String> rest;
+
+  /// The original list of arguments that were parsed.
+  final List<String> arguments;
+
+  /// Creates a new [LenientArgResults].
+  LenientArgResults._(this._parser, this._parsed, this._unknown, this.name,
+      this.command, List<String> rest, List<String> arguments)
+      : this.rest = new UnmodifiableListView(rest),
+        this.arguments = new UnmodifiableListView(arguments);
+
+  /// Gets the parsed command-line option named [name].
+  operator [](String name) {
+    if (!_parser.options.containsKey(name)) {
+      throw new ArgumentError('Could not find an option named "$name".');
+    }
+
+    return _parser.options[name].getOrDefault(_parsed[name]);
+  }
+
+  /// Get the names of the available options as an [Iterable].
+  ///
+  /// This includes the options whose values were parsed or that have defaults.
+  /// Options that weren't present and have no default will be omitted.
+  Iterable<String> get options {
+    var result = new Set<String>.from(_parsed.keys);
+
+    // Include the options that have defaults.
+    _parser.options.forEach((name, option) {
+      if (option.defaultValue != null) result.add(name);
+    });
+
+    return result;
+  }
+
+  Iterable<String> get unknownOptions => new Set<String>.from(_unknown);
+
+  /// Returns `true` if the option with [name] was parsed from an actual
+  /// argument.
+  ///
+  /// Returns `false` if it wasn't provided and the default value or no default
+  /// value would be used instead.
+  bool wasParsed(String name) {
+    var option = _parser.options[name];
+    if (option == null) {
+      throw new ArgumentError('Could not find an option named "$name".');
+    }
+
+    return _parsed.containsKey(name);
+  }
+}

--- a/lib/src/lenient_args/lenient_parser.dart
+++ b/lib/src/lenient_args/lenient_parser.dart
@@ -1,0 +1,125 @@
+import 'package:args/args.dart';
+import 'package:args/src/parser.dart';
+
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
+
+class LenientParser extends Parser {
+  static LenientArgResults parseArgs(ArgParser argParser, List<String> args) =>
+      new LenientParser(null, argParser, args.toList(), null, null).parse();
+
+  List<String> _unknownOptions = [];
+
+  LenientParser(commandName, grammar, args, parent, rest)
+      : super(commandName, grammar, args, parent, rest);
+
+  /// Parses the arguments. This can only be called once.
+  ///
+  /// Instead of throwing when an unrecognized option/flag is found (like
+  /// [Parser] does), this will store them and continue parsing.
+  @override
+  LenientArgResults parse() {
+    var arguments = args.toList();
+    var commandResults = null;
+
+    // Parse the args.
+    while (args.length > 0) {
+      if (current == '--') {
+        // Reached the argument terminator, so stop here.
+        args.removeAt(0);
+        break;
+      }
+
+      // Try to parse the current argument as a command. This happens before
+      // options so that commands can have option-like names.
+      var command = grammar.commands[current];
+      if (command != null) {
+        validate(rest.isEmpty, 'Cannot specify arguments before a command.');
+        var commandName = args.removeAt(0);
+        var commandParser =
+            new LenientParser(commandName, command, args, this, rest);
+        commandResults = commandParser.parse();
+
+        // All remaining arguments were passed to command so clear them here.
+        rest.clear();
+        break;
+      }
+
+      // Try to parse the current argument as an option. Note that the order
+      // here matters.
+      try {
+        if (parseSoloOption()) continue;
+      } on FormatException {
+        // Unknown solo option. Need to try to determine if this is a flag or an
+        // option with a value.
+        var unknownSoloOpt = args.removeAt(0);
+
+        // If there are no more args, then it must be a flag.
+        if (args.isEmpty) {
+          _unknownOptions.add(unknownSoloOpt);
+          continue;
+        }
+
+        // If there is another arg and it does not appear to be a new option,
+        // then assume it is a value for this solo option.
+        if (!args[0].startsWith('-')) {
+          _unknownOptions.addAll([unknownSoloOpt, args.removeAt(0)]);
+          continue;
+        }
+
+        // Otherwise, assume it is a flag.
+        _unknownOptions.add(unknownSoloOpt);
+        continue;
+      }
+
+      try {
+        if (parseAbbreviation(this)) continue;
+      } on FormatException {
+        // Unknown abbreviation option. Abbreviations can either be a series of
+        // collapsed abbreviations (like "-abc") or a single abbreviation with
+        // the value directly attached to it (like "-mrelease"). Without the
+        // option being defined, it's impossible to know which is correct.
+        // Instead of guessing, store the entire arg as an unknown flag.
+        _unknownOptions.add(args.removeAt(0));
+        continue;
+      }
+
+      try {
+        if (parseLongOption()) continue;
+      } on FormatException {
+        // Unknown long option.
+
+        // If it contains "=", it's in the form "--mode=release".
+        if (args[0].contains('=')) {
+          _unknownOptions.add(args.removeAt(0));
+          continue;
+        }
+
+        // Otherwise, it's either the long name for a flag ("--enable") or it's
+        // an option in the form "--mode release". Unfortunately, there's no way
+        // to know which it is. We can't assume the latter because the value
+        // could also be a plain arg. Because of this, we'll assume it's a flag.
+
+        // Otherwise, it must be in the form "--mode release".
+        _unknownOptions.add(args.removeAt(0));
+        continue;
+      }
+
+      // This argument is neither option nor command, so stop parsing unless
+      // the [allowTrailingOptions] option is set.
+      if (!grammar.allowTrailingOptions) break;
+      rest.add(args.removeAt(0));
+    }
+
+    // Invoke the callbacks.
+    grammar.options.forEach((name, option) {
+      if (option.callback == null) return;
+      option.callback(option.getOrDefault(results[name]));
+    });
+
+    // Add in the leftover arguments we didn't parse to the innermost command.
+    rest.addAll(args);
+    args.clear();
+    return newLenientArgResults(grammar, results, _unknownOptions, commandName,
+        commandResults, rest, arguments);
+  }
+}

--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -27,7 +27,8 @@ AnalyzeTask analyze(
     bool fatalWarnings: defaultFatalWarnings,
     bool hints: defaultHints,
     bool fatalHints: defaultFatalHints,
-    bool strong: defaultStrong}) {
+    bool strong: defaultStrong,
+    List<String> cliArgs}) {
   var executable = 'dartanalyzer';
   var args = [];
   if (fatalWarnings) {
@@ -41,15 +42,15 @@ AnalyzeTask analyze(
   if (strong) {
     args.add('--strong');
   }
-
+  args.addAll(cliArgs);
   args.addAll(_findFilesFromEntryPoints(entryPoints));
 
   TaskProcess process = new TaskProcess(executable, args);
   AnalyzeTask task =
       new AnalyzeTask('$executable ${args.join(' ')}', process.done);
 
-  process.stdout.listen(task._analyzerOutput.add);
-  process.stderr.listen(task._analyzerOutput.addError);
+  process.stdout.listen((l) {print(l); task._analyzerOutput.add(l);});
+  process.stderr.listen((l) {print(l); task._analyzerOutput.addError(l);});
   process.exitCode.then((code) {
     task.successful = code <= 0;
   });

--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -49,8 +49,14 @@ AnalyzeTask analyze(
   AnalyzeTask task =
       new AnalyzeTask('$executable ${args.join(' ')}', process.done);
 
-  process.stdout.listen((l) {print(l); task._analyzerOutput.add(l);});
-  process.stderr.listen((l) {print(l); task._analyzerOutput.addError(l);});
+  process.stdout.listen((l) {
+    print(l);
+    task._analyzerOutput.add(l);
+  });
+  process.stderr.listen((l) {
+    print(l);
+    task._analyzerOutput.addError(l);
+  });
   process.exitCode.then((code) {
     task.successful = code <= 0;
   });

--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -50,11 +50,9 @@ AnalyzeTask analyze(
       new AnalyzeTask('$executable ${args.join(' ')}', process.done);
 
   process.stdout.listen((l) {
-    print(l);
     task._analyzerOutput.add(l);
   });
   process.stderr.listen((l) {
-    print(l);
     task._analyzerOutput.addError(l);
   });
   process.exitCode.then((code) {

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -36,8 +36,7 @@ class AnalyzeCli extends TaskCli {
   final String command = 'analyze';
 
   Future<String> getUsage() async {
-    var usage =
-        ['dartanalyzer options', '====================', ''].join('\n');
+    var usage = ['dartanalyzer options', '====================', ''].join('\n');
     var process = new TaskProcess('dartanalyzer', ['--help']);
     usage += await process.stderr.join('\n');
     return usage;

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -18,53 +18,46 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter;
+import 'package:dart_dev/util.dart' show reporter, TaskProcess;
 
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
 import 'package:dart_dev/src/tasks/analyze/api.dart';
-import 'package:dart_dev/src/tasks/analyze/config.dart';
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
 
 class AnalyzeCli extends TaskCli {
-  final ArgParser argParser = new ArgParser()
-    ..addFlag('fatal-warnings',
-        defaultsTo: defaultFatalWarnings,
-        negatable: true,
-        help: 'Treat non-type warnings as fatal.')
-    ..addFlag('hints',
-        defaultsTo: defaultHints, negatable: true, help: 'Show hint results.')
-    ..addFlag('fatal-hints',
-        defaultsTo: defaultFatalHints,
-        negatable: true,
-        help: 'Treat hints as fatal.')
-    ..addFlag('strong',
-        defaultsTo: defaultStrong,
-        negatable: true,
-        help: 'Enable strong static checks (https://goo.gl/DqcBsw)');
+  static Future<String> getAnalyzerUsage() {
+    var process = new TaskProcess('dartanalyzer', ['--help']);
+    return process.stdout.join();
+  }
+
+  final ArgParser argParser = new ArgParser();
 
   final String command = 'analyze';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
-    List<String> entryPoints = config.analyze.entryPoints;
-    bool fatalWarnings = TaskCli.valueOf(
-        'fatal-warnings', parsedArgs, config.analyze.fatalWarnings);
-    bool hints = TaskCli.valueOf('hints', parsedArgs, config.analyze.hints);
-    bool fatalHints =
-        TaskCli.valueOf('fatal-hints', parsedArgs, config.analyze.fatalHints);
-    bool strong = TaskCli.valueOf('strong', parsedArgs, config.analyze.strong);
+  Future<String> getUsage() async {
+    var usage =
+        ['dartanalyzer options', '====================', ''].join('\n');
+    var process = new TaskProcess('dartanalyzer', ['--help']);
+    usage += await process.stderr.join('\n');
+    return usage;
+  }
 
-    if (!hints && fatalHints) {
-      return new CliResult.fail('You must enable hints to fail on hints.');
-    }
+  Future<CliResult> run(LenientArgResults parsedArgs) async {
+    List<String> entryPoints = config.analyze.entryPoints;
+    var cliArgs = parsedArgs.unknownOptions.toList()..addAll(parsedArgs.rest);
+
+    print('\nForwarding the following options and args to dartanalyzer:');
+    print(cliArgs);
 
     AnalyzeTask task = analyze(
         entryPoints: entryPoints,
-        fatalWarnings: fatalWarnings,
-        hints: hints,
-        fatalHints: fatalHints,
-        strong: strong);
+        fatalWarnings: config.analyze.fatalWarnings,
+        hints: config.analyze.hints,
+        fatalHints: config.analyze.fatalHints,
+        strong: config.analyze.strong,
+        cliArgs: cliArgs);
     var title = task.analyzerCommand;
-    if (fatalHints) title += ' (treating hints as fatal)';
 
     reporter.logGroup(title, outputStream: task.analyzerOutput);
     await task.done;

--- a/lib/src/tasks/cli.dart
+++ b/lib/src/tasks/cli.dart
@@ -18,6 +18,8 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
+
 class CliResult {
   final String message;
   final bool successful;
@@ -26,11 +28,12 @@ class CliResult {
 }
 
 abstract class TaskCli {
-  static valueOf(String arg, ArgResults parsedArgs, dynamic fallback) =>
+  static valueOf(String arg, LenientArgResults parsedArgs, dynamic fallback) =>
       parsedArgs.wasParsed(arg) ? parsedArgs[arg] : fallback;
 
   ArgParser get argParser;
   String get command;
 
-  Future<CliResult> run(ArgResults parsedArgs);
+  Future<String> getUsage();
+  Future<CliResult> run(LenientArgResults parsedArgs);
 }

--- a/lib/src/tasks/copy_license/cli.dart
+++ b/lib/src/tasks/copy_license/cli.dart
@@ -28,7 +28,9 @@ class CopyLicenseCli extends TaskCli {
 
   final String command = 'copy-license';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<String> getUsage() async => 'The copy-license task has no options.';
+
+  Future<CliResult> run(_) async {
     List<String> directories = config.copyLicense.directories;
     String licensePath = config.copyLicense.licensePath;
 

--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -19,8 +19,9 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter;
+import 'package:dart_dev/util.dart' show reporter, TaskProcess;
 
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
@@ -40,18 +41,23 @@ class CoverageCli extends TaskCli {
         negatable: true,
         defaultsTo: defaultHtml,
         help: 'Generate and open an HTML report.')
-    ..addFlag('pub-serve',
-        negatable: true,
-        defaultsTo: defaultPubServe,
-        help: 'Serves browser tests using a Pub server.')
     ..addFlag('open',
         negatable: true,
         defaultsTo: true,
-        help: 'Open the HTML report automatically.');
+        help: 'Open the HTML report automatically.')
+    ..addFlag('pub-serve',
+        negatable: false,
+        defaultsTo: defaultPubServe,
+        help: 'Spins up a Pub server and uses it to serve browser tests.');
 
   final String command = 'coverage';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<String> getUsage() async {
+    return ['dart_dev options', '================', '${argParser.usage}']
+        .join('\n');
+  }
+
+  Future<CliResult> run(LenientArgResults parsedArgs) async {
     if (!platform_util.hasImmediateDependency('coverage'))
       return new CliResult.fail(
           'Package "coverage" must be an immediate dependency in order to run its executables.');
@@ -66,7 +72,7 @@ class CoverageCli extends TaskCli {
 
     bool html = TaskCli.valueOf('html', parsedArgs, config.coverage.html);
     bool pubServe =
-        TaskCli.valueOf('pub-serve', parsedArgs, config.coverage.pubServe);
+        TaskCli.valueOf('pub-serve', parsedArgs, config.test.pubServe);
     bool open = TaskCli.valueOf('open', parsedArgs, true);
 
     List<String> tests = [];

--- a/lib/src/tasks/coverage/config.dart
+++ b/lib/src/tasks/coverage/config.dart
@@ -15,7 +15,6 @@
 library dart_dev.src.tasks.coverage.config;
 
 import 'package:dart_dev/src/tasks/config.dart';
-import 'package:dart_dev/src/tasks/test/config.dart';
 
 const bool defaultHtml = true;
 const String defaultOutput = 'coverage/';
@@ -23,7 +22,6 @@ const List<String> defaultReportOn = const ['lib/'];
 
 class CoverageConfig extends TaskConfig {
   bool html = defaultHtml;
-  bool pubServe = defaultPubServe;
   String output = defaultOutput;
   List<String> reportOn = defaultReportOn;
 }

--- a/lib/src/tasks/docs/cli.dart
+++ b/lib/src/tasks/docs/cli.dart
@@ -21,6 +21,7 @@ import 'package:args/args.dart';
 import 'package:dart_dev/util.dart' show hasImmediateDependency, reporter;
 import 'package:path/path.dart' as path;
 
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/docs/api.dart';
 
@@ -31,7 +32,15 @@ class DocsCli extends TaskCli {
 
   final String command = 'docs';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<String> getUsage() async {
+    return [
+      'dart_dev docs options',
+      '=====================',
+      '${argParser.usage}',
+    ].join('\n');
+  }
+
+  Future<CliResult> run(LenientArgResults parsedArgs) async {
     if (!hasImmediateDependency('dartdoc'))
       return new CliResult.fail(
           'Package "dartdoc" must be an immediate dependency in order to run its executables.');

--- a/lib/src/tasks/examples/cli.dart
+++ b/lib/src/tasks/examples/cli.dart
@@ -20,11 +20,13 @@ import 'package:args/args.dart';
 
 import 'package:dart_dev/util.dart' show reporter;
 
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
 import 'package:dart_dev/src/tasks/examples/api.dart';
 import 'package:dart_dev/src/tasks/examples/config.dart';
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
 
+// TODO: Make a more generic serve task that forwards args to `pub serve`
 class ExamplesCli extends TaskCli {
   final ArgParser argParser = new ArgParser()
     ..addOption('hostname',
@@ -35,7 +37,15 @@ class ExamplesCli extends TaskCli {
 
   final String command = 'examples';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<String> getUsage() async {
+    return [
+      'dart_dev examples options',
+      '=========================',
+      '${argParser.usage}'
+    ].join('\n');
+  }
+
+  Future<CliResult> run(LenientArgResults parsedArgs) async {
     String hostname =
         TaskCli.valueOf('hostname', parsedArgs, config.examples.hostname);
     var port = TaskCli.valueOf('port', parsedArgs, config.examples.port);

--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -25,6 +25,7 @@ import 'package:dart_dev/src/tasks/task.dart';
 
 FormatTask format(
     {bool check: defaultCheck,
+    List<String> cliArgs: const [],
     List<String> directories: defaultDirectories,
     List<String> exclude: defaultExclude,
     int lineLength: defaultLineLength}) {
@@ -83,6 +84,8 @@ FormatTask format(
 
     args.addAll(filesToFormat);
   }
+
+  args.addAll(cliArgs);
 
   TaskProcess process = new TaskProcess(executable, args);
   FormatTask task = new FormatTask(

--- a/lib/src/tasks/init/cli.dart
+++ b/lib/src/tasks/init/cli.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
+import 'package:dart_dev/src/lenient_args/lenient_arg_results.dart';
 import 'package:dart_dev/src/tasks/init/api.dart';
 import 'package:dart_dev/src/tasks/cli.dart';
 
@@ -26,7 +27,9 @@ class InitCli extends TaskCli {
 
   final String command = 'init';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<String> getUsage() async => argParser.usage;
+
+  Future<CliResult> run(LenientArgResults parsedArgs) async {
     InitTask task = init();
     await task.done;
     return task.successful

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -21,20 +21,16 @@ import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:dart_dev/src/tasks/task.dart';
 
 TestTask test(
-    {int concurrency,
-    List<String> additionalArgs: const [],
+    {List<String> cliArgs: const [],
     List<String> platforms: const [],
     List<String> tests: const []}) {
   var executable = 'pub';
   var args = ['run', 'test'];
-  if (concurrency != null) {
-    args.add('--concurrency=$concurrency');
-  }
   platforms.forEach((p) {
     args.addAll(['-p', p]);
   });
   args.addAll(['--reporter=expanded']);
-  args.addAll(additionalArgs);
+  args.addAll(cliArgs);
   args.addAll(tests);
 
   TaskProcess process = new TaskProcess(executable, args);

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -60,24 +60,6 @@ class TestCli extends TaskCli {
     return parsedArgs.rest.length > 0;
   }
 
-//  Future addToTestsFromRest(List<String> tests, List<String> rest) async {
-//    int restLength = rest.length;
-//    int individualTests = 0;
-//    // Verify this is a test-file and it exists.
-//    for (var i = 0; i < restLength; i++) {
-//      String filePath = rest[i];
-//      await new File(filePath).exists().then((bool exists) {
-//        if (exists) {
-//          individualTests++;
-//          tests.add(filePath);
-//        } else {
-//          print("Ignoring unknown argument");
-//        }
-//      });
-//    }
-//    return individualTests;
-//  }
-
   bool isExplicitlyFalse(bool value) {
     return value != null && value == false;
   }
@@ -102,10 +84,6 @@ class TestCli extends TaskCli {
         (option) => option.contains('-p') || option.contains('--platform'))) {
       platforms = config.test.platforms;
     }
-
-//    if (hasRestParams(parsedArgs)) {
-//      individualTests = await addToTestsFromRest(tests, parsedArgs.rest);
-//    }
 
     if (isExplicitlyFalse(unit) && !integration && individualTests == 0) {
       return new CliResult.fail(

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -25,6 +25,7 @@ const List<String> defaultUnitTests = const ['test/'];
 const List<String> defaultPlatforms = const [];
 
 class TestConfig extends TaskConfig {
+  @deprecated
   int concurrency = defaultConcurrency;
   bool pubServe = defaultPubServe;
   List<String> integrationTests = defaultIntegrationTests;

--- a/test/fixtures/coverage/failing_test/test/failing_test.dart.temp.html
+++ b/test/fixtures/coverage/failing_test/test/failing_test.dart.temp.html
@@ -1,0 +1,1 @@
+<script type="application/dart" src="failing_test.dart"></script>

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -77,9 +77,8 @@ void main() {
 
     test('should run individual unit test', () async {
       expect(
-          await runTests(projectWithPassingTests, files: [
-            'test/passing_unit_test.dart'
-          ]),
+          await runTests(projectWithPassingTests,
+              files: ['test/passing_unit_test.dart']),
           isTrue);
     });
 

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -78,7 +78,7 @@ void main() {
     test('should run individual unit test', () async {
       expect(
           await runTests(projectWithPassingTests, files: [
-            'test/fixtures/test/passing/test/passing_unit_test.dart'
+            'test/passing_unit_test.dart'
           ]),
           isTrue);
     });
@@ -86,8 +86,8 @@ void main() {
     test('should run individual unit tests', () async {
       expect(
           await runTests(projectWithPassingTests, files: [
-            'test/fixtures/test/passing/test/passing_unit_test.dart',
-            'test/fixtures/test/passing/test/passing_unit_integration.dart'
+            'test/passing_unit_test.dart',
+            'test/passing_integration_test.dart'
           ]),
           isTrue);
     });


### PR DESCRIPTION
## Issue
- Currently we have to explicitly support every argument that we want to pass on to the underlying executables because the `ArgParser` class throws if it encounters an unknown option.

## Changes
**Source:**
- Added a `LenientParser` class and a `LenientArgResults` class that can be used to parse args in a lenient manner that captures the unknown args instead of throwing.
- Updated most of the tasks to use this lenient arg parsing and forward all unknown args to the underlying executable (`dartanalyzer`, `dart_style:format`, `test`)

**Tests:**
- Updated tests
- Analyzer tests are still failing (will be fixed in #126)
- Coverage tests are still failing (see https://github.com/dart-lang/coverage/issues/104)

## Areas of Regression
- Any task that is forwarding args:
  - `analyze`
  - `format`
  - `test`

## Testing
- CI passes

## Code Review
@trentgrover-wf
@maxwellpeterson-wf 
@dustinlessard-wf
@jayudey-wf 