### PR TITLE
CP-2954 Release dart_dev 1.5.3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.5.2
+version: 1.5.3
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [CP-2990 Fix README dependencies so that users can pull down the latest dart_dev](https://github.com/Workiva/dart_dev/pull/194)
* [RAP-1367 Add hyphen to local task regex](https://github.com/Workiva/dart_dev/pull/196)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.5.2...version-bump-dart_dev-1-5-3
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.5.2...1.5.3