### PR TITLE
CP-2990 Fix README dependencies so that users can pull down the latest dart_dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Add the following to your `pubspec.yaml`:
 dev_dependencies:
   coverage: "^0.7.3"
   dart_dev: "^1.0.0"
-  dart_style: ">=0.1.8 <0.3.0"
-  dartdoc: "^0.4.0"
+  dart_style: ">=0.2.0 <0.3.0"
+  dartdoc: ">=0.8.0 <=0.10.0"
   test: "^0.12.0"
 ```
 


### PR DESCRIPTION
## Issue

Following the existing dart_dev documentation, users will not be able to pull down the latest version of dart_dev

## Changes

Tweak the dependencies in the documentation

## Testing

Make a new project with a new `pubspec.yaml`. Add the listed dependencies and run `pub get`. Verify that dart_dev 1.5.2 is pulled down.

## Code Review

@trentgrover-wf
@maxwellpeterson-wf
@evanweible-wf
@dustinlessard-wf
@jayudey-wf 