### PR TITLE
CP-1398 Update logic around including unit tests by default

### DIFF
--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -87,7 +87,7 @@ class TestCli extends TaskCli {
 
     List<String> additionalArgs = [];
 
-    bool unit = parsedArgs['unit'];
+    bool unit = !isExplicitlyFalse(parsedArgs['unit']);
     bool integration = parsedArgs['integration'];
     bool testNamed = parsedArgs['name'] != null;
     List<String> tests = [];

--- a/test/fixtures/test/default_unit/lib/passing_unit.dart
+++ b/test/fixtures/test/default_unit/lib/passing_unit.dart
@@ -1,0 +1,9 @@
+library default_unit.lib.passing_unit;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passing', () {
+    expect(true, isTrue);
+  });
+}

--- a/test/fixtures/test/default_unit/pubspec.yaml
+++ b/test/fixtures/test/default_unit/pubspec.yaml
@@ -1,0 +1,6 @@
+name: default_unit
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../../..
+  test: "^0.12.0"

--- a/test/fixtures/test/default_unit/tool/dev.dart
+++ b/test/fixtures/test/default_unit/tool/dev.dart
@@ -1,0 +1,10 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  config.test
+    ..unitTests = ['lib/passing_unit.dart'];
+
+  await dev(args);
+}

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -21,6 +21,8 @@ import 'dart:io';
 import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:test/test.dart';
 
+const String projectToVerifyUnitTestsRunByDefault =
+    'test/fixtures/test/default_unit';
 const String projectWithoutTestPackage = 'test/fixtures/test/no_test_package';
 const String projectWithFailingTests = 'test/fixtures/test/failing';
 const String projectWithPassingTests = 'test/fixtures/test/passing';
@@ -103,7 +105,7 @@ void main() {
 
     test('should run unit tests by default', () async {
       expect(
-          await runTests(projectWithPassingTests,
+          await runTests(projectToVerifyUnitTestsRunByDefault,
               unit: null, integration: null),
           isTrue);
     });


### PR DESCRIPTION
## Issue
- With inclusion of https://github.com/Workiva/dart_dev/pull/131 the way unit tests were being included wasn't working as expected.

[6:20 PM] Greg Littlefield: FYI Our builds started failing after dart_dev 1.1.0 was released: https://github.com/Workiva/web_skin_dart/pull/284. In case anyone runs into a similar issue.

## Changes
**Source:**
- Updated the logic to see if the cli param was explicitly set to false
- Updated the tests that runs default unit tests to fail if unit tests aren't being run by default

**Tests:**
- updated

## Areas of Regression
- the `test` task

## Testing
- verify that `test` task is working as expected

## Code Review
@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf