### PR TITLE
CP-1453 Upgrade to coverage 0.7.3 to fix coverage issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pubspec.lock
 /test/fixtures/coverage/browser/coverage/
 /test/fixtures/coverage/browser_needs_pub_serve/coverage/
 /test/fixtures/coverage/failing_test/coverage/
+/test/fixtures/coverage/failing_test/test/failing_test.dart.temp.html
 /test/fixtures/coverage/non_test_file/coverage/
 /test/fixtures/coverage/vm/coverage/
 /test/fixtures/docs/docs/doc/api/

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ need to know how to use the `dart_dev` tool.
 Add the following to your `pubspec.yaml`:
 ```yaml
 dev_dependencies:
-  coverage: "^0.7.2"
+  coverage: "^0.7.3"
   dart_dev: "^1.0.0"
   dart_style: ">=0.1.8 <0.3.0"
   dartdoc: "^0.4.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ homepage: https://github.com/Workiva/dart_dev
 dependencies:
   ansicolor: "^0.0.9"
   args: "^0.13.0"
-  coverage: "^0.7.2"
+  coverage: "^0.7.3"
   dart_style: ">=0.1.8 <0.3.0"
   dartdoc: ">=0.4.0 <0.9.0"
   path: "^1.3.6"


### PR DESCRIPTION
## Issue

Coverage broke with Dart SDK 1.14. The coverage package released version 0.7.3 to address this issue, although it was only compatible with Dart SDK 1.15. Now that 1.15 is out, we need to update and make sure coverage is working.

## Changes

Upgrade to coverage 0.7.3.

## Testing
- [ ] Ensure all tests pass
- [ ] Run coverage in a project with VM and browser tests and ensure that it is correctly collected.

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 