### PR TITLE
CP-1393 Update test task to observe `--no-unit` flag

### DIFF
--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -111,8 +111,6 @@ class TestCli extends TaskCli {
     if (isExplicitlyFalse(unit) && !integration && individualTests == 0) {
       return new CliResult.fail(
           'No tests were selected. Include at least one of --unit or --integration.');
-    } else {
-      if (individualTests == 0) unit = true;
     }
 
     if (unit) {

--- a/test/fixtures/test/passingIntegration/pubspec.yaml
+++ b/test/fixtures/test/passingIntegration/pubspec.yaml
@@ -1,0 +1,6 @@
+name: integration_test_passing
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"

--- a/test/fixtures/test/passingIntegration/test/failing_unit_test.dart
+++ b/test/fixtures/test/passingIntegration/test/failing_unit_test.dart
@@ -1,0 +1,9 @@
+library integration_test_passing.test.failing_unit_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(false, isTrue);
+  });
+}

--- a/test/fixtures/test/passingIntegration/test/passing_integration_test.dart
+++ b/test/fixtures/test/passingIntegration/test/passing_integration_test.dart
@@ -1,0 +1,9 @@
+library integration_test_passing.test.passing_integration_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test/fixtures/test/passingIntegration/tool/dev.dart
+++ b/test/fixtures/test/passingIntegration/tool/dev.dart
@@ -1,0 +1,11 @@
+library integration_test_passing.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.test
+    ..unitTests = ['test/failing_unit_test.dart']
+    ..integrationTests = ['test/passing_integration_test.dart'];
+
+  await dev(args);
+}

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -24,6 +24,8 @@ import 'package:test/test.dart';
 const String projectWithoutTestPackage = 'test/fixtures/test/no_test_package';
 const String projectWithFailingTests = 'test/fixtures/test/failing';
 const String projectWithPassingTests = 'test/fixtures/test/passing';
+const String projectWithPassingIntegrationTests =
+    'test/fixtures/test/passingIntegration';
 const String projectThatNeedsPubServe = 'test/fixtures/test/needs_pub_serve';
 
 Future<bool> runTests(String projectPath,
@@ -106,9 +108,9 @@ void main() {
           isTrue);
     });
 
-    test('should run integration tests', () async {
+    test('should run integration tests and not unit tests', () async {
       expect(
-          await runTests(projectWithPassingTests,
+          await runTests(projectWithPassingIntegrationTests,
               unit: false, integration: true),
           isTrue);
     });


### PR DESCRIPTION
## Issue
- If a user passed in the following command `pub run dart_dev test --no-unit --integration` unit tests were still being run


[11:26 AM] Travis Sanderson: I am on dart_dev 1.0.6 and when I run "pub run dart_dev test --no-unit --integration" it runs my unit tests too, but if I use coverage with the same params it only runs integrations like I want

## Changes
**Source:**
- removed un-necessary code block overriding cli params

**Tests:**
- updated tests to verify behavior as expected (in the updated tests if unit tests were run it would cause the test task to fail)

## Areas of Regression
- failing CI

## Testing
- passing CI

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf