### PR TITLE
CP-3325 Release dart_dev 1.7.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.6.0
+version: 1.7.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3183 Create dart_dev task to allow for tasks to run con-currently](https://github.com/Workiva/dart_dev/pull/199)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.6.0...version-bump-dart_dev-1-7-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.6.0...1.7.0