### PR TITLE
CP-2275 Adds support for --fatal-lints analyzer flag

### DIFF
--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -27,6 +27,7 @@ AnalyzeTask analyze(
     bool fatalWarnings: defaultFatalWarnings,
     bool hints: defaultHints,
     bool fatalHints: defaultFatalHints,
+    bool fatalLints: defaultFatalLints,
     bool strong: defaultStrong}) {
   var executable = 'dartanalyzer';
   var args = [];
@@ -40,6 +41,9 @@ AnalyzeTask analyze(
   }
   if (strong) {
     args.add('--strong');
+  }
+  if (fatalLints) {
+    args.add('--fatal-lints');
   }
 
   args.addAll(_findFilesFromEntryPoints(entryPoints));

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -40,7 +40,10 @@ class AnalyzeCli extends TaskCli {
     ..addFlag('strong',
         defaultsTo: defaultStrong,
         negatable: true,
-        help: 'Enable strong static checks (https://goo.gl/DqcBsw)');
+        help: 'Enable strong static checks (https://goo.gl/DqcBsw)')
+    ..addFlag('fatal-lints',
+        defaultsTo: defaultFatalLints,
+        help: 'Treat lints as fatal.');
 
   final String command = 'analyze';
 
@@ -52,6 +55,7 @@ class AnalyzeCli extends TaskCli {
     bool fatalHints =
         TaskCli.valueOf('fatal-hints', parsedArgs, config.analyze.fatalHints);
     bool strong = TaskCli.valueOf('strong', parsedArgs, config.analyze.strong);
+    bool fatalLints = TaskCli.valueOf('fatal-lints', parsedArgs, config.analyze.fatalLints);
 
     if (!hints && fatalHints) {
       return new CliResult.fail('You must enable hints to fail on hints.');
@@ -62,9 +66,9 @@ class AnalyzeCli extends TaskCli {
         fatalWarnings: fatalWarnings,
         hints: hints,
         fatalHints: fatalHints,
+        fatalLints: fatalLints,
         strong: strong);
     var title = task.analyzerCommand;
-    if (fatalHints) title += ' (treating hints as fatal)';
 
     reporter.logGroup(title, outputStream: task.analyzerOutput);
     await task.done;

--- a/lib/src/tasks/analyze/cli.dart
+++ b/lib/src/tasks/analyze/cli.dart
@@ -43,6 +43,7 @@ class AnalyzeCli extends TaskCli {
         help: 'Enable strong static checks (https://goo.gl/DqcBsw)')
     ..addFlag('fatal-lints',
         defaultsTo: defaultFatalLints,
+        negatable: true,
         help: 'Treat lints as fatal.');
 
   final String command = 'analyze';
@@ -55,7 +56,8 @@ class AnalyzeCli extends TaskCli {
     bool fatalHints =
         TaskCli.valueOf('fatal-hints', parsedArgs, config.analyze.fatalHints);
     bool strong = TaskCli.valueOf('strong', parsedArgs, config.analyze.strong);
-    bool fatalLints = TaskCli.valueOf('fatal-lints', parsedArgs, config.analyze.fatalLints);
+    bool fatalLints =
+        TaskCli.valueOf('fatal-lints', parsedArgs, config.analyze.fatalLints);
 
     if (!hints && fatalHints) {
       return new CliResult.fail('You must enable hints to fail on hints.');

--- a/lib/src/tasks/analyze/config.dart
+++ b/lib/src/tasks/analyze/config.dart
@@ -21,6 +21,7 @@ const bool defaultFatalWarnings = true;
 const bool defaultHints = true;
 const bool defaultFatalHints = false;
 const bool defaultStrong = false;
+const bool defaultFatalLints = false;
 
 class AnalyzeConfig extends TaskConfig {
   List<String> entryPoints = defaultEntryPoints.toList();
@@ -28,4 +29,5 @@ class AnalyzeConfig extends TaskConfig {
   bool hints = defaultHints;
   bool fatalHints = defaultFatalHints;
   bool strong = defaultStrong;
+  bool fatalLints = defaultFatalLints;
 }

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -129,6 +129,7 @@ void main() {
     test('should not report hints as fatal if none existed', () async {
       Analysis analysis =
           await analyzeProject(projectWithNoIssues, fatalHints: true);
+      expect(analysis.numErrors, equals(0));
       expect(analysis.numHints, equals(0));
       expect(analysis.exitCode, equals(0));
     });
@@ -141,9 +142,10 @@ void main() {
       expect(analysis.exitCode, greaterThan(0));
     });
 
-    test('should not report hints as fatal if none existed', () async {
+    test('should not report lints as fatal if none existed', () async {
       Analysis analysis =
           await analyzeProject(projectWithNoIssues, fatalLints: true);
+      expect(analysis.numErrors, equals(0));
       expect(analysis.numHints, equals(0));
       expect(analysis.exitCode, equals(0));
     });

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -40,8 +40,8 @@ Future<Analysis> analyzeProject(String projectPath,
   args.add(fatalWarnings ? '--fatal-warnings' : '--no-fatal-warnings');
   args.add(hints ? '--hints' : '--no-hints');
   args.add(strong ? '--strong' : '--no-strong');
-  args.add(fatalHints ? '--fatal-hints' : ' --no-fatal-hints');
-  args.add(fatalLints ? '--fatal-lints' : ' --no-fatal-lints');
+  args.add(fatalHints ? '--fatal-hints' : '--no-fatal-hints');
+  args.add(fatalLints ? '--fatal-lints' : '--no-fatal-lints');
 
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -23,6 +23,7 @@ import 'package:test/test.dart';
 
 const String projectWithErrors = 'test_fixtures/analyze/errors';
 const String projectWithHints = 'test_fixtures/analyze/hints';
+const String projectWithLints = 'test_fixtures/analyze/lints';
 const String projectWithNoIssues = 'test_fixtures/analyze/no_issues';
 const String projectWithStaticTypingIssues = 'test_fixtures/analyze/strong';
 const String projectWithWarnings = 'test_fixtures/analyze/warnings';
@@ -31,7 +32,8 @@ Future<Analysis> analyzeProject(String projectPath,
     {bool fatalWarnings: true,
     bool hints: true,
     bool fatalHints: false,
-    bool strong: false}) async {
+    bool strong: false,
+    bool fatalLints: false}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   var args = ['run', 'dart_dev', 'analyze'];
@@ -39,6 +41,7 @@ Future<Analysis> analyzeProject(String projectPath,
   args.add(hints ? '--hints' : '--no-hints');
   args.add(strong ? '--strong' : '--no-strong');
   args.add(fatalHints ? '--fatal-hints' : ' --no-fatal-hints');
+  args.add(fatalLints ? '--fatal-lints' : ' --no-fatal-lints');
 
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
@@ -126,6 +129,21 @@ void main() {
     test('should not report hints as fatal if none existed', () async {
       Analysis analysis =
           await analyzeProject(projectWithNoIssues, fatalHints: true);
+      expect(analysis.numHints, equals(0));
+      expect(analysis.exitCode, equals(0));
+    });
+
+    test('should report lints as fatal if configured to do so', () async {
+      Analysis analysis =
+          await analyzeProject(projectWithLints, fatalLints: true);
+      expect(analysis.numErrors, equals(1));
+      expect(analysis.numHints, equals(0));
+      expect(analysis.exitCode, greaterThan(0));
+    });
+
+    test('should not report hints as fatal if none existed', () async {
+      Analysis analysis =
+          await analyzeProject(projectWithNoIssues, fatalLints: true);
       expect(analysis.numHints, equals(0));
       expect(analysis.exitCode, equals(0));
     });

--- a/test_fixtures/analyze/lints/.analysis_options
+++ b/test_fixtures/analyze/lints/.analysis_options
@@ -1,0 +1,3 @@
+linter:
+  rules:
+    - annotate_overrides

--- a/test_fixtures/analyze/lints/lib/hints.dart
+++ b/test_fixtures/analyze/lints/lib/hints.dart
@@ -1,0 +1,13 @@
+library analyze_hints;
+
+class BaseClass {
+  void doSomeStuff(bool ifTrue) {
+
+  }
+}
+
+class ExtendoClass extends BaseClass {
+  void doSomeStuff(bool ifTrue) {
+    // yuno @override?
+  }
+}

--- a/test_fixtures/analyze/lints/lib/lints.dart
+++ b/test_fixtures/analyze/lints/lib/lints.dart
@@ -1,7 +1,11 @@
-library analyze_hints;
+library analyze_lints;
 
 class BaseClass {
   void doSomeStuff(bool ifTrue) {
+
+  }
+
+  void doSomeOtherStuff() {
 
   }
 }
@@ -9,5 +13,10 @@ class BaseClass {
 class ExtendoClass extends BaseClass {
   void doSomeStuff(bool ifTrue) {
     // yuno @override?
+  }
+
+  @override
+  void doSomeOtherStuff() {
+
   }
 }

--- a/test_fixtures/analyze/lints/pubspec.yaml
+++ b/test_fixtures/analyze/lints/pubspec.yaml
@@ -1,0 +1,5 @@
+name: analyze_lints
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..


### PR DESCRIPTION
Addresses https://github.com/Workiva/dart_dev/issues/164

@evanweible-wf @maxwellpeterson-wf @trentgrover-wf @jayudey-wf 