### PR TITLE
Correct Grammar in Error Statement

### DIFF
--- a/lib/src/tasks/local/cli.dart
+++ b/lib/src/tasks/local/cli.dart
@@ -70,8 +70,8 @@ class LocalCli extends TaskCli {
 
     if (executableParams == null) {
       var failedExecutableLookup =
-          'A executable was not defined for the discovered task '
-          '${executable.name}.\n\nPlease provide a updated local configuration '
+          'An executable was not defined for the discovered task '
+          '${executable.name}.\n\nPlease provide an updated local configuration '
           'which defines what executable to use for the '
           '"${executable.extension}" file extension.';
 


### PR DESCRIPTION
Problem
--------
The reported error when running a local task includes a grammatical mistake.

Solution
--------

Correctly use *an*.

Howto Test/QA
--------------------

- [ ] Confirm grammar in error statement is correct.

