### PR TITLE
CP-1768 Allow a provided pub serve port

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,6 @@ object.
     </tbody>
 </table>
 * Individual test files can be executed by appending their path to the end of the command.
-
 ```
 ddev test path/to/test_name path/to/another/test_name
 ```
@@ -494,6 +493,11 @@ ddev test path/to/test_name path/to/another/test_name
 ddev test -n 'run only this test'
 ```
 
+* A new `pub serve` instance is created for every test run. To use a specific `pub serve` instance, pass `--pub-serve-port` to the CLI.
+```
+$ pub serve --port 56001 test
+$ ddev test --pub-serve-port 56001
+```
 
 ## CLI Usage
 This package comes with a single executable: `dart_dev`. To run this executable:

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ ddev test -n 'run only this test'
 * A new `pub serve` instance is created for every test run. To use a specific `pub serve` instance, pass `--pub-serve-port` to the CLI.
 ```
 $ pub serve --port 56001 test
-$ ddev test --pub-serve-port 56001
+$ ddev test --pub-serve --pub-serve-port 56001
 ```
 
 ## CLI Usage

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -15,11 +15,10 @@
 library dart_dev.src.tasks.test.cli;
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter;
+import 'package:dart_dev/util.dart' show reporter, isPortBound;
 
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -208,21 +207,5 @@ class TestCli extends TaskCli {
     return task.successful
         ? new CliResult.success(task.testSummary)
         : new CliResult.fail(task.testSummary);
-  }
-
-  Future<bool> isPortBound(int port) async {
-    if (port == 0) {
-      return false;
-    }
-
-    ServerSocket socket;
-    try {
-      socket = await ServerSocket.bind('localhost', port);
-      return false;
-    } on SocketException {
-      return true;
-    } finally {
-      await socket?.close();
-    }
   }
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -71,6 +71,22 @@ Future<int> getOpenPort() async {
   }
 }
 
+Future<bool> isPortBound(int port) async {
+  if (port == 0) {
+    return false;
+  }
+
+  ServerSocket socket;
+  try {
+    socket = await ServerSocket.bind('localhost', port);
+    return false;
+  } on SocketException {
+    return true;
+  } finally {
+    await socket?.close();
+  }
+}
+
 String parseExecutableFromCommand(String command) {
   return command.split(' ').first;
 }

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -23,5 +23,6 @@ export 'package:dart_dev/src/util.dart'
     show
         copyDirectory,
         getOpenPort,
+        isPortBound,
         parseArgsFromCommand,
         parseExecutableFromCommand;

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -56,8 +56,6 @@ Future<int> runTests(String projectPath,
         'pub', ['serve', '--port=$pubServePort', 'test'],
         workingDirectory: '$projectPath');
 
-    args.add('--pub-serve-started');
-
     // A port of 0 is ignored to validate a failure scenario for no port + pub-serve-started flag
     if (pubServePort > 0) {
       args.add('--pub-serve-port=$pubServePort');
@@ -154,11 +152,6 @@ void main() {
     test('should run tests that provides a Pub server', () async {
       expect(await runTests(projectThatNeedsPubServe, runCustomPubServe: true),
           equals(1));
-    });
-
-    test('should warn if "pub-serve-started" argument passed without port', () async {
-      expect(runTests(projectWithoutTestPackage, runCustomPubServe: true, pubServePort: 0),
-          throwsA(new isInstanceOf<TestFailure>()));
     });
 
     test('should run tests with test name specified', () async {

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -35,7 +35,9 @@ Future<int> runTests(String projectPath,
     {bool unit: true,
     bool integration: false,
     List<String> files,
-    String testName: ''}) async {
+    String testName: '',
+    bool runCustomPubServe: false,
+    int pubServePort: 56090}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   List args = ['run', 'dart_dev', 'test', '--no-color'];
@@ -47,8 +49,22 @@ Future<int> runTests(String projectPath,
     args.addAll(['-n', testName]);
   }
 
-  args.addAll(files ?? <String>[]);
+  Process pubServeProcess;
+  if (runCustomPubServe) {
+    // start a default pub server
+    pubServeProcess = await Process.start(
+        'pub', ['serve', '--port=$pubServePort', 'test'],
+        workingDirectory: '$projectPath');
 
+    args.add('--pub-serve-started');
+
+    // A port of 0 is ignored to validate a failure scenario for no port + pub-serve-started flag
+    if (pubServePort > 0) {
+      args.add('--pub-serve-port=$pubServePort');
+    }
+  }
+
+  args.addAll(files ?? <String>[]);
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
 
@@ -56,7 +72,12 @@ Future<int> runTests(String projectPath,
   if ((await process.exitCode) != 0)
     throw new TestFailure('Expected test to pass.');
 
-  var lastLine = await process.stdout.last;
+  String lastLine = await process.stdout.last;
+
+  if (pubServeProcess != null) {
+    pubServeProcess.kill();
+  }
+
   var numTestsRun = -1;
   if (numTestsPassedPattern.hasMatch(lastLine)) {
     numTestsRun =
@@ -128,6 +149,16 @@ void main() {
 
     test('should run tests that require a Pub server', () async {
       expect(await runTests(projectThatNeedsPubServe), equals(1));
+    });
+
+    test('should run tests that provides a Pub server', () async {
+      expect(await runTests(projectThatNeedsPubServe, runCustomPubServe: true),
+          equals(1));
+    });
+
+    test('should warn if "pub-serve-started" argument passed without port', () async {
+      expect(runTests(projectWithoutTestPackage, runCustomPubServe: true, pubServePort: 0),
+          throwsA(new isInstanceOf<TestFailure>()));
     });
 
     test('should run tests with test name specified', () async {


### PR DESCRIPTION
This is WIP as I'm not familiar with the expected code approach. Let me know any changes to better implement this sort of feature. I'm open to cleaning it up.

Problem
--

Running tests with `pub serve` is slow due to starting a new pub server for every run. If the pub serve existed as long as I wanted, the tests could speed up by reusing that same serve instance. In my specific case, the test watcher I use on SOX will start/stop the pub serve for me so it is cleaned up.

Solution
--

Allow a `pub-serve-port` arg on the test CLI so it doesn't start pub serve and only passes the port to the test run.

How to test
--

Verify all tests pass.

References
--

* /cc
 * @evanweible-wf
 * @maxwellpeterson-wf
 * @trentgrover-wf
 * @georgelesica-wf