### PR TITLE
CP-2383 Release dart_dev 1.4.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.4.1
+version: 1.4.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2388 Fix slash bug](https://github.com/Workiva/dart_dev/pull/168)
* [CP-2404 Fix bug when gen-test-runner --check runs on Smithy](https://github.com/Workiva/dart_dev/pull/169)


Requested by: charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.4.1...version-bump-dart_dev-1-4-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.4.1...1.4.2