### PR TITLE
RAP-1367 Add hyphen to local task regex

### DIFF
--- a/lib/src/tasks/local/config.dart
+++ b/lib/src/tasks/local/config.dart
@@ -19,7 +19,7 @@ import 'package:dart_dev/src/tasks/config.dart';
 class LocalConfig extends TaskConfig {
   List<String> taskPaths = ['tool'];
   bool followSymlinks = false;
-  String commandFilePattern = '([a-zA-Z0-9]+)_task.([a-zA-Z0-9]+)';
+  String commandFilePattern = '([a-zA-Z0-9-]+)_task.([a-zA-Z0-9]+)';
   Map<String, List<String>> executables = {
     'dart': ['dart'],
     'sh': ['bash']


### PR DESCRIPTION
[Jira Ticket](https://jira.atl.workiva.net/browse/RAP-1367)

## Problem

It would be nice to be able to name local tasks using the convention followed by the built-in tasks whereby multi-word commands are separated by a hyphen. Right now we only accept alphanumeric names.

## Solution

Add a hyphen to the regex.

## Potential Regressions

None.

## Tests

NA - untested

## QA / +10

1. Checkout the branch.
2. Update dependencies.
3. Unit tests should pass.
4. Pull this branch into the "Home" application (repo: home).
5. Rename the file `tool/tasks/watchsass_task.dart` to `tool/tasks/watch-sass_task.dart`.
6. Run `ddev watch-sass`, this should work.

## FYI

@Workiva/web-platform-pp @Workiva/rich-app-platform-pp 