### PR TITLE
Add additional configuration options to functional coverage / test task

### DIFF
--- a/README.md
+++ b/README.md
@@ -893,8 +893,8 @@ main() async {
   var selenium = new SeleniumHelper(executablePath: 'tool/selenium-server');
 
   config.test
-    ..before = [selenium.start]
-    ..after = [selenium.stop];
+    ..beforeFunctionalTests = [selenium.start]
+    ..afterFunctionalTests = [selenium.stop];
 }
 ```
 

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -24,7 +24,8 @@ import 'package:dart_dev/util.dart'
         TaskProcess,
         parseArgsFromCommand,
         parseExecutableFromCommand,
-        reporter;
+        reporter,
+        runAll;
 
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
@@ -175,10 +176,10 @@ Future _run(List<String> args) async {
   }
 
   TaskConfig config = _cliConfigs[task];
-  await _runAll(config.before);
+  await runAll(config.before);
   CliResult result =
       await _cliTasks[task].run(env.command, color: env['color']);
-  await _runAll(config.after);
+  await runAll(config.after);
 
   reporter.log('');
   if (result.successful) {
@@ -186,19 +187,5 @@ Future _run(List<String> args) async {
   } else {
     reporter.error(result.message, shout: true);
     exitCode = 1;
-  }
-}
-
-Future _runAll(List tasks) async {
-  for (int i = 0; i < tasks.length; i++) {
-    if (tasks[i] is Function) {
-      await tasks[i]();
-    } else if (tasks[i] is String) {
-      TaskProcess process = new TaskProcess(
-          parseExecutableFromCommand(tasks[i]), parseArgsFromCommand(tasks[i]));
-      reporter.logGroup(tasks[i],
-          outputStream: process.stdout, errorStream: process.stderr);
-      await process.done;
-    }
   }
 }

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -24,8 +24,7 @@ import 'package:dart_dev/util.dart'
         TaskProcess,
         parseArgsFromCommand,
         parseExecutableFromCommand,
-        reporter,
-        runAll;
+        reporter;
 
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';
@@ -42,6 +41,7 @@ import 'package:dart_dev/src/tasks/init/cli.dart';
 import 'package:dart_dev/src/tasks/local/cli.dart';
 import 'package:dart_dev/src/tasks/saucelabs/cli.dart';
 import 'package:dart_dev/src/tasks/test/cli.dart';
+import 'package:dart_dev/src/util.dart' show runAll;
 
 import 'package:dart_dev/src/version.dart' show printVersion;
 

--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter, runAll;
+import 'package:dart_dev/util.dart' show reporter;
 
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -28,6 +28,7 @@ import 'package:dart_dev/src/tasks/coverage/api.dart';
 import 'package:dart_dev/src/tasks/coverage/config.dart';
 import 'package:dart_dev/src/tasks/coverage/exceptions.dart';
 import 'package:dart_dev/src/tasks/test/config.dart';
+import 'package:dart_dev/src/util.dart' show runAll;
 
 class CoverageCli extends TaskCli {
   final ArgParser argParser = new ArgParser()

--- a/lib/src/tasks/coverage/cli.dart
+++ b/lib/src/tasks/coverage/cli.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter;
+import 'package:dart_dev/util.dart' show reporter, runAll;
 
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -99,6 +99,10 @@ class CoverageCli extends TaskCli {
       }
     }
 
+    if (functional && config.coverage.beforeFunctionalTests.isNotEmpty) {
+      await runAll(config.coverage.beforeFunctionalTests);
+    }
+
     CoverageResult result;
     try {
       CoverageTask task = CoverageTask.start(tests,
@@ -113,6 +117,10 @@ class CoverageCli extends TaskCli {
       return new CliResult.fail(e.message);
     } catch (e) {
       return new CliResult.fail(e.toString());
+    } finally {
+      if (functional && config.coverage.afterFunctionalTests.isNotEmpty) {
+        await runAll(config.coverage.afterFunctionalTests);
+      }
     }
 
     if (result.successful && html && open) {

--- a/lib/src/tasks/coverage/config.dart
+++ b/lib/src/tasks/coverage/config.dart
@@ -17,11 +17,15 @@ library dart_dev.src.tasks.coverage.config;
 import 'package:dart_dev/src/tasks/config.dart';
 import 'package:dart_dev/src/tasks/test/config.dart';
 
+const List defaultAfterFunctional = const [];
+const List defaultBeforeFunctional = const [];
 const bool defaultHtml = true;
 const String defaultOutput = 'coverage/';
 const List<String> defaultReportOn = const ['lib/'];
 
 class CoverageConfig extends TaskConfig {
+  List afterFunctionalTests = defaultAfterFunctional;
+  List beforeFunctionalTests = defaultBeforeFunctional;
   bool html = defaultHtml;
   String output = defaultOutput;
   bool pubServe = defaultPubServe;

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter, isPortBound, runAll;
+import 'package:dart_dev/util.dart' show reporter, isPortBound;
 
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -26,6 +26,7 @@ import 'package:dart_dev/src/tasks/config.dart';
 import 'package:dart_dev/src/tasks/serve/api.dart';
 import 'package:dart_dev/src/tasks/test/api.dart';
 import 'package:dart_dev/src/tasks/test/config.dart';
+import 'package:dart_dev/src/util.dart' show runAll;
 
 class TestCli extends TaskCli {
   final ArgParser argParser = new ArgParser()

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter, isPortBound;
+import 'package:dart_dev/util.dart' show reporter, isPortBound, runAll;
 
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -201,6 +201,10 @@ class TestCli extends TaskCli {
       additionalArgs.addAll(['-n', '${parsedArgs['name']}']);
     }
 
+    if (functional && config.test.beforeFunctionalTests.isNotEmpty) {
+      await runAll(config.test.beforeFunctionalTests);
+    }
+
     TestTask task = test(
         tests: tests,
         concurrency: concurrency,
@@ -214,6 +218,10 @@ class TestCli extends TaskCli {
       pubServeTask.stop();
       // Wait for the task to finish to flush its output.
       await pubServeTask.done;
+    }
+
+    if (functional && config.test.afterFunctionalTests.isNotEmpty) {
+      await runAll(config.test.after = config.test.afterFunctionalTests);
     }
 
     return task.successful

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -16,6 +16,8 @@ library dart_dev.src.tasks.test.config;
 
 import 'package:dart_dev/src/tasks/config.dart';
 
+const List defaultAfterFunctional = const [];
+const List defaultBeforeFunctional = const [];
 const int defaultConcurrency = 4;
 const bool defaultPauseAfterLoad = false;
 const bool defaultPubServe = false;
@@ -29,6 +31,8 @@ const List<String> defaultFunctionalTests = const [];
 const List<String> defaultPlatforms = const [];
 
 class TestConfig extends TaskConfig {
+  List afterFunctionalTests = defaultAfterFunctional;
+  List beforeFunctionalTests = defaultBeforeFunctional;
   int concurrency = defaultConcurrency;
   List<String> functionalTests = defaultFunctionalTests;
   List<String> integrationTests = defaultIntegrationTests;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:dart_dev/util.dart' show TaskProcess, reporter;
 
 void copyDirectory(Directory source, Directory dest) {
   if (!dest.existsSync()) {
@@ -95,4 +95,18 @@ List<String> parseArgsFromCommand(String command) {
   var parts = command.split(' ');
   if (parts.length <= 1) return [];
   return parts.getRange(1, parts.length).toList();
+}
+
+Future runAll(List tasks) async {
+  for (int i = 0; i < tasks.length; i++) {
+    if (tasks[i] is Function) {
+      await tasks[i]();
+    } else if (tasks[i] is String) {
+      TaskProcess process = new TaskProcess(
+          parseExecutableFromCommand(tasks[i]), parseArgsFromCommand(tasks[i]));
+      reporter.logGroup(tasks[i],
+          outputStream: process.stdout, errorStream: process.stderr);
+      await process.done;
+    }
+  }
 }

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -25,4 +25,5 @@ export 'package:dart_dev/src/util.dart'
         getOpenPort,
         isPortBound,
         parseArgsFromCommand,
-        parseExecutableFromCommand;
+        parseExecutableFromCommand,
+        runAll;

--- a/lib/util.dart
+++ b/lib/util.dart
@@ -25,5 +25,4 @@ export 'package:dart_dev/src/util.dart'
         getOpenPort,
         isPortBound,
         parseArgsFromCommand,
-        parseExecutableFromCommand,
-        runAll;
+        parseExecutableFromCommand;

--- a/test_fixtures/coverage/functional_test/tool/dev.dart
+++ b/test_fixtures/coverage/functional_test/tool/dev.dart
@@ -26,11 +26,11 @@ main(List<String> args) async {
   config.test
     ..unitTests = []
     ..functionalTests = ['test/functional/']
-    ..before = [startSeleniumAndServeWebDir]
-    ..after = [stopSeleniumAndPubServe];
+    ..beforeFunctionalTests = [startSeleniumAndServeWebDir]
+    ..afterFunctionalTests = [stopSeleniumAndPubServe];
   config.coverage
-    ..before = [startSeleniumAndServeWebDir]
-    ..after = [stopSeleniumAndPubServe];
+    ..beforeFunctionalTests = [startSeleniumAndServeWebDir]
+    ..afterFunctionalTests = [stopSeleniumAndPubServe];
 
   await dev(args);
 }


### PR DESCRIPTION
## Issue
- There were issues trying to set up the before and after commands needed for the functional tasks that wouldn't negatively impact other tasks.

## Changes
**Source:**
- Added the ability to specify tasks to be run exclusively before functional tasks.

**Tests:**
- updated

## Areas of Regression
- functional coverage / testing
- before and after commands for other tasks

## Testing
- CI
- install into a project and ensure that newly added (and historical) functionality is working as expected

## Code Review
@Workiva/web-platform-pp 
@joewaters-wf 