### PR TITLE
CP-1400 Release dart_dev 1.1.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.1.1
+version: 1.1.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1400

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1453  - Upgrade to coverage 0.7.3 to fix coverage issues  - https://github.com/Workiva/dart_dev/pull/140

 CP-1480  - Test Task correctly build the set of tests to run and respect the nocolor flag  - https://github.com/Workiva/dart_dev/pull/141

 CP-1524  - Coverage tests were routinely timing out on travis.ci  - https://github.com/Workiva/dart_dev/pull/143

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.1.1...CP-1400_release_1.1.2

