### PR TITLE
REF-956: Add --check option to gen-test-runner task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .pub
 packages
 pubspec.lock
+build/
 
 # generated docs
 /doc/api/
@@ -10,11 +11,15 @@ pubspec.lock
 /coverage/
 
 # generated assets in test fixtures
+/test_fixtures/copy_license/license_with_empty_lines_temp/
+/test_fixtures/copy_license/no_licenses_temp/
 /test_fixtures/coverage/browser/coverage/
-/test_fixtures/coverage/functional_test/coverage/
 /test_fixtures/coverage/browser_needs_pub_serve/coverage/
 /test_fixtures/coverage/failing_test/coverage/
 /test_fixtures/coverage/failing_test/test/failing_test.dart.temp.html
+/test_fixtures/coverage/functional_test/coverage/
+/test_fixtures/coverage/functional_test/test/functional/simple_test.dart.temp.html
 /test_fixtures/coverage/non_test_file/coverage/
 /test_fixtures/coverage/vm/coverage/
 /test_fixtures/docs/docs/doc/api/
+/test_fixtures/format/changes_needed_temp/

--- a/README.md
+++ b/README.md
@@ -502,8 +502,18 @@ object.
             <td><code>[TestRunnerConfig()]</code></td>
             <td>The list of runner configurations used to create individual test runners</td>
         </tr>
+        <tr>
+            <td><code>check</code></td>
+            <td><code>bool/code></td>
+            <td><code>false</code></td>
+            <td>If true, will only check to ensure the runner is up-to-date</td>
+        </tr>
     </tbody>
 </table>
+
+**Note:** if you plan to use the `--check` option, be sure to exclude
+the `generated_runner_test.dart` file from formatting. This can be done
+by adding it to the `config.format.exclude` list.
 
 #### Local Config
 All configuration options for the local task discovery are found on the

--- a/lib/src/tasks/gen_test_runner/config.dart
+++ b/lib/src/tasks/gen_test_runner/config.dart
@@ -16,6 +16,7 @@ library dart_dev.src.tasks.gen_test_runner.config;
 
 import 'package:dart_dev/src/tasks/config.dart';
 
+const bool defaultCheck = false;
 const List<String> defaultDartHeaders = const [];
 const List<String> defaultPreTestCommands = const [];
 const String defaultDirectory = 'test/';
