### PR TITLE
CP-2861 Release dart_dev 1.5.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.5.1
+version: 1.5.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2275 Adds support for --fatal-lints analyzer flag](https://github.com/Workiva/dart_dev/pull/190)
* [CP-2946 Adding smithy.yaml](https://github.com/Workiva/dart_dev/pull/191)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.5.1...version-bump-dart_dev-1-5-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.5.1...1.5.2