### PR TITLE
CP-2661 Release dart_dev 1.5.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.4.2
+version: 1.5.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2272 Implemented task that allows a user to run browser based dart unit tests on saucelabs](https://github.com/Workiva/dart_dev/pull/148)


Requested by: charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.4.2...version-bump-dart_dev-1-5-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.4.2...1.5.0