### PR TITLE
WP-4263 Use platform_detect instead of browser_detect

### DIFF
--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -18,13 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:completion/completion.dart';
-import 'package:dart_dev/util.dart'
-    show
-        TaskProcess,
-        parseArgsFromCommand,
-        parseExecutableFromCommand,
-        reporter;
+import 'package:dart_dev/util.dart' show reporter;
 
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';

--- a/lib/src/tasks/saucelabs/cli.dart
+++ b/lib/src/tasks/saucelabs/cli.dart
@@ -19,7 +19,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter, TaskProcess;
+import 'package:dart_dev/util.dart' show reporter;
 
 import 'package:dart_dev/src/tasks/cli.dart';
 import 'package:dart_dev/src/tasks/config.dart';

--- a/lib/src/tasks/saucelabs/sauce_iframe_runner/sauce_iframe_runner.dart
+++ b/lib/src/tasks/saucelabs/sauce_iframe_runner/sauce_iframe_runner.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'dart:html';
 import 'dart:js';
 
-import 'package:browser_detect/browser_detect.dart';
+import 'package:platform_detect/platform_detect.dart';
 import 'package:fluri/fluri.dart';
 import 'package:rate_limit/rate_limit.dart';
 
@@ -170,7 +170,7 @@ String getTestPlatform({bool friendlyName: false}) {
   if (browser.isSafari) {
     return friendlyName ? 'Safari' : 'safari';
   }
-  if (browser.isIe) {
+  if (browser.isInternetExplorer) {
     return friendlyName ? 'Internet Explorer' : 'ie';
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,13 +13,13 @@ dependencies:
   ansicolor: ^0.0.9
   args: ^0.13.0
   browser: '>=0.10.0 <0.11.0'
-  browser_detect: ^1.0.3
   completion: ^0.1.5
   coverage: ^0.7.3
   dart_style: '>=0.2.4 <2.0.0'
   dartdoc: ^0.9.0
   fluri: ^1.1.1
   path: ^1.3.6
+  platform_detect: ^1.3.2
   rate_limit: ^0.1.0
   resource: '>=1.0.0 <3.0.0'
   sass: ^0.4.2


### PR DESCRIPTION
### Issue
`platform_detect` is strong-mode compliant while `browser_detect` is not.
`platform_detect` intends to replace `browser_detect`.

### Changes
- Use `platform_detect` instead of `browser_detect`.
- Remove some unused imports.

### Testing
- CI Passes

### Code Review
@Workiva/web-platform-pp