### PR TITLE
RAP-1618 Skip files in .pub directories when formatting

### DIFF
--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -62,6 +62,8 @@ FormatTask format(
         if (!entity.path.endsWith('.dart')) continue;
         // Skip dependency files.
         if (entity.absolute.path.contains('/packages/')) continue;
+        // Skip contents of .pub directories.
+        if (entity.absolute.path.contains('/.pub/')) continue;
 
         // Skip excluded files.
         bool isExcluded = false;

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -98,5 +98,21 @@ void main() {
       String contentsAfter = file.readAsStringSync();
       expect(contentsBefore, equals(contentsAfter));
     });
+
+    test('should skip files in "packages" when excludes specified', () async {
+      File file = new File('$projectWithExclusions/lib/packages/main.dart');
+      String contentsBefore = file.readAsStringSync();
+      expect(await formatProject(projectWithExclusions), isTrue);
+      String contentsAfter = file.readAsStringSync();
+      expect(contentsBefore, equals(contentsAfter));
+    });
+
+    test('should skip files in ".pub" when excludes specified', () async {
+      File file = new File('$projectWithExclusions/lib/.pub/main.dart');
+      String contentsBefore = file.readAsStringSync();
+      expect(await formatProject(projectWithExclusions), isTrue);
+      String contentsAfter = file.readAsStringSync();
+      expect(contentsBefore, equals(contentsAfter));
+    });
   });
 }

--- a/test_fixtures/format/exclusions/lib/.pub/main.dart
+++ b/test_fixtures/format/exclusions/lib/.pub/main.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}

--- a/test_fixtures/format/exclusions/lib/packages/main.dart
+++ b/test_fixtures/format/exclusions/lib/packages/main.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}


### PR DESCRIPTION
## Problem:
When you specify a set of files to be excluded during formatting dart_dev walks the file structure and identifies each file that should be formatted. Currently it is picking up files in `.pub` folders. `dartfmt` skips those folders, so `ddev format` should too.

## Solution:
Updated the format task to skip folders named `.pub`.

## +10/QA:
- [ ] CI build passes
- [ ] Link dart_dev into a project with `.pub` directories and files excluded from formatting
- [ ] Run `ddev format` on that project
- [ ] Confirm dart files in`.pub` directories are not formatted