### PR TITLE
WP-3881 Widen dart_style range to include 1.x

### DIFF
--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -87,8 +87,9 @@ FormatTask format(
   }
 
   TaskProcess process = new TaskProcess(executable, args);
-  FormatTask task = new FormatTask(
-      '$executable ${args.join(' ')}', process.done)..isDryRun = check;
+  FormatTask task =
+      new FormatTask('$executable ${args.join(' ')}', process.done)
+        ..isDryRun = check;
 
   RegExp cwdPattern = new RegExp('Formatting directory (.+):');
   RegExp formattedPattern = new RegExp('Formatted (.+\.dart)');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,28 +10,28 @@ authors:
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/dart_dev
 dependencies:
-  ansicolor: "^0.0.9"
-  args: "^0.13.0"
-  browser: ">=0.10.0 <0.11.0"
-  browser_detect: "^1.0.3"
-  completion: "^0.1.5"
-  coverage: "^0.7.3"
-  dart_style: ">=0.2.4 <0.3.0"
-  dartdoc: "^0.9.0"
-  fluri: "^1.1.1"
-  path: "^1.3.6"
-  rate_limit: "^0.1.0"
-  resource: ">=1.0.0 <3.0.0"
-  sass: "^0.4.2"
-  test: "^0.12.0"
-  uuid: "^0.5.0"
-  webdriver: "^1.0.0"
-  yaml: "^2.1.0"
-  xml: "^2.4.2"
+  ansicolor: ^0.0.9
+  args: ^0.13.0
+  browser: '>=0.10.0 <0.11.0'
+  browser_detect: ^1.0.3
+  completion: ^0.1.5
+  coverage: ^0.7.3
+  dart_style: '>=0.2.4 <2.0.0'
+  dartdoc: ^0.9.0
+  fluri: ^1.1.1
+  path: ^1.3.6
+  rate_limit: ^0.1.0
+  resource: '>=1.0.0 <3.0.0'
+  sass: ^0.4.2
+  test: ^0.12.0
+  uuid: ^0.5.0
+  webdriver: ^1.0.0
+  yaml: ^2.1.0
+  xml: ^2.4.2
 executables:
   dart_dev:
 environment:
-  sdk: ">=1.9.0 <2.0.0"
+  sdk: '>=1.9.0 <2.0.0'
 
 transformers:
   - test/pub_serve:


### PR DESCRIPTION
## Issue

`dart_style` recently jumped to the 1.x line, which our current constraint does not allow. This prevents consumers from upgrading even though our format task is still compatible with the latest.

## Solution

Widen the `dart_style` range to include 1.x

## Testing

- [ ] CI passes
- [ ] Verify that dart_style 1.0.1 was installed

## Code Review
@Workiva/web-platform-pp 