### PR TITLE
CP-1864 Wait for pub-serve process to complete before test execution

### DIFF
--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -16,6 +16,7 @@
 library dart_dev.test.integration.test_test;
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_dev/util.dart' show TaskProcess;
@@ -55,6 +56,19 @@ Future<int> runTests(String projectPath,
     pubServeProcess = await Process.start(
         'pub', ['serve', '--port=$pubServePort', 'test'],
         workingDirectory: '$projectPath');
+
+    Completer completer = new Completer();
+
+    pubServeProcess.stdout
+        .transform(UTF8.decoder)
+        .transform(new LineSplitter())
+        .listen((var line) {
+      if (line.contains('Build completed successfully')) {
+        completer.complete();
+      }
+    });
+
+    await completer.future;
 
     // A port of 0 is ignored to validate a failure scenario for no port + pub-serve-started flag
     if (pubServePort > 0) {


### PR DESCRIPTION
## Issue
- There was a race condition that existed where https://github.com/Workiva/dart_dev/blob/master/test/integration/test_test.dart#L152 could start executing before the pub serve process could get set up. This was causing test failures.

## Changes
**Source:**
- Waited for pub-serve to complete prior to test execution

**Tests:**
- n/a

## Areas of Regression
- Tests failing

## Testing
- Check out branch locally and verify that tests are still passing, on Travis it appears that for dart 1.16.1 content_shell was not properly installed and is causing failures there (https://travis-ci.org/Workiva/dart_dev/builds/135127265#L872)

## Code Review
@dustinlessard-wf 
@evanweible-wf 
@trentgrover-wf 