### PR TITLE
CP-1531 Release dart_dev 1.2.0

### DIFF
--- a/lib/src/tasks/local/cli.dart
+++ b/lib/src/tasks/local/cli.dart
@@ -70,8 +70,8 @@ class LocalCli extends TaskCli {
 
     if (executableParams == null) {
       var failedExecutableLookup =
-          'A executable was not defined for the discovered task '
-          '${executable.name}.\n\nPlease provide a updated local configuration '
+          'An executable was not defined for the discovered task '
+          '${executable.name}.\n\nPlease provide an updated local configuration '
           'which defines what executable to use for the '
           '"${executable.extension}" file extension.';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.1.2
+version: 1.2.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1531

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 



 CP-1604  - Functional Coverage Working For Real I Promise  - https://github.com/Workiva/dart_dev/pull/145

 CP-1329  - Create dart test runner generator, dart_dev  - https://github.com/Workiva/dart_dev/pull/124

 CP-1768  - Allow a provided pub serve port  - https://github.com/Workiva/dart_dev/pull/153

 CP-1754  - Add fish completions  - https://github.com/Workiva/dart_dev/pull/149

 CP-1794  - Add completions.dart support  - https://github.com/Workiva/dart_dev/pull/151

 CP-1811  - Add Local Task Integrations  - https://github.com/Workiva/dart_dev/pull/150

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.1.2...CP-1531_release_1.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.1.2...1.2.0

