### PR TITLE
CP-2767 Release dart_dev 1.5.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.5.0
+version: 1.5.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
Pulls Included in Release:
* [CP-2824 Fixes for compatibility with Dart 1.20.x](https://github.com/Workiva/dart_dev/pull/183)
* [CP-2858 Update gen-test-runner task based on feedback](https://github.com/Workiva/dart_dev/pull/184)


Requested by: @charliekump-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.5.0...version-bump-dart_dev-1-5-1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.5.0...1.5.1