### PR TITLE
CP-1480 Test Task: correctly build the set of tests to run and respect the --no-color flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.1.2](https://github.com/Workiva/dart_dev/compare/1.1.1...1.1.2)
+_March 22, 2016_
+
+- **Bug fix:** The test reporter output now respects the `--no-color` flag.
+
+- **Bug fix:** The test task was previously running the unit test suite even
+  when it was disabled. This has been fixed. Additionally, passing in individual
+  test files/directories overrides the unit and integration suites.
+
 ## [1.1.1](https://github.com/Workiva/dart_dev/compare/1.1.0...1.1.1)
 _February 24, 2016_
 

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -140,7 +140,8 @@ Future _run(List<String> args) async {
 
   TaskConfig config = _cliConfigs[task];
   await _runAll(config.before);
-  CliResult result = await _cliTasks[task].run(env.command);
+  CliResult result =
+      await _cliTasks[task].run(env.command, color: env['color']);
   await _runAll(config.after);
 
   reporter.log('');

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -44,7 +44,7 @@ class AnalyzeCli extends TaskCli {
 
   final String command = 'analyze';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     List<String> entryPoints = config.analyze.entryPoints;
     bool fatalWarnings = TaskCli.valueOf(
         'fatal-warnings', parsedArgs, config.analyze.fatalWarnings);

--- a/lib/src/tasks/cli.dart
+++ b/lib/src/tasks/cli.dart
@@ -32,5 +32,5 @@ abstract class TaskCli {
   ArgParser get argParser;
   String get command;
 
-  Future<CliResult> run(ArgResults parsedArgs);
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true});
 }

--- a/lib/src/tasks/copy_license/cli.dart
+++ b/lib/src/tasks/copy_license/cli.dart
@@ -28,7 +28,7 @@ class CopyLicenseCli extends TaskCli {
 
   final String command = 'copy-license';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     List<String> directories = config.copyLicense.directories;
     String licensePath = config.copyLicense.licensePath;
 

--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -51,7 +51,7 @@ class CoverageCli extends TaskCli {
 
   final String command = 'coverage';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     if (!platform_util.hasImmediateDependency('coverage'))
       return new CliResult.fail(
           'Package "coverage" must be an immediate dependency in order to run its executables.');

--- a/lib/src/tasks/docs/cli.dart
+++ b/lib/src/tasks/docs/cli.dart
@@ -31,7 +31,7 @@ class DocsCli extends TaskCli {
 
   final String command = 'docs';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     if (!hasImmediateDependency('dartdoc'))
       return new CliResult.fail(
           'Package "dartdoc" must be an immediate dependency in order to run its executables.');

--- a/lib/src/tasks/examples/cli.dart
+++ b/lib/src/tasks/examples/cli.dart
@@ -35,7 +35,7 @@ class ExamplesCli extends TaskCli {
 
   final String command = 'examples';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     String hostname =
         TaskCli.valueOf('hostname', parsedArgs, config.examples.hostname);
     var port = TaskCli.valueOf('port', parsedArgs, config.examples.port);

--- a/lib/src/tasks/format/cli.dart
+++ b/lib/src/tasks/format/cli.dart
@@ -38,7 +38,7 @@ class FormatCli extends TaskCli {
 
   final String command = 'format';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     try {
       if (!platform_util.hasImmediateDependency('dart_style'))
         return new CliResult.fail(

--- a/lib/src/tasks/init/cli.dart
+++ b/lib/src/tasks/init/cli.dart
@@ -26,7 +26,7 @@ class InitCli extends TaskCli {
 
   final String command = 'init';
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     InitTask task = init();
     await task.done;
     return task.successful

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -15,7 +15,6 @@
 library dart_dev.src.tasks.test.cli;
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/args.dart';
 
@@ -54,44 +53,21 @@ class TestCli extends TaskCli {
 
   final String command = 'test';
 
-  bool hasRestParams(ArgResults parsedArgs) {
-    return parsedArgs.rest.length > 0;
-  }
-
-  Future addToTestsFromRest(List<String> tests, List<String> rest) async {
-    int restLength = rest.length;
-    int individualTests = 0;
-    //verify this is a test-file and it exists.
-    for (var i = 0; i < restLength; i++) {
-      String filePath = rest[i];
-      await new File(filePath).exists().then((bool exists) {
-        if (exists) {
-          individualTests++;
-          tests.add(filePath);
-        } else {
-          print("Ignoring unknown argument");
-        }
-      });
-    }
-    return individualTests;
-  }
-
   bool isExplicitlyFalse(bool value) {
     return value != null && value == false;
   }
 
-  Future<CliResult> run(ArgResults parsedArgs) async {
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
     if (!platform_util.hasImmediateDependency('test'))
       return new CliResult.fail(
           'Package "test" must be an immediate dependency in order to run its executables.');
 
     List<String> additionalArgs = [];
-
-    bool unit = !isExplicitlyFalse(parsedArgs['unit']);
-    bool integration = parsedArgs['integration'];
-    bool testNamed = parsedArgs['name'] != null;
     List<String> tests = [];
-    int individualTests = 0;
+
+    if (!color) {
+      additionalArgs.add('--no-color');
+    }
 
     bool pubServe =
         TaskCli.valueOf('pub-serve', parsedArgs, config.test.pubServe);
@@ -104,20 +80,37 @@ class TestCli extends TaskCli {
     List<String> platforms =
         TaskCli.valueOf('platform', parsedArgs, config.test.platforms);
 
-    if (hasRestParams(parsedArgs)) {
-      individualTests = await addToTestsFromRest(tests, parsedArgs.rest);
-    }
+    // CLI user can specify individual test files to run.
+    bool individualTestsSpecified = parsedArgs.rest.isNotEmpty;
 
-    if (isExplicitlyFalse(unit) && !integration && individualTests == 0) {
+    // The unit test suite should be run by default.
+    bool unit = parsedArgs['unit'] ?? true;
+
+    // The integration suite should only be run if the --integration is set.
+    bool integration = parsedArgs['integration'] ?? false;
+
+    // CLI user can filter tests by name.
+    bool testNamed = parsedArgs['name'] != null;
+
+    if (!individualTestsSpecified && !unit && !integration) {
       return new CliResult.fail(
-          'No tests were selected. Include at least one of --unit or --integration.');
+          'No tests were selected. Include at least one of --unit or '
+          '--integration, or pass in one or more test files/directories');
     }
 
-    if (unit) {
-      tests.addAll(config.test.unitTests);
-    }
-    if (integration) {
-      tests.addAll(config.test.integrationTests);
+    // Build the list of tests to run.
+    if (individualTestsSpecified) {
+      // Individual tests explicitly passed in should override the test suites.
+      tests.addAll(parsedArgs.rest);
+    } else {
+      // Unit and/or integration suites should only run if individual tests
+      // were not specified.
+      if (unit) {
+        tests.addAll(config.test.unitTests);
+      }
+      if (integration) {
+        tests.addAll(config.test.integrationTests);
+      }
     }
 
     if (tests.isEmpty) {

--- a/test/fixtures/test/default_unit/test/unit_test.dart
+++ b/test/fixtures/test/default_unit/test/unit_test.dart
@@ -1,0 +1,5 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {});
+}

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -21,6 +21,7 @@ import 'dart:io';
 import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:test/test.dart';
 
+RegExp numTestsPassedPattern = new RegExp(r'\+(\d+)(:| )');
 const String projectToVerifyUnitTestsRunByDefault =
     'test/fixtures/test/default_unit';
 const String projectWithoutTestPackage = 'test/fixtures/test/no_test_package';
@@ -30,118 +31,113 @@ const String projectWithPassingIntegrationTests =
     'test/fixtures/test/passingIntegration';
 const String projectThatNeedsPubServe = 'test/fixtures/test/needs_pub_serve';
 
-Future<bool> runTests(String projectPath,
+Future<int> runTests(String projectPath,
     {bool unit: true,
     bool integration: false,
     List<String> files,
     String testName: ''}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
-  List args = ['run', 'dart_dev', 'test'];
+  List args = ['run', 'dart_dev', 'test', '--no-color'];
   if (unit != null) args.add(unit ? '--unit' : '--no-unit');
   if (integration != null)
     args.add(integration ? '--integration' : '--no-integration');
-  int i;
-
-  if (files != null) {
-    int filesLength = files.length;
-    if (filesLength > 0) {
-      for (i = 0; i < filesLength; i++) {
-        args.add(files[i]);
-      }
-    }
-  }
 
   if (testName.isNotEmpty) {
     args.addAll(['-n', testName]);
   }
 
+  args.addAll(files ?? <String>[]);
+
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
 
   await process.done;
-  return (await process.exitCode) == 0;
+  if ((await process.exitCode) != 0)
+    throw new TestFailure('Expected test to pass.');
+
+  var lastLine = await process.stdout.last;
+  var numTestsRun = -1;
+  if (numTestsPassedPattern.hasMatch(lastLine)) {
+    numTestsRun =
+        int.parse(numTestsPassedPattern.firstMatch(lastLine).group(1));
+  }
+  return numTestsRun;
 }
 
 void main() {
   group('Test Task', () {
     test('should fail if some unit tests fail', () async {
-      expect(
-          await runTests(projectWithFailingTests,
-              unit: true, integration: false),
-          isFalse);
+      expect(runTests(projectWithFailingTests, unit: true, integration: false),
+          throwsA(new isInstanceOf<TestFailure>()));
     });
 
     test('should fail if some integration tests fail', () async {
-      expect(
-          await runTests(projectWithFailingTests,
-              unit: false, integration: true),
-          isFalse);
+      expect(runTests(projectWithFailingTests, unit: false, integration: true),
+          throwsA(new isInstanceOf<TestFailure>()));
     });
 
     test('should run individual unit test', () async {
       expect(
-          await runTests(projectWithPassingTests, files: [
-            'test/fixtures/test/passing/test/passing_unit_test.dart'
-          ]),
-          isTrue);
+          await runTests(projectWithPassingTests,
+              files: ['test/passing_unit_test.dart']),
+          equals(1));
     });
 
     test('should run individual unit tests', () async {
       expect(
           await runTests(projectWithPassingTests, files: [
-            'test/fixtures/test/passing/test/passing_unit_test.dart',
-            'test/fixtures/test/passing/test/passing_unit_integration.dart'
+            'test/passing_unit_test.dart',
+            'test/passing_integration_test.dart'
           ]),
-          isTrue);
+          equals(2));
     });
 
     test('should run unit tests', () async {
       expect(
           await runTests(projectWithPassingTests,
               unit: true, integration: false),
-          isTrue);
+          equals(1));
     });
 
     test('should run unit tests by default', () async {
       expect(
           await runTests(projectToVerifyUnitTestsRunByDefault,
               unit: null, integration: null),
-          isTrue);
+          equals(1));
     });
 
     test('should run integration tests and not unit tests', () async {
       expect(
           await runTests(projectWithPassingIntegrationTests,
               unit: false, integration: true),
-          isTrue);
+          equals(1));
     });
 
     test('should run unit and integration tests', () async {
       expect(
           await runTests(projectWithPassingTests,
               unit: true, integration: true),
-          isTrue);
+          equals(2));
     });
 
     test('should warn if "test" package is not immediate dependency', () async {
-      expect(await runTests(projectWithoutTestPackage), isFalse);
+      expect(runTests(projectWithoutTestPackage),
+          throwsA(new isInstanceOf<TestFailure>()));
     });
 
     test('should run tests that require a Pub server', () async {
-      expect(await runTests(projectThatNeedsPubServe), isTrue);
+      expect(await runTests(projectThatNeedsPubServe), equals(1));
     });
 
     test('should run tests with test name specified', () async {
-      expect(
-          await runTests(projectWithPassingTests, testName: 'passes'), isTrue);
+      expect(await runTests(projectWithPassingTests, testName: 'passes'),
+          equals(1));
     });
 
     test('should fail if named test does not exist', () async {
-      expect(
-          await runTests(projectWithPassingTests,
-              testName: 'non-existent test'),
-          isFalse);
+      expect(runTests(projectWithPassingTests, testName: 'non-existent test'),
+          throwsA(new isInstanceOf<TestFailure>()));
     });
   });
 }


### PR DESCRIPTION
Fix #137.
Fix #138.

## Issues
Originally discovered in #138. The test is incorrectly including the default unit test suite even when individual tests are given as args and even with `--no-unit`.

Additionally, the test task does not respect the `--no-color` flag (#137).

## Changes
- Update the `TaskCli.run` abstract method to take `color` as an optional param. This allows the top-level CLI to pass the value of the `color` flag into the tasks.

- Forward the `--no-color` flag onto the the `pub run test` command.

- Update the logic used to build the list of tests to run as follows:
  - If individual test files/directories are passed in, only those are run.
  - Unless `--no-unit` is passed in, run the unit test suite.
  - If `--integration` is passed in, run the integration suite.

- The tests for the test task have been updated such that tests that expect the test task to succeed now also verify the number of tests that were run.

## Testing
- CI passes
- Checkout 0dc911c and verify that the newly updated tests that expect only a certain number of tests to run fail because of the issue from #138 (`ddev test --integration -n "Test Task"`)
- Checkout 20c8037 and verify that the test task tests pass (`ddev test --integration -n "Test Task"`)

## Code Review
@trentgrover-wf 
@maxwellpeterson-wf 
@dustinlessard-wf 
@jayudey-wf 

fyi: @trentonsmith-wf @philipbalvanz-wf @johnbland-wf @mattsanders-wf 