### PR TITLE
CP-3183 Create dart_dev task to allow for tasks to run con-currently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - stable
+  - 1.19.1
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ local tasks.
 - **Applying a License to Source Files:** copies a LICENSE file to all applicable files.
 - **Generate a test runner file:** that allows for faster test execution.
 - **Running dart unit tests on Sauce Labs** compiles dart unit tests that can be run in the browser and executes them on various platforms using Sauce Labs.
-- **Running concurrent dart commands** allows for continuous integration systems to run concurrently rather then serially.
+- **Running concurrent dart commands** allows continuous integration systems to run concurrently rather then serially.
 
 ### Local Tasks
 
@@ -252,7 +252,7 @@ ddev examples
 ddev format
 ddev gen-test-runner
 ddev saucelabs
-ddev task-runner
+ddev run-ci
 ddev test
 
 # without the alias
@@ -264,7 +264,7 @@ pub run dart_dev examples
 pub run dart_dev format
 pub run dart_dev gen-test-runner
 pub run dart_dev saucelabs
-pub run dart_dev task-runner
+pub run dart_dev run-ci
 pub run dart_dev test
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ local tasks.
 - **Serving Examples:** uses [`pub serve`](https://www.dartlang.org/tools/pub/cmd/pub-serve.html) to serve the project examples.
 - **Applying a License to Source Files:** copies a LICENSE file to all applicable files.
 - **Generate a test runner file:** that allows for faster test execution.
-- **Running dart unit tests on Sauce Labs** compiles dart unit tests that can be run in the browser and executes them on various platforms using Sauce Labs.
-- **Running concurrent dart commands** allows continuous integration systems to run concurrently rather then serially.
+- **Running dart unit tests on Sauce Labs:** compiles dart unit tests that can be run in the browser and executes them on various platforms using Sauce Labs.
+- **Running concurrent dart commands:** allows continuous integration systems to run concurrently rather then serially.
 
 ### Local Tasks
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ ddev examples
 ddev format
 ddev gen-test-runner
 ddev saucelabs
-ddev run-ci
+ddev task-runner
 ddev test
 
 # without the alias
@@ -264,7 +264,7 @@ pub run dart_dev examples
 pub run dart_dev format
 pub run dart_dev gen-test-runner
 pub run dart_dev saucelabs
-pub run dart_dev run-ci
+pub run dart_dev task-runner
 pub run dart_dev test
 ```
 

--- a/README.md
+++ b/README.md
@@ -710,7 +710,7 @@ object.
         <tr>
             <td><code>tasksToRun</code></td>
             <td><code>List&lt;String&gt;</code></td>
-            <td><code>['pub run dart_dev format --check','pub run dart_dev analyze']</code></td>
+            <td><code>['pub run dart_dev format --check','pub run dart_dev analyze','pub run dart_dev test']</code></td>
             <td>The list of tasks to run</td>
         </tr>
     </tbody>

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ local tasks.
 - **Applying a License to Source Files:** copies a LICENSE file to all applicable files.
 - **Generate a test runner file:** that allows for faster test execution.
 - **Running dart unit tests on Sauce Labs** compiles dart unit tests that can be run in the browser and executes them on various platforms using Sauce Labs.
+- **Running concurrent dart commands** allows for continuous integration systems to run concurrently rather then serially.
 
 ### Local Tasks
 
@@ -251,6 +252,7 @@ ddev examples
 ddev format
 ddev gen-test-runner
 ddev saucelabs
+ddev task-runner
 ddev test
 
 # without the alias
@@ -262,6 +264,7 @@ pub run dart_dev examples
 pub run dart_dev format
 pub run dart_dev gen-test-runner
 pub run dart_dev saucelabs
+pub run dart_dev task-runner
 pub run dart_dev test
 ```
 
@@ -288,6 +291,7 @@ main(args) async {
   config.genTestRunner
   config.init
   config.saucelabs
+  config.taskRunner
   config.test
 
   await dev(args);
@@ -686,6 +690,31 @@ object.
 * The html files to be transformed should have the `packages/test/dart.js` script tag listed last.
 
 * During this process the test directory will be served which means that the `filesToTest` must be within the test directory and their path will be relative to the test directory.
+
+#### `task-runner` Config
+All configuration options for the `task-runner` task are found on the `config.taskRunnerConfig`
+object.
+
+##### `TaskRunnerConfig`
+
+<table>
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Default</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>tasksToRun</code></td>
+            <td><code>List&lt;String&gt;</code></td>
+            <td><code>['pub run dart_dev format --check','pub run dart_dev analyze']</code></td>
+            <td>The list of tasks to run</td>
+        </tr>
+    </tbody>
+</table>
 
 #### `test` Config
 All configuration options for the `test` task are found on the `config.test`

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -40,6 +40,7 @@ import 'package:dart_dev/src/tasks/gen_test_runner/cli.dart';
 import 'package:dart_dev/src/tasks/init/cli.dart';
 import 'package:dart_dev/src/tasks/local/cli.dart';
 import 'package:dart_dev/src/tasks/saucelabs/cli.dart';
+import 'package:dart_dev/src/tasks/task_runner/cli.dart';
 import 'package:dart_dev/src/tasks/test/cli.dart';
 
 import 'package:dart_dev/src/version.dart' show printVersion;
@@ -68,6 +69,7 @@ dev(List<String> args) async {
   registerTask(new GenTestRunnerCli(), config.genTestRunner);
   registerTask(new InitCli(), config.init);
   registerTask(new SauceRunnerCli(), config.saucelabs);
+  registerTask(new TaskRunnerCli(), config.taskRunner);
   registerTask(new TestCli(), config.test);
 
   try {

--- a/lib/src/tasks/config.dart
+++ b/lib/src/tasks/config.dart
@@ -24,6 +24,7 @@ import 'package:dart_dev/src/tasks/format/config.dart';
 import 'package:dart_dev/src/tasks/gen_test_runner/config.dart';
 import 'package:dart_dev/src/tasks/init/config.dart';
 import 'package:dart_dev/src/tasks/saucelabs/config.dart';
+import 'package:dart_dev/src/tasks/task_runner/config.dart';
 import 'package:dart_dev/src/tasks/test/config.dart';
 import 'package:dart_dev/src/tasks/local/config.dart';
 
@@ -41,6 +42,7 @@ class Config {
   GenTestRunnerConfig genTestRunner = new GenTestRunnerConfig();
   InitConfig init = new InitConfig();
   SaucelabsConfig saucelabs = new SaucelabsConfig();
+  TaskRunnerConfig taskRunner = new TaskRunnerConfig();
   TestConfig test = new TestConfig();
 }
 

--- a/lib/src/tasks/task_runner/api.dart
+++ b/lib/src/tasks/task_runner/api.dart
@@ -1,0 +1,120 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show reporter, TaskProcess;
+
+import 'package:dart_dev/src/tasks/task.dart';
+
+Future<TaskRunner> runTasks({List<String> tasksToRun}) async {
+  var taskGroup = new TaskGroup(tasksToRun);
+  await taskGroup.startTaskGroup();
+  taskGroup.taskGroupOutput();
+
+  TaskRunner task = new TaskRunner(await taskGroup.checkExitCodes(),
+      taskGroup.taskGroupStdout, taskGroup.taskGroupStderr);
+  return task;
+}
+
+class TaskRunner extends Task {
+  final Future done = new Future.value();
+  final String stdout;
+  final String stderr;
+  bool successful;
+
+  TaskRunner(int exitCode, String this.stdout, String this.stderr) {
+    exitCode == 0 ? this.successful = true : this.successful = false;
+  }
+}
+
+class SubTask {
+  /// Process to be executed
+  String command;
+
+  /// A string consisting of all the subtask's output
+  String taskOutput = '';
+
+  /// Any output created in the subtask's stderr
+  String taskError = '';
+
+  TaskProcess taskProcess;
+
+  SubTask(String task) {
+    command = task;
+  }
+
+  /// Starts the provided subtask and wires up a stream to allow
+  /// the TaskGroup to listen for subtask completion.
+  startProcess() {
+    var taskArguments = command.split(' ');
+    taskProcess =
+        new TaskProcess(taskArguments.first, taskArguments.sublist(1));
+    taskProcess.stdout.listen((line) {
+      this.taskOutput += '\n$line';
+    });
+    taskProcess.stderr.listen((line) {
+      this.taskOutput += '\n$line';
+      this.taskError += '\n$line';
+    });
+  }
+}
+
+class TaskGroup {
+  /// List of the individual subtasks executed
+  List<String> subTaskCommands = [];
+
+  /// List of the subtasks making up the TaskGroup
+  List<SubTask> subTasks = [];
+
+  /// TaskGroup stdout
+  String taskGroupStdout = '';
+
+  /// TaskGroup stderr
+  String taskGroupStderr = '';
+
+  TaskGroup(List<String> this.subTaskCommands) {
+    for (String taskCommand in subTaskCommands) {
+      SubTask task = new SubTask(taskCommand);
+      subTasks.add(task);
+    }
+  }
+
+  /// Begin each subtask and wait for completion
+  startTaskGroup() async {
+    List<Future> futures = [];
+    var timer = new Timer.periodic(new Duration(seconds: 30), (_) {
+      reporter.log('Tasks running...');
+    });
+    for (SubTask task in subTasks) {
+      task.startProcess();
+      futures.add(task.taskProcess.exitCode);
+    }
+    await Future.wait(futures);
+    timer.cancel();
+  }
+
+  /// Retrieve output from subtasks
+  taskGroupOutput() {
+    String output = '';
+    for (SubTask task in subTasks) {
+      output += task.taskOutput + '\n';
+    }
+    this.taskGroupStdout = output;
+  }
+
+  /// Determine if subtasks completed successfully
+  Future<int> checkExitCodes() async {
+    for (SubTask task in subTasks) {
+      if (await task.taskProcess.exitCode != 0) {
+        exitCode = 1;
+        this.taskGroupStderr +=
+            'The command, ${task.command}, contained this in the stderr; \n${task.taskError}\n';
+      }
+    }
+    if (exitCode != 0) {
+      this.taskGroupStderr =
+          'One of your subtasks exited with a non-zero exit code. '
+          'See the output below for more information: \n${this.taskGroupStderr}';
+    }
+    return exitCode;
+  }
+}

--- a/lib/src/tasks/task_runner/api.dart
+++ b/lib/src/tasks/task_runner/api.dart
@@ -5,7 +5,7 @@ import 'package:dart_dev/util.dart' show reporter, TaskProcess;
 
 import 'package:dart_dev/src/tasks/task.dart';
 
-Future<TaskRunner> runTasks({List<String> tasksToRun}) async {
+Future<TaskRunner> runTasks(tasksToRun) async {
   var taskGroup = new TaskGroup(tasksToRun);
   await taskGroup.start();
   taskGroup.output();

--- a/lib/src/tasks/task_runner/api.dart
+++ b/lib/src/tasks/task_runner/api.dart
@@ -58,10 +58,10 @@ class SubTask {
 
 class TaskGroup {
   /// List of the individual subtasks executed
-  List<String> subTaskCommands = [];
+  List<String> subTaskCommands = <String>[];
 
   /// List of the subtasks making up the TaskGroup
-  List<SubTask> subTasks = [];
+  List<SubTask> subTasks = <SubTask>[];
 
   /// TaskGroup stdout
   String taskGroupStdout = '';
@@ -69,7 +69,7 @@ class TaskGroup {
   /// TaskGroup stderr
   String taskGroupStderr = '';
 
-  TaskGroup(List<String> this.subTaskCommands) {
+  TaskGroup(this.subTaskCommands) {
     for (String taskCommand in subTaskCommands) {
       SubTask task = new SubTask(taskCommand);
       subTasks.add(task);
@@ -77,8 +77,8 @@ class TaskGroup {
   }
 
   /// Begin each subtask and wait for completion
-  start() async {
-    List<Future> futures = [];
+  Future start() async {
+    List<Future> futures = <Future>[];
     var timer = new Timer.periodic(new Duration(seconds: 30), (_) {
       reporter.log('Tasks running...');
     });
@@ -91,7 +91,7 @@ class TaskGroup {
   }
 
   /// Retrieve output from subtasks
-  output() {
+  void output() {
     String output = '';
     for (SubTask task in subTasks) {
       output += task.taskOutput + '\n';

--- a/lib/src/tasks/task_runner/api.dart
+++ b/lib/src/tasks/task_runner/api.dart
@@ -7,8 +7,8 @@ import 'package:dart_dev/src/tasks/task.dart';
 
 Future<TaskRunner> runTasks({List<String> tasksToRun}) async {
   var taskGroup = new TaskGroup(tasksToRun);
-  await taskGroup.startTaskGroup();
-  taskGroup.taskGroupOutput();
+  await taskGroup.start();
+  taskGroup.output();
 
   TaskRunner task = new TaskRunner(await taskGroup.checkExitCodes(),
       taskGroup.taskGroupStdout, taskGroup.taskGroupStderr);
@@ -22,7 +22,7 @@ class TaskRunner extends Task {
   bool successful;
 
   TaskRunner(int exitCode, String this.stdout, String this.stderr) {
-    exitCode == 0 ? this.successful = true : this.successful = false;
+    this.successful = exitCode == 0;
   }
 }
 
@@ -79,7 +79,7 @@ class TaskGroup {
   }
 
   /// Begin each subtask and wait for completion
-  startTaskGroup() async {
+  start() async {
     List<Future> futures = [];
     var timer = new Timer.periodic(new Duration(seconds: 30), (_) {
       reporter.log('Tasks running...');
@@ -93,7 +93,7 @@ class TaskGroup {
   }
 
   /// Retrieve output from subtasks
-  taskGroupOutput() {
+  output() {
     String output = '';
     for (SubTask task in subTasks) {
       output += task.taskOutput + '\n';

--- a/lib/src/tasks/task_runner/api.dart
+++ b/lib/src/tasks/task_runner/api.dart
@@ -28,7 +28,7 @@ class TaskRunner extends Task {
 
 class SubTask {
   /// Process to be executed
-  String command;
+  final String command;
 
   /// A string consisting of all the subtask's output
   String taskOutput = '';
@@ -38,9 +38,7 @@ class SubTask {
 
   TaskProcess taskProcess;
 
-  SubTask(String task) {
-    command = task;
-  }
+  SubTask(this.command);
 
   /// Starts the provided subtask and wires up a stream to allow
   /// the TaskGroup to listen for subtask completion.

--- a/lib/src/tasks/task_runner/cli.dart
+++ b/lib/src/tasks/task_runner/cli.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+
+import 'package:args/args.dart';
+
+import 'package:dart_dev/util.dart' show reporter;
+
+import 'package:dart_dev/src/tasks/task_runner/api.dart';
+import 'package:dart_dev/src/tasks/cli.dart';
+import 'package:dart_dev/src/tasks/config.dart';
+
+class TaskRunnerCli extends TaskCli {
+  final ArgParser argParser = new ArgParser()
+    ..addOption('config',
+        help:
+            'Configuration options should be performed in local dev.dart file');
+
+  final String command = 'task-runner';
+
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
+    List<String> tasksToRun = config.taskRunner.tasksToRun;
+
+    if (tasksToRun.isEmpty) {
+      return new CliResult.fail(
+          'There are no currently defined tasks in your dev.dart file.');
+    }
+
+    TaskRunner task = await runTasks(tasksToRun: tasksToRun);
+
+    reporter.logGroup('Tasks run: \'${tasksToRun.join('\', \'')}\'',
+        output: task.stdout);
+    if (!task.successful) {
+      reporter.logGroup('Failure output:', error: task.stderr);
+    }
+
+    return task.successful
+        ? new CliResult.success('Tasks completed successfuly.')
+        : new CliResult.fail('Some task / tasks failed.');
+  }
+}

--- a/lib/src/tasks/task_runner/cli.dart
+++ b/lib/src/tasks/task_runner/cli.dart
@@ -24,7 +24,7 @@ class TaskRunnerCli extends TaskCli {
           'There are no currently defined tasks in your dev.dart file.');
     }
 
-    TaskRunner task = await runTasks(tasksToRun: tasksToRun);
+    TaskRunner task = await runTasks(tasksToRun);
 
     reporter.logGroup('Tasks run: \'${tasksToRun.join('\', \'')}\'',
         output: task.stdout);

--- a/lib/src/tasks/task_runner/config.dart
+++ b/lib/src/tasks/task_runner/config.dart
@@ -1,0 +1,10 @@
+import 'package:dart_dev/src/tasks/config.dart';
+
+const List<String> defaultTasks = const [
+  'pub run dart_dev format --check',
+  'pub run dart_dev analyze'
+];
+
+class TaskRunnerConfig extends TaskConfig {
+  List<String> tasksToRun = defaultTasks;
+}

--- a/lib/src/tasks/task_runner/config.dart
+++ b/lib/src/tasks/task_runner/config.dart
@@ -2,7 +2,8 @@ import 'package:dart_dev/src/tasks/config.dart';
 
 const List<String> defaultTasks = const [
   'pub run dart_dev format --check',
-  'pub run dart_dev analyze'
+  'pub run dart_dev analyze',
+  'pub run dart_dev test'
 ];
 
 class TaskRunnerConfig extends TaskConfig {

--- a/test/integration/generated_runner.dart
+++ b/test/integration/generated_runner.dart
@@ -12,6 +12,7 @@ import './format_test.dart' as format_test;
 import './gen_test_runner_test.dart' as gen_test_runner_test;
 import './init_test.dart' as init_test;
 import './local_test.dart' as local_test;
+import './task_runner_test.dart' as task_runner_test;
 import './test_test.dart' as test_test;
 import 'package:test/test.dart';
 
@@ -25,5 +26,6 @@ void main() {
   gen_test_runner_test.main();
   init_test.main();
   local_test.main();
+  task_runner_test.main();
   test_test.main();
 }

--- a/test/integration/task_runner_test.dart
+++ b/test/integration/task_runner_test.dart
@@ -33,8 +33,8 @@ Future<TasksRun> runTasks(String projectPath) async {
   var args = ['run', 'dart_dev', 'task-runner'];
   TaskProcess process =
       new TaskProcess('pub', args, workingDirectory: projectPath);
-  List<String> failedTasks = [];
-  List<String> successfulTasks = [];
+  List<String> failedTasks = <String>[];
+  List<String> successfulTasks = <String>[];
 
   process.stdout.listen((line) {
     if (line.contains(successfulFormatting)) {

--- a/test/integration/task_runner_test.dart
+++ b/test/integration/task_runner_test.dart
@@ -25,6 +25,7 @@ const String projectFailingTasks = 'test_fixtures/task_runner/failing_tasks';
 const String failedFormatting = 'The Dart formatter needs to be run.';
 const String successfulFormatting = 'Your Dart code is good to go!';
 const String successfulAnalysis = 'Analysis completed.';
+const String successfulTesting = 'All tests passed!';
 
 /// Runs the task-runner task via dart_dev on a given project.
 Future<TasksRun> runTasks(String projectPath) async {
@@ -44,6 +45,9 @@ Future<TasksRun> runTasks(String projectPath) async {
     }
     if (line.contains(failedFormatting)) {
       failedTasks.add(failedFormatting);
+    }
+    if (line.contains(successfulTesting)) {
+      successfulTasks.add(successfulTesting);
     }
   });
 
@@ -66,6 +70,7 @@ void main() {
       expect(tasks.exitCode, isZero);
       expect(tasks.successfulTasks.contains(successfulAnalysis), isTrue);
       expect(tasks.successfulTasks.contains(successfulFormatting), isTrue);
+      expect(tasks.successfulTasks.contains(successfulTesting), isTrue);
     });
 
     test('a task failed', () async {
@@ -74,6 +79,7 @@ void main() {
       expect(tasks.successfulTasks.contains(successfulAnalysis), isTrue);
       expect(tasks.successfulTasks.contains(successfulFormatting), isFalse);
       expect(tasks.failedTasks.contains(failedFormatting), isTrue);
+      expect(tasks.successfulTasks.contains(successfulTesting), isTrue);
     });
   });
 }

--- a/test/integration/task_runner_test.dart
+++ b/test/integration/task_runner_test.dart
@@ -1,0 +1,79 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@TestOn('vm')
+import 'dart:async';
+import 'dart:io';
+
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:test/test.dart';
+
+const String projectPassingTasks = 'test_fixtures/task_runner/passing_tasks';
+const String projectFailingTasks = 'test_fixtures/task_runner/failing_tasks';
+
+const String failedFormatting = 'The Dart formatter needs to be run.';
+const String successfulFormatting = 'Your Dart code is good to go!';
+const String successfulAnalysis = 'Analysis completed.';
+
+/// Runs the task-runner task via dart_dev on a given project.
+Future<TasksRun> runTasks(String projectPath) async {
+  await Process.run('pub', ['get'], workingDirectory: projectPath);
+  var args = ['run', 'dart_dev', 'task-runner'];
+  TaskProcess process =
+      new TaskProcess('pub', args, workingDirectory: projectPath);
+  List<String> failedTasks = [];
+  List<String> successfulTasks = [];
+
+  process.stdout.listen((line) {
+    if (line.contains(successfulFormatting)) {
+      successfulTasks.add(successfulFormatting);
+    }
+    if (line.contains(successfulAnalysis)) {
+      successfulTasks.add(successfulAnalysis);
+    }
+    if (line.contains(failedFormatting)) {
+      failedTasks.add(failedFormatting);
+    }
+  });
+
+  await process.done;
+
+  return new TasksRun(await process.exitCode, successfulTasks, failedTasks);
+}
+
+class TasksRun {
+  final int exitCode;
+  final List<String> successfulTasks;
+  final List<String> failedTasks;
+  TasksRun(this.exitCode, this.successfulTasks, this.failedTasks);
+}
+
+void main() {
+  group('Task Runner,', () {
+    test('tasks completed successfully', () async {
+      TasksRun tasks = await runTasks(projectPassingTasks);
+      expect(tasks.exitCode, isZero);
+      expect(tasks.successfulTasks.contains(successfulAnalysis), isTrue);
+      expect(tasks.successfulTasks.contains(successfulFormatting), isTrue);
+    });
+
+    test('a task failed', () async {
+      TasksRun tasks = await runTasks(projectFailingTasks);
+      expect(tasks.exitCode, isNonZero);
+      expect(tasks.successfulTasks.contains(successfulAnalysis), isTrue);
+      expect(tasks.successfulTasks.contains(successfulFormatting), isFalse);
+      expect(tasks.failedTasks.contains(failedFormatting), isTrue);
+    });
+  });
+}

--- a/test_fixtures/task_runner/failing_tasks/lib/main.dart
+++ b/test_fixtures/task_runner/failing_tasks/lib/main.dart
@@ -1,0 +1,15 @@
+List longList = [
+  'one',
+  'two',
+  'three', 'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten'
+];
+
+void doStuff(content) {
+  print(content);
+}

--- a/test_fixtures/task_runner/failing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/failing_tasks/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  test: "^0.12.0"

--- a/test_fixtures/task_runner/failing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/failing_tasks/pubspec.yaml
@@ -1,0 +1,6 @@
+name: task_runner_failing
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  dart_style: ">=0.1.8 <0.3.0"

--- a/test_fixtures/task_runner/failing_tasks/test/simple_test.dart
+++ b/test_fixtures/task_runner/failing_tasks/test/simple_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/task_runner/failing_tasks/tool/dev.dart
+++ b/test_fixtures/task_runner/failing_tasks/tool/dev.dart
@@ -1,0 +1,7 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  await dev(args);
+}

--- a/test_fixtures/task_runner/passing_tasks/lib/main.dart
+++ b/test_fixtures/task_runner/passing_tasks/lib/main.dart
@@ -1,0 +1,16 @@
+List longList = [
+  'one',
+  'two',
+  'three',
+  'four',
+  'five',
+  'six',
+  'seven',
+  'eight',
+  'nine',
+  'ten'
+];
+
+void doStuff(content) {
+  print(content);
+}

--- a/test_fixtures/task_runner/passing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/passing_tasks/pubspec.yaml
@@ -1,0 +1,6 @@
+name: task_runner_passing
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  dart_style: ">=0.1.8 <0.3.0"

--- a/test_fixtures/task_runner/passing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/passing_tasks/pubspec.yaml
@@ -4,3 +4,5 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  test: "^0.12.0"
+

--- a/test_fixtures/task_runner/passing_tasks/test/simple_test.dart
+++ b/test_fixtures/task_runner/passing_tasks/test/simple_test.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('passes', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/task_runner/passing_tasks/tool/dev.dart
+++ b/test_fixtures/task_runner/passing_tasks/tool/dev.dart
@@ -1,0 +1,7 @@
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart' show dev, config;
+
+main(List<String> args) async {
+  await dev(args);
+}


### PR DESCRIPTION
## Issue
- There is no way to easily run dart tasks asynchronously.

## Changes
**Source:**
- Created a task to allow for a user to specify dart commands that they wish to run in parallel.

**Tests:**
- added

## Areas of Regression
- n/a (new tasks was added)

## Testing
- passing CI
- install into this branch into a repo and ensure that the tasks complete as expected (I tried doing this on travis CI for dart_dev and I don't think the instance could handle running the tasks)

## Code Review
@Workiva/web-platform-pp 