@@ -28,6 +29,7 @@ const List<String> defaultHtmlHeaders = const [];
 enum Environment { vm, browser }
 
 class TestRunnerConfig {
+  bool check = defaultCheck;
   List<String> dartHeaders = defaultDartHeaders;
   List<String> preTestCommands = defaultPreTestCommands;
   String directory = defaultDirectory;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: "^0.13.0"
   completion: "^0.1.5"
   coverage: "^0.7.3"
-  dart_style: ">=0.1.8 <0.3.0"
+  dart_style: ">=0.2.4 <0.3.0"
   dartdoc: ">=0.4.0 <0.9.0"
   path: "^1.3.6"
   resource: "^1.1.0"

--- a/test/integration/gen_test_runner_test.dart
+++ b/test/integration/gen_test_runner_test.dart
@@ -22,15 +22,19 @@ import 'package:dart_dev/util.dart' show TaskProcess;
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
-const String defaultConfig = 'test/fixtures/gen_test_runner/default_config';
-const String browserAndVm = 'test/fixtures/gen_test_runner/browser_and_vm';
+const String browserAndVm = 'test_fixtures/gen_test_runner/browser_and_vm';
+const String checkFail = 'test_fixtures/gen_test_runner/check_fail';
+const String checkPass = 'test_fixtures/gen_test_runner/check_pass';
+const String defaultConfig = 'test_fixtures/gen_test_runner/default_config';
 
-Future<Runner> generateTestRunnerDocsFor(String projectPath,
+Future<Runner> generateTestRunner(String projectPath,
     {List<String> additionalArgs: const []}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   var files = [];
   var errors = [];
+  var stderr = '';
+  var stdout = '';
   var args = ['run', 'dart_dev', 'gen-test-runner'];
   if (additionalArgs.isNotEmpty) {
     additionalArgs.forEach((argument) {
@@ -40,9 +44,17 @@ Future<Runner> generateTestRunnerDocsFor(String projectPath,
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
 
+  process.stdout.listen((line) {
+    stdout += line;
+  });
+
+  process.stderr.listen((line) {
+    stderr += line;
+  });
+
   await process.done;
 
-  return new Runner(await process.exitCode, errors, files);
+  return new Runner(await process.exitCode, errors, files, stderr, stdout);
 }
 
 verifyExistenceAndCleanup(String file,
@@ -56,7 +68,7 @@ verifyExistenceAndCleanup(String file,
 void main() {
   group('gen-test-runner task', () {
     test('should work with default config', () async {
-      Runner runner = await generateTestRunnerDocsFor(defaultConfig);
+      Runner runner = await generateTestRunner(defaultConfig);
       expect(runner.exitCode, isZero);
       verifyExistenceAndCleanup(
           path.join(defaultConfig, 'test/generated_runner.dart'),
@@ -67,7 +79,7 @@ void main() {
     });
 
     test('should work with multiple configs', () async {
-      Runner runner = await generateTestRunnerDocsFor(browserAndVm);
+      Runner runner = await generateTestRunner(browserAndVm);
       expect(runner.exitCode, isZero);
       verifyExistenceAndCleanup(
           path.join(browserAndVm, 'test/browser/generated_runner.dart'),
@@ -82,6 +94,27 @@ void main() {
           path.join(browserAndVm, 'test/vm/generated_runner.html'),
           shouldFileExist: false);
     });
+
+    group('--check flag', () {
+      test('should succeed if the runner is up to date', () async {
+        Runner runner =
+            await generateTestRunner(checkPass, additionalArgs: ['--check']);
+        expect(runner.exitCode, isZero);
+        expect(runner.stderr, equals(''));
+        expect(runner.stdout.contains('Generated test runner is up-to-date.'),
+            isTrue);
+      });
+
+      test('should fail if the runner is not up to date', () async {
+        Runner runner =
+            await generateTestRunner(checkFail, additionalArgs: ['--check']);
+        expect(runner.exitCode, isNot(0));
+        expect(
+            runner.stderr.contains('Generated test runner is not up-to-date.'),
+            isTrue);
+        expect(runner.stdout, equals(''));
+      });
+    });
   });
 }
 
@@ -89,5 +122,8 @@ class Runner {
   final int exitCode;
   final List<String> errors;
   final List<String> files;
-  Runner(this.exitCode, this.errors, this.files);
+  final String stderr;
+  final String stdout;
+
+  Runner(this.exitCode, this.errors, this.files, this.stderr, this.stdout);
 }

--- a/test_fixtures/coverage/functional_test/pubspec.yaml
+++ b/test_fixtures/coverage/functional_test/pubspec.yaml
@@ -3,7 +3,7 @@ version: 0.0.0
 dev_dependencies:
   browser: any
   coverage: "^0.7.2"
-  test: '0.12.0'
+  test: '^0.12.0'
   webdriver: '0.10.0-pre.13'
   dart_dev:
     path: ../../..

--- a/test_fixtures/gen_test_runner/browser_and_vm/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/browser_and_vm/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_generator_browser_and_vm
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  test: '^0.12.0'

--- a/test_fixtures/gen_test_runner/browser_and_vm/test/browser/browser_test.dart
+++ b/test_fixtures/gen_test_runner/browser_and_vm/test/browser/browser_test.dart
@@ -1,0 +1,10 @@
+@TestOn('browser')
+library test_generator_browser_and_vm.test.browser.browser_test;
+
+import 'package:test/test.dart';
+
+main() {
+  test('browser test', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/browser_and_vm/test/vm/vm_test.dart
+++ b/test_fixtures/gen_test_runner/browser_and_vm/test/vm/vm_test.dart
@@ -1,0 +1,10 @@
+@TestOn('vm')
+library test_generator_browser_and_vm.test.vm.vm_test;
+
+import 'package:test/test.dart';
+
+main() {
+  test('vm test', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/browser_and_vm/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/browser_and_vm/tool/dev.dart
@@ -1,0 +1,12 @@
+library test_generator_browser_and_vm.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart';
+
+main(List<String> args) async {
+  config.genTestRunner.configs = [
+    new TestRunnerConfig(env: Environment.vm, directory: 'test/vm/'),
+    new TestRunnerConfig(directory: 'test/browser/', genHtml: true),
+  ];
+
+  await dev(args);
+}

--- a/test_fixtures/gen_test_runner/check_fail/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/check_fail/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_generator_check_fail
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  test: '^0.12.0'

--- a/test_fixtures/gen_test_runner/check_fail/test/browser_test.dart
+++ b/test_fixtures/gen_test_runner/check_fail/test/browser_test.dart
@@ -1,0 +1,9 @@
+library test_generator_check_fail.test.browser.brower_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/check_fail/test/generated_runner.dart
+++ b/test_fixtures/gen_test_runner/check_fail/test/generated_runner.dart
@@ -1,0 +1,10 @@
+@TestOn('browser')
+library test.generated_runner;
+
+import './browser_test.dart' as browser_test;
+import 'package:test/test.dart';
+
+void main() {
+  browser_test.main();
+  test_that_should_be_removed.main();
+}

--- a/test_fixtures/gen_test_runner/check_fail/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/check_fail/tool/dev.dart
@@ -1,0 +1,9 @@
+library test_generator_check_fail.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+import 'package:dart_dev/src/tasks/gen_test_runner/config.dart';
+
+main(List<String> args) async {
+
+  await dev(args);
+}

--- a/test_fixtures/gen_test_runner/check_pass/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/check_pass/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_generator_check_pass
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  test: '^0.12.0'

--- a/test_fixtures/gen_test_runner/check_pass/test/browser_test.dart
+++ b/test_fixtures/gen_test_runner/check_pass/test/browser_test.dart
@@ -1,0 +1,9 @@
+library test_generator_check_pass.test.browser.brower_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/check_pass/test/generated_runner.dart
+++ b/test_fixtures/gen_test_runner/check_pass/test/generated_runner.dart
@@ -1,0 +1,9 @@
+@TestOn('browser')
+library test.generated_runner;
+
+import './browser_test.dart' as browser_test;
+import 'package:test/test.dart';
+
+void main() {
+  browser_test.main();
+}

--- a/test_fixtures/gen_test_runner/check_pass/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/check_pass/tool/dev.dart
@@ -1,0 +1,9 @@
+library test_generator_check_pass.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+import 'package:dart_dev/src/tasks/gen_test_runner/config.dart';
+
+main(List<String> args) async {
+
+  await dev(args);
+}

--- a/test_fixtures/gen_test_runner/default_config/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/default_config/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_generator_default_config
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  test: '^0.12.0'

--- a/test_fixtures/gen_test_runner/default_config/test/browser_test.dart
+++ b/test_fixtures/gen_test_runner/default_config/test/browser_test.dart
@@ -1,0 +1,9 @@
+library test_generator_default_config.test.browser.brower_test;
+
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/default_config/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/default_config/tool/dev.dart
@@ -1,0 +1,9 @@
+library test_generator_default_config.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+import 'package:dart_dev/src/tasks/gen_test_runner/config.dart';
+
+main(List<String> args) async {
+
+  await dev(args);
+}


### PR DESCRIPTION
## Problem

We wanted a simple way to fail our build if the test runner hadn't been regenerated.

## Solution

Add a `--check` flag to the `gen-test-runner` task, to be consistent with the `format` task.

## Testing

Link into a Dart project that uses the `gen-test-runner` task and try `ddev gen-test-runner --check`. Then make a change, either add a test file, or just make a random change within the generated test runner itself, and run it again.

## Review

@evanweible-wf 