### PR TITLE
Fix Firefox test failures in Sauce Labs due to window not being active

### DIFF
--- a/lib/src/tasks/saucelabs_tests/sauce_unit_test_driver.dart
+++ b/lib/src/tasks/saucelabs_tests/sauce_unit_test_driver.dart
@@ -6,7 +6,7 @@ import 'dart:io';
 
 import 'package:dart_dev/util.dart';
 import 'package:webdriver/io.dart'
-    show BrowserPlatform, Capabilities, WebDriver, createDriver;
+    show By, Capabilities, WebDriver, createDriver;
 
 import './platforms.dart';
 import 'sauce_runner.dart';
@@ -156,6 +156,18 @@ class SauceUnitTestDriver {
             ProcessSignal.SIGTERM.watch().take(1).listen((_) => _quitDriver()))
         ..add(
             ProcessSignal.SIGINT.watch().take(1).listen((_) => _quitDriver()));
+
+      // If the browser window is not active, focus events won't be dispatched in Firefox as expected.
+      //
+      // So, before running any tests, we'll ensure the browser window is active by clicking on the page with WebDriver.
+      //
+      // 1. Load `about:blank` to ensure that clicking on the page does nothing.
+      // 2. Move the cursor over a valid element so that the WebDriver doesn't break itself trying to click on nothing.
+      // 3. Click.
+      await _driver.get('about:blank'); // [1]
+      await _driver.mouse.moveTo(
+          element: await _driver.findElement(const By.tagName('body'))); // [2]
+      await _driver.mouse.click(); // [3]
 
       await _driver.get(testUrl);
 


### PR DESCRIPTION
## Ultimate Problem
For some reason, Sauce Labs no longer activates the Firefox window when running tests. In Firefox, if the window isn't active, focus events won't be fired (see <https://bugzilla.mozilla.org/show_bug.cgi?id=566671>).

This causes focus-related unit tests to fail in Firefox for Sauce Labs builds.

## Solution
_Focusing the iframe, its window and then its body via JS doesn't work._

_Focusing/blurring all kinds of other elements via JS doesn't work._

_Setting the iframe as the active frame in the WebDriver doesn't work._

What does work? Having the WebDriver click the page before it loads our tests, which has the side effect of activating the browser window.

## Testing
Verify that focus-related tests pass. (see https://github.com/Workiva/web_skin_dart/pull/391)

## Areas of Regression
Sauce Labs builds.

---

FYA: @jayudey-wf 
FYI: @joelleibow-wf @jacehensley-wf @clairesarsam-wf @aaronlademann-wf 