### PR TITLE
CP-3445 Release dart_dev 1.7.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.7.1
+version: 1.7.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [CP-3485 Pub serve single instance for coverage](https://github.com/Workiva/dart_dev/pull/212)
* [RAP-1618 Skip files in .pub directories when formatting](https://github.com/Workiva/dart_dev/pull/213)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.7.1...version-bump-dart_dev-1-7-2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.7.1...1.7.2