### PR TITLE
HY-4464 - Add onError handlers to Reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 packages
 pubspec.lock
 build/
+.idea/
 
 # generated docs
 /doc/api/

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -66,12 +66,12 @@ class Reporter {
 
       outputStream?.listen((line) {
         log(_indent(line));
-      })?.onError((line){
+      })?.onError((line) {
         warning(_indent(line));
       });
       errorStream?.listen((line) {
         warning(_indent(line));
-      })?.onError((line){
+      })?.onError((line) {
         this.error(_indent(line));
       });
     }

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -66,9 +66,13 @@ class Reporter {
 
       outputStream?.listen((line) {
         log(_indent(line));
+      })?.onError((line){
+        warning(_indent(line));
       });
       errorStream?.listen((line) {
         warning(_indent(line));
+      })?.onError((line){
+        this.error(_indent(line));
       });
     }
   }

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -59,7 +59,13 @@ TestTask test(
   });
 
   stdoutc.stream.listen(task._testOutput.add);
-  process.stderr.listen(task._testOutput.addError);
+  process.stderr.listen((line) async {
+    task._testOutput.addError(line);
+    if (line.contains('No tests match regular expression')) {
+      await SeleniumHelper.killChildrenProcesses();
+      outputProcessed.complete();
+    }
+  });
   process.exitCode.then((code) {
     if (task.successful == null) {
       task.successful = code <= 0;


### PR DESCRIPTION
### Problem
The Reporter logGroup has an outputStream and errorStream.  Many tasks just use the outputStream and add errors on to that stream.  The outputStream does not have an onError handler.  When any errors are added, they cause a useless exception, and the user can't see what actually went wrong.

### Solution
Add onError handlers.

### Testing
- [ ] Run ddev format on a repo that has a file with a syntax error.  You should actually see the problem, and ddev format should not die mid-run because of the error put on the stream.