### PR TITLE
CP-2273 Widen dartdoc version constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   completion: "^0.1.5"
   coverage: "^0.7.3"
   dart_style: ">=0.2.4 <0.3.0"
-  dartdoc: ">=0.4.0 <0.9.0"
+  dartdoc: ">=0.4.0 <0.10.0"
   path: "^1.3.6"
   resource: "^1.1.0"
   test: "^0.12.0"


### PR DESCRIPTION
The only breaking change in the dartdoc 0.9.0 was an updated SDK constraint, so we should be able to safely include 0.9.x.

@evanweible-wf @maxwellpeterson-wf @trentgrover-wf