### PR TITLE
CP-2388 Fix slash bug

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,4 @@
+analyzer:
+  exclude:
+    - 'test_fixtures'
+    

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -34,7 +34,7 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
   }
 
   File generatedRunner =
-      new File('${currentDirectory}/${currentConfig.filename}.dart');
+      new File('${currentDirectory}${currentConfig.filename}.dart');
 
   String existingContent;
   if (currentConfig.check) {


### PR DESCRIPTION
@theisensanders-wf noted that we were adding an extra slash to the runner path. I figured we might as well fix it. I also added an `.analysis_options` file so I could exclude the test fixtures in Atom.