### PR TITLE
CP-2035 Release dart_dev 1.4.1

### DIFF
--- a/lib/src/tools/selenium.dart
+++ b/lib/src/tools/selenium.dart
@@ -110,8 +110,12 @@ class SeleniumHelper {
             response['result']['isolates'] is List &&
             response['result']['isolates'].isNotEmpty);
       });
-      ws.add(JSON.encode(
-          {'jsonrpc': '2.0', 'method': 'getVM', 'params': {}, 'id': uuid,}));
+      ws.add(JSON.encode({
+        'jsonrpc': '2.0',
+        'method': 'getVM',
+        'params': {},
+        'id': uuid,
+      }));
       return c.future;
     } catch (e) {
       return false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.4.0
+version: 1.4.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
JIRA: https://jira.webfilings.com/browse/CP-2035

Releases that need to go out at the same time (if any): 

JIRA and PR's included in this release: 

======= dart_dev 1.4.1 items =======

 CP-2273  - Widen dartdoc version constraint  - https://github.com/Workiva/dart_dev/pull/166

======= end =======

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.4.0...CP-2035_release_1.4.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.4.0...1.4.1

