### PR TITLE
CP-2404 Fix bug when gen-test-runner --check runs on Smithy

### DIFF
--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -50,7 +50,7 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
   Directory testDirectory = new Directory(currentDirectory);
   List<File> testFiles = [];
   List<FileSystemEntity> allFiles =
-      testDirectory.listSync(recursive: true, followLinks: false);
+      testDirectory.listSync(recursive: true, followLinks: false).where((FileSystemEntity entity) => entity is File);
   allFiles.forEach((FileSystemEntity entity) {
     var isTestRunner = entity.path.endsWith('${currentConfig.filename}.dart');
     if (entity is File) {

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -108,21 +108,20 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
 
   task.runnerFile = generatedRunner.path;
 
-  print('New lines:\n${runnerLines.join("\n")}');
-  print('Old lines:\n${existingLines.join("\n")}');
-
   if (currentConfig.check) {
+    task.newLength = runnerLines.length;
+    task.oldLength = existingLines.length;
+
     bool success = true;
     if (existingLines.length != runnerLines.length) {
       success = false;
-      print('New and existing runners have different number of lines.');
     }
     for (int i = 0; i < existingLines.length; i++) {
       if (existingLines[i] != runnerLines[i]) {
         success = false;
-        print('Mismatch starting at line ${i + 1}:');
-        print('New: ${runnerLines[i]}');
-        print('Old: ${existingLines[i]}');
+        task.mismatchedLineNumber = i + 1;
+        task.newMismatchedLine = runnerLines[i];
+        task.oldMismatchedLine = existingLines[i];
         break;
       }
     }
@@ -159,6 +158,11 @@ class GenTestRunnerTask extends Task {
   List<String> excludedFiles = [];
   final String generateCommand;
   List<String> testFiles = [];
+  int newLength;
+  int oldLength;
+  int mismatchedLineNumber;
+  String newMismatchedLine = '';
+  String oldMismatchedLine = '';
   String runnerFile;
 
   GenTestRunnerTask(String this.generateCommand);

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -49,10 +49,15 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
 
   Directory testDirectory = new Directory(currentDirectory);
   List<File> testFiles = [];
-  List<File> allFiles =
-      testDirectory.listSync(recursive: true, followLinks: false).where((FileSystemEntity entity) => entity is File).toList();
+  List<File> allFiles = testDirectory
+      .listSync(recursive: true, followLinks: false)
+      .where((FileSystemEntity entity) => entity is File)
+      .toList();
   allFiles.sort((File left, File right) => left.path.compareTo(right.path));
-  allFiles.where((File entity) => !entity.path.endsWith('${currentConfig.filename}.dart')).forEach((File entity) {
+  allFiles
+      .where((File entity) =>
+          !entity.path.endsWith('${currentConfig.filename}.dart'))
+      .forEach((File entity) {
     if (entity.path.endsWith('_test.dart')) {
       testFiles.add(entity);
       task.testFiles.add(entity.path);

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -36,12 +36,12 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
   File generatedRunner =
       new File('${currentDirectory}/${currentConfig.filename}.dart');
 
-  String existingContent;
+  List<String> existingLines;
   if (currentConfig.check) {
     try {
-      existingContent = generatedRunner.readAsStringSync();
+      existingLines = generatedRunner.readAsStringSync().split('\n');
     } catch (_) {
-      existingContent = '';
+      existingLines = [];
     }
   }
 
@@ -111,7 +111,20 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
   task.runnerFile = generatedRunner.path;
 
   if (currentConfig.check) {
-    task.successful = existingContent == updatedContent;
+    bool success = true;
+    if (existingLines.length != runnerLines.length) {
+      success = false;
+      print('New and existing runners have different number of lines.');
+    }
+    for (int i = 0; i < existingLines.length; i++) {
+      if (existingLines[i] != runnerLines[i]) {
+        success = false;
+        print('New:\n${runnerLines[i]}');
+        print('Existing:\n${existingLines[i]}');
+        break;
+      }
+    }
+    task.successful = success;
   } else {
     generatedRunner.writeAsStringSync(updatedContent);
     task.successful = true;

--- a/lib/src/tasks/gen_test_runner/cli.dart
+++ b/lib/src/tasks/gen_test_runner/cli.dart
@@ -62,7 +62,23 @@ class GenTestRunnerCli extends TaskCli {
 
     if (results.passing.contains(false)) {
       if (check) {
-        return new CliResult.fail('Generated test runner is not up-to-date.');
+        String message = '';
+        for (var task in results.tasks) {
+          if (!task.successful) {
+            if (task.newLength != task.oldLength) {
+              message += 'New and old runners have different length:\n';
+              message += 'New length: ${task.newLength}\n';
+              message += 'Old length: ${task.oldLength}\n';
+            }
+            if (task.mismatchedLineNumber != null) {
+              message += 'Mismatch on line ${task.mismatchedLineNumber}:\n';
+              message += 'New line: ${task.newMismatchedLine}\n';
+              message += 'Old line: ${task.oldMismatchedLine}\n';
+            }
+          }
+        }
+        message += 'Generated test runner is not up-to-date.';
+        return new CliResult.fail(message);
       }
       var failedFiles = '';
       for (var task in results.tasks) {

--- a/lib/src/tools/selenium.dart
+++ b/lib/src/tools/selenium.dart
@@ -110,12 +110,8 @@ class SeleniumHelper {
             response['result']['isolates'] is List &&
             response['result']['isolates'].isNotEmpty);
       });
-      ws.add(JSON.encode({
-        'jsonrpc': '2.0',
-        'method': 'getVM',
-        'params': {},
-        'id': uuid,
-      }));
+      ws.add(JSON.encode(
+          {'jsonrpc': '2.0', 'method': 'getVM', 'params': {}, 'id': uuid,}));
       return c.future;
     } catch (e) {
       return false;

--- a/lib/src/tools/selenium.dart
+++ b/lib/src/tools/selenium.dart
@@ -110,8 +110,12 @@ class SeleniumHelper {
             response['result']['isolates'] is List &&
             response['result']['isolates'].isNotEmpty);
       });
-      ws.add(JSON.encode(
-          {'jsonrpc': '2.0', 'method': 'getVM', 'params': {}, 'id': uuid,}));
+      ws.add(JSON.encode({
+        'jsonrpc': '2.0',
+        'method': 'getVM',
+        'params': {},
+        'id': uuid,
+      }));
       return c.future;
     } catch (e) {
       return false;


### PR DESCRIPTION
It seems that while `gen-test-runner --check` works locally, it fails on Smithy, at least some of the time. I suspect that the directory listing order just isn't stable across platforms. Sorting the test files fixes the problem. I also added some more helpful error output. @evanweible-wf @maxwellpeterson-wf 