### PR TITLE
WP-4208 Release dart_dev 1.7.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.7.4
+version: 1.7.5
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4263 Use platform_detect instead of browser_detect](https://github.com/Workiva/dart_dev/pull/221)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.7.4...version-bump-dart_dev-1-7-5
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.7.4...1.7.5