### PR TITLE
CP-1816 Release dart_dev 1.3.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.2.0
+version: 1.3.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-1816

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= dart_dev 1.3.0 items =======

 CP-1835  - Dart dev does not allow undefined arguments for any local task.  - https://github.com/Workiva/dart_dev/pull/158

 CP-1864  - Wait for pub-serve process to complete before test execution  - https://github.com/Workiva/dart_dev/pull/161

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.2.0...CP-1816_release_1.3.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.2.0...1.3.0

