### PR TITLE
WP-4339 Release dart_dev 1.7.7

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.7.6
+version: 1.7.7
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4404 Loosen dartdoc range](https://github.com/Workiva/dart_dev/pull/225)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.7.6...version-bump-dart_dev-1-7-7
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.7.6...1.7.7