### PR TITLE
CP-1794 Add completions.dart support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,14 @@ alias ddev='pub run dart_dev'
 
 #### Bash Completion
 
-Symlink or copy the file `tool/ddev-completion.sh` into
-`/etc/bash_completion.d/` (or wherever your completion scripts live, if you
-have installed Bash through Homebrew on a Mac, for instance, this will be
-`/usr/local/etc/bash_completion.d/`).
+Bash command completion is available and easy to use. You'll want to install
+dart_dev globally: `pub global activate dart_dev`.
+
+Add the following to your `.bashrc`:
+
+```
+eval "$(pub global run dart_dev bash-completion)"
+```
 
 If you are using Bash installed through Homebrew, you'll also need to install
 the completion machinery with `brew install bash-completion`. Then make sure
@@ -131,7 +135,7 @@ autoload -U compinit
 compinit
 autoload -U bashcompinit
 bashcompinit
-source <path/to/ddev-completion.sh>
+eval "$(pub global run dart_dev bash-completion)"
 ```
 
 #### Configuration

--- a/lib/bash-completion.sh
+++ b/lib/bash-completion.sh
@@ -57,51 +57,6 @@ fi
 
 ###-end-ddev-completion-###
 
-###-begin-dart_dev-completion-###
-
-if type complete &>/dev/null; then
-  __dart_dev_completion() {
-    local si="$IFS"
-    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
-                           COMP_LINE="$COMP_LINE" \
-                           COMP_POINT="$COMP_POINT" \
-                           dart_dev completion -- "${COMP_WORDS[@]}" \
-                           2>/dev/null)) || return $?
-    IFS="$si"
-  }
-  complete -F __dart_dev_completion dart_dev
-elif type compdef &>/dev/null; then
-  __dart_dev_completion() {
-    si=$IFS
-    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
-                 COMP_LINE=$BUFFER \
-                 COMP_POINT=0 \
-                 dart_dev completion -- "${words[@]}" \
-                 2>/dev/null)
-    IFS=$si
-  }
-  compdef __dart_dev_completion dart_dev
-elif type compctl &>/dev/null; then
-  __dart_dev_completion() {
-    local cword line point words si
-    read -Ac words
-    read -cn cword
-    let cword-=1
-    read -l line
-    read -ln point
-    si="$IFS"
-    IFS=$'\n' reply=($(COMP_CWORD="$cword" \
-                       COMP_LINE="$line" \
-                       COMP_POINT="$point" \
-                       dart_dev completion -- "${words[@]}" \
-                       2>/dev/null)) || return $?
-    IFS="$si"
-  }
-  compctl -K __dart_dev_completion dart_dev
-fi
-
-###-end-dart_dev-completion-###
-
-## Generated 2016-05-04 21:49:06.300497Z
+## Generated 2016-05-04 22:44:09.283669Z
 ## By /Volumes/Workspace/dart_dev/.pub/bin/completion/shell_completion_generator.dart.snapshot
 

--- a/lib/bash-completion.sh
+++ b/lib/bash-completion.sh
@@ -12,6 +12,51 @@
 #    /usr/local/etc/bash_completion.d/
 #
 
+###-begin-dart_dev-completion-###
+
+if type complete &>/dev/null; then
+  __dart_dev_completion() {
+    local si="$IFS"
+    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
+                           COMP_LINE="$COMP_LINE" \
+                           COMP_POINT="$COMP_POINT" \
+                           dart_dev completion -- "${COMP_WORDS[@]}" \
+                           2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  complete -F __dart_dev_completion dart_dev
+elif type compdef &>/dev/null; then
+  __dart_dev_completion() {
+    si=$IFS
+    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
+                 COMP_LINE=$BUFFER \
+                 COMP_POINT=0 \
+                 dart_dev completion -- "${words[@]}" \
+                 2>/dev/null)
+    IFS=$si
+  }
+  compdef __dart_dev_completion dart_dev
+elif type compctl &>/dev/null; then
+  __dart_dev_completion() {
+    local cword line point words si
+    read -Ac words
+    read -cn cword
+    let cword-=1
+    read -l line
+    read -ln point
+    si="$IFS"
+    IFS=$'\n' reply=($(COMP_CWORD="$cword" \
+                       COMP_LINE="$line" \
+                       COMP_POINT="$point" \
+                       dart_dev completion -- "${words[@]}" \
+                       2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  compctl -K __dart_dev_completion dart_dev
+fi
+
+###-end-dart_dev-completion-###
+
 ###-begin-ddev-completion-###
 
 if type complete &>/dev/null; then
@@ -57,6 +102,6 @@ fi
 
 ###-end-ddev-completion-###
 
-## Generated 2016-05-04 22:44:09.283669Z
+## Generated 2016-05-04 22:46:09.154755Z
 ## By /Volumes/Workspace/dart_dev/.pub/bin/completion/shell_completion_generator.dart.snapshot
 

--- a/lib/bash-completion.sh
+++ b/lib/bash-completion.sh
@@ -57,6 +57,51 @@ fi
 
 ###-end-ddev-completion-###
 
-## Generated 2016-05-03 13:57:21.755825Z
+###-begin-dart_dev-completion-###
+
+if type complete &>/dev/null; then
+  __dart_dev_completion() {
+    local si="$IFS"
+    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
+                           COMP_LINE="$COMP_LINE" \
+                           COMP_POINT="$COMP_POINT" \
+                           dart_dev completion -- "${COMP_WORDS[@]}" \
+                           2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  complete -F __dart_dev_completion dart_dev
+elif type compdef &>/dev/null; then
+  __dart_dev_completion() {
+    si=$IFS
+    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
+                 COMP_LINE=$BUFFER \
+                 COMP_POINT=0 \
+                 dart_dev completion -- "${words[@]}" \
+                 2>/dev/null)
+    IFS=$si
+  }
+  compdef __dart_dev_completion dart_dev
+elif type compctl &>/dev/null; then
+  __dart_dev_completion() {
+    local cword line point words si
+    read -Ac words
+    read -cn cword
+    let cword-=1
+    read -l line
+    read -ln point
+    si="$IFS"
+    IFS=$'\n' reply=($(COMP_CWORD="$cword" \
+                       COMP_LINE="$line" \
+                       COMP_POINT="$point" \
+                       dart_dev completion -- "${words[@]}" \
+                       2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  compctl -K __dart_dev_completion dart_dev
+fi
+
+###-end-dart_dev-completion-###
+
+## Generated 2016-05-04 21:49:06.300497Z
 ## By /Volumes/Workspace/dart_dev/.pub/bin/completion/shell_completion_generator.dart.snapshot
 

--- a/lib/bash-completion.sh
+++ b/lib/bash-completion.sh
@@ -12,51 +12,6 @@
 #    /usr/local/etc/bash_completion.d/
 #
 
-###-begin-dart_dev-completion-###
-
-if type complete &>/dev/null; then
-  __dart_dev_completion() {
-    local si="$IFS"
-    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
-                           COMP_LINE="$COMP_LINE" \
-                           COMP_POINT="$COMP_POINT" \
-                           dart_dev completion -- "${COMP_WORDS[@]}" \
-                           2>/dev/null)) || return $?
-    IFS="$si"
-  }
-  complete -F __dart_dev_completion dart_dev
-elif type compdef &>/dev/null; then
-  __dart_dev_completion() {
-    si=$IFS
-    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
-                 COMP_LINE=$BUFFER \
-                 COMP_POINT=0 \
-                 dart_dev completion -- "${words[@]}" \
-                 2>/dev/null)
-    IFS=$si
-  }
-  compdef __dart_dev_completion dart_dev
-elif type compctl &>/dev/null; then
-  __dart_dev_completion() {
-    local cword line point words si
-    read -Ac words
-    read -cn cword
-    let cword-=1
-    read -l line
-    read -ln point
-    si="$IFS"
-    IFS=$'\n' reply=($(COMP_CWORD="$cword" \
-                       COMP_LINE="$line" \
-                       COMP_POINT="$point" \
-                       dart_dev completion -- "${words[@]}" \
-                       2>/dev/null)) || return $?
-    IFS="$si"
-  }
-  compctl -K __dart_dev_completion dart_dev
-fi
-
-###-end-dart_dev-completion-###
-
 ###-begin-ddev-completion-###
 
 if type complete &>/dev/null; then
@@ -102,6 +57,6 @@ fi
 
 ###-end-ddev-completion-###
 
-## Generated 2016-05-04 22:46:09.154755Z
+## Generated 2016-05-17 19:21:47.711257Z
 ## By /Volumes/Workspace/dart_dev/.pub/bin/completion/shell_completion_generator.dart.snapshot
 

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-
+import 'package:completion/completion.dart';
 import 'package:dart_dev/util.dart'
     show
         TaskProcess,
@@ -101,7 +101,7 @@ Future _run(List<String> args) async {
 
   ArgResults env;
   try {
-    env = _parser.parse(args);
+    env = tryArgsCompletion(args, _parser);
   } on FormatException catch (e) {
     reporter.error('${e.message}\n', shout: true);
     reporter.log(_generateUsage(), shout: true);

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -30,6 +30,7 @@ import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
 
 import 'package:dart_dev/src/tasks/analyze/cli.dart';
+import 'package:dart_dev/src/tasks/bash_completion/cli.dart';
 import 'package:dart_dev/src/tasks/copy_license/cli.dart';
 import 'package:dart_dev/src/tasks/coverage/cli.dart';
 import 'package:dart_dev/src/tasks/docs/cli.dart';
@@ -55,6 +56,7 @@ String _topLevelUsage = _parser.usage;
 
 dev(List<String> args) async {
   registerTask(new AnalyzeCli(), config.analyze);
+  registerTask(new BashCompletionCli(), config.bashCompletion);
   registerTask(new CopyLicenseCli(), config.copyLicense);
   registerTask(new CoverageCli(), config.coverage);
   registerTask(new DocsCli(), config.docs);

--- a/lib/src/tasks/bash_completion/api.dart
+++ b/lib/src/tasks/bash_completion/api.dart
@@ -1,0 +1,43 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:resource/resource.dart' as resource;
+
+import 'package:dart_dev/src/tasks/task.dart';
+
+BashCompletionTask bashCompletion() {
+  Completer done = new Completer();
+  BashCompletionTask task = new BashCompletionTask(done.future);
+
+  var script = new resource.Resource('package:dart_dev/bash-completion.sh');
+  script.readAsString(encoding: UTF8).then((content) {
+    task
+      ..completionScript = content
+      ..successful = true;
+    done.complete();
+  }).catchError((error) {
+    done.complete();
+  });
+
+  return task;
+}
+
+class BashCompletionTask extends Task {
+  final Future done;
+  String completionScript;
+  BashCompletionTask(Future this.done);
+}

--- a/lib/src/tasks/bash_completion/cli.dart
+++ b/lib/src/tasks/bash_completion/cli.dart
@@ -1,0 +1,41 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+
+import 'package:args/args.dart';
+
+import 'package:dart_dev/src/tasks/bash_completion/api.dart';
+import 'package:dart_dev/src/tasks/cli.dart';
+import 'package:dart_dev/util.dart' show reporter;
+
+class BashCompletionCli extends TaskCli {
+  final ArgParser argParser = new ArgParser();
+
+  final String command = 'bash-completion';
+
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
+    // This is kind of a hack to suppress output coloring, which messes us up since
+    // we're outputting shell code (the control sequences are syntax errors).
+    reporter.color = false;
+
+    BashCompletionTask task = bashCompletion();
+    await task.done;
+    if (task.successful) {
+      return new CliResult.success(task.completionScript);
+    } else {
+      return new CliResult.fail('No completion script found.');
+    }
+  }
+}

--- a/lib/src/tasks/bash_completion/config.dart
+++ b/lib/src/tasks/bash_completion/config.dart
@@ -1,0 +1,17 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:dart_dev/src/tasks/config.dart';
+
+class BashCompletionConfig extends TaskConfig {}

--- a/lib/src/tasks/config.dart
+++ b/lib/src/tasks/config.dart
@@ -15,6 +15,7 @@
 library dart_dev.src.tasks.config;
 
 import 'package:dart_dev/src/tasks/analyze/config.dart';
+import 'package:dart_dev/src/tasks/bash_completion/config.dart';
 import 'package:dart_dev/src/tasks/copy_license/config.dart';
 import 'package:dart_dev/src/tasks/coverage/config.dart';
 import 'package:dart_dev/src/tasks/docs/config.dart';
@@ -27,6 +28,7 @@ Config config = new Config();
 
 class Config {
   AnalyzeConfig analyze = new AnalyzeConfig();
+  BashCompletionConfig bashCompletion = new BashCompletionConfig();
   CopyLicenseConfig copyLicense = new CopyLicenseConfig();
   CoverageConfig coverage = new CoverageConfig();
   DocsConfig docs = new DocsConfig();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   dart_style: ">=0.1.8 <0.3.0"
   dartdoc: ">=0.4.0 <0.9.0"
   path: "^1.3.6"
+  resource: "^1.1.0"
   test: "^0.12.0"
   uuid: "^0.5.0"
   yaml: "^2.1.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ homepage: https://github.com/Workiva/dart_dev
 dependencies:
   ansicolor: "^0.0.9"
   args: "^0.13.0"
+  completion: "^0.1.5"
   coverage: "^0.7.3"
   dart_style: ">=0.1.8 <0.3.0"
   dartdoc: ">=0.4.0 <0.9.0"

--- a/tool/ddev-completion.sh
+++ b/tool/ddev-completion.sh
@@ -1,43 +1,62 @@
-_ddev()
-{
-    local cur prev cmds
+#
+# Installation:
+#
+# Via shell config file  ~/.bashrc  (or ~/.zshrc)
+#
+#   Append the contents to config file
+#   'source' the file in the config file
+#
+# You may also have a directory on your system that is configured
+#    for completion files, such as:
+#
+#    /usr/local/etc/bash_completion.d/
+#
 
-    COMPREPLY=()
+###-begin-ddev-completion-###
 
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    cmds="--help --quiet --version --color --no-color analyze copy-license coverage docs examples format init test"
+if type complete &>/dev/null; then
+  __ddev_completion() {
+    local si="$IFS"
+    IFS=$'\n' COMPREPLY=($(COMP_CWORD="$COMP_CWORD" \
+                           COMP_LINE="$COMP_LINE" \
+                           COMP_POINT="$COMP_POINT" \
+                           ddev completion -- "${COMP_WORDS[@]}" \
+                           2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  complete -F __ddev_completion ddev
+elif type compdef &>/dev/null; then
+  __ddev_completion() {
+    si=$IFS
+    compadd -- $(COMP_CWORD=$((CURRENT-1)) \
+                 COMP_LINE=$BUFFER \
+                 COMP_POINT=0 \
+                 ddev completion -- "${words[@]}" \
+                 2>/dev/null)
+    IFS=$si
+  }
+  compdef __ddev_completion ddev
+elif type compctl &>/dev/null; then
+  __ddev_completion() {
+    local cword line point words si
+    read -Ac words
+    read -cn cword
+    let cword-=1
+    read -l line
+    read -ln point
+    si="$IFS"
+    IFS=$'\n' reply=($(COMP_CWORD="$cword" \
+                       COMP_LINE="$line" \
+                       COMP_POINT="$point" \
+                       ddev completion -- "${words[@]}" \
+                       2>/dev/null)) || return $?
+    IFS="$si"
+  }
+  compctl -K __ddev_completion ddev
+fi
 
-    #
-    # Complete subcommand options instead of top-level commands and options.
-    #
+###-end-ddev-completion-###
 
-    if [[ " ${COMP_WORDS[*]} " == *" analyze "* ]]; then
-        cmds="--help --fatal-warnings --no-fatal-warnings --hints --no-hints"
-    fi
-
-    if [[ " ${COMP_WORDS[*]} " == *" coverage "* ]]; then
-        cmds="--help --unit --no-unit --integration --no-integration --html --no-html --open --no-open"
-    fi
-
-    if [[ " ${COMP_WORDS[*]} " == *" docs "* ]]; then
-        cmds="--help --open --no-open"
-    fi
-
-    if [[ " ${COMP_WORDS[*]} " == *" examples "* ]]; then
-        cmds="--help --hostname --port"
-    fi
-
-    if [[ " ${COMP_WORDS[*]} " == *" format "* ]]; then
-        cmds="--help --check --line-length"
-    fi
-
-    if [[ " ${COMP_WORDS[*]} " == *" test "* ]]; then
-        cmds="--help --unit --no-unit --integration --no-integration --concurrency --platform"
-    fi
-
-    COMPREPLY=($(compgen -W "${cmds}" -- ${cur}))  
-    return 0
-}
-complete -F _ddev ddev
+## Generated 2016-05-03 13:57:21.755825Z
+## By /Volumes/Workspace/dart_dev/.pub/bin/completion/shell_completion_generator.dart.snapshot
 

--- a/tool/generate_completions.sh
+++ b/tool/generate_completions.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-pub run completion:shell_completion_generator ddev > tool/ddev-completion.sh
+pub run completion:shell_completion_generator ddev dart_dev > lib/bash-completion.sh

--- a/tool/generate_completions.sh
+++ b/tool/generate_completions.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+
+set -e
+
+pub run completion:shell_completion_generator ddev > tool/ddev-completion.sh

--- a/tool/generate_completions.sh
+++ b/tool/generate_completions.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-pub run completion:shell_completion_generator ddev dart_dev > lib/bash-completion.sh
+pub run completion:shell_completion_generator ddev > lib/bash-completion.sh

--- a/tool/generate_completions.sh
+++ b/tool/generate_completions.sh
@@ -2,9 +2,7 @@
 
 set -e
 
-# We support completions for two forms of the command. First
-# is `dart_dev`, which is the global version. Second is `ddev`
-# which, if configured according to the README, will only work
-# within a Dart project directory.
+# We only support completions when the command is run through
+# the `ddev` alias detailed in the README.
 
-pub run completion:shell_completion_generator dart_dev ddev> lib/bash-completion.sh
+pub run completion:shell_completion_generator ddev> lib/bash-completion.sh

--- a/tool/generate_completions.sh
+++ b/tool/generate_completions.sh
@@ -2,4 +2,9 @@
 
 set -e
 
-pub run completion:shell_completion_generator ddev > lib/bash-completion.sh
+# We support completions for two forms of the command. First
+# is `dart_dev`, which is the global version. Second is `ddev`
+# which, if configured according to the README, will only work
+# within a Dart project directory.
+
+pub run completion:shell_completion_generator dart_dev ddev> lib/bash-completion.sh


### PR DESCRIPTION
This addresses #103. I've added basic support for generating the completion file using completions.dart.

See the README for information on how to consume the new completions.

The script even works with custom project-specific tasks because it operates by adding a pseudo command to ddev that effectively introspects its current configuration. This means the script won't actually need updating all that often. In the future we may not even need to store the script, we may just generate it on the fly from completions.dart.

## Code Review / +10

Follow the instructions in the README to get it working. Then make sure it works.

Install globally using `pub global activate -s /path/to/clone` instead of the command in the README since that would just install the release version. Of particular use would be testing in zsh since I don't use it.

The completions only work within a project, see the readme for how to set up the `ddev` alias, which is required. Link this branch into a random Dart project, pub upgrade, and then you should have completions when you do `ddev <tab> <tab> <tab>...`.

## Review:

@evanweible-wf 
@maxwellpeterson-wf 
@jayudey-wf 