### PR TITLE
WP-4438 strong mode and lints

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,4 +1,0 @@
-analyzer:
-  exclude:
-    - 'test_fixtures'
-    

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,9 @@
+analyzer:
+  strong-mode: true
+  exclude:
+    - 'test_fixtures'
+  
+linter:
+  rules:
+    - cancel_subscriptions
+    - close_sinks   

--- a/lib/src/tasks/analyze/api.dart
+++ b/lib/src/tasks/analyze/api.dart
@@ -82,9 +82,11 @@ List<String> _findFilesFromEntryPoints(List<String> entryPoints) {
 
 class AnalyzeTask extends Task {
   final String analyzerCommand;
-  final Future done;
+  final Future<TaskResult> done;
 
   StreamController<String> _analyzerOutput = new StreamController();
   Stream<String> get analyzerOutput => _analyzerOutput.stream;
-  AnalyzeTask(String this.analyzerCommand, Future this.done);
+  AnalyzeTask(String this.analyzerCommand, Future<TaskResult> this.done) {
+    done.whenComplete(() => _analyzerOutput.close());
+  }
 }

--- a/lib/src/tasks/bash_completion/api.dart
+++ b/lib/src/tasks/bash_completion/api.dart
@@ -37,7 +37,7 @@ BashCompletionTask bashCompletion() {
 }
 
 class BashCompletionTask extends Task {
-  final Future done;
+  final Future<TaskResult> done;
   String completionScript;
-  BashCompletionTask(Future this.done);
+  BashCompletionTask(Future<TaskResult> this.done);
 }

--- a/lib/src/tasks/copy_license/api.dart
+++ b/lib/src/tasks/copy_license/api.dart
@@ -126,7 +126,7 @@ String trimLeadingAndTrailingEmptyLines(String input) {
 
 class CopyLicenseTask extends Task {
   List<String> affectedFiles = [];
-  final Future done = new Future.value();
+  final Future<TaskResult> done = new Future.value();
   CopyLicenseTask();
 }
 

--- a/lib/src/tasks/coverage/api.dart
+++ b/lib/src/tasks/coverage/api.dart
@@ -36,27 +36,30 @@ const String _testFilePattern = '_test.dart';
 class CoverageResult extends TaskResult {
   final File collection;
   final Directory report;
-  final File reportIndex;
+  File get reportIndex => _reportIndex;
+  File _reportIndex;
   final File lcov;
   final Iterable<String> tests;
 
   CoverageResult.fail(
       Iterable<String> this.tests, File this.collection, File this.lcov,
       {Directory report})
-      : super.fail(),
-        this.report = report,
-        reportIndex = report != null
-            ? new File(path.join(report.path, 'index.html'))
-            : null;
+      : this.report = report,
+        super.fail() {
+    if (report != null) {
+      _reportIndex = new File(path.join(report.path, 'index.html'));
+    }
+  }
 
   CoverageResult.success(
       Iterable<String> this.tests, File this.collection, File this.lcov,
       {Directory report})
-      : super.success(),
-        this.report = report,
-        reportIndex = report != null
-            ? new File(path.join(report.path, 'index.html'))
-            : null;
+      : this.report = report,
+        super.success() {
+    if (report != null) {
+      _reportIndex = new File(path.join(report.path, 'index.html'));
+    }
+  }
 }
 
 class CoverageTask extends Task {

--- a/lib/src/tasks/docs/api.dart
+++ b/lib/src/tasks/docs/api.dart
@@ -26,8 +26,8 @@ class DocsFailure implements Exception {}
 class DocsResult extends TaskResult {
   final Directory output;
   DocsResult()
-      : super.success(),
-        output = new Directory('doc/api/');
+      : output = new Directory('doc/api/'),
+        super.success();
 }
 
 class DocsTask extends Task {

--- a/lib/src/tasks/examples/api.dart
+++ b/lib/src/tasks/examples/api.dart
@@ -50,7 +50,7 @@ ExamplesTask serveExamples(
   ExamplesTask task = new ExamplesTask(
       '$dartiumExecutable ${dartiumArgs.join(' ')}',
       '$pubServeExecutable ${pubServeArgs.join(' ')}',
-      Future.wait([dartiumProcess.done, pubServeProcess.done]));
+      TaskResult.fromList([dartiumProcess.done, pubServeProcess.done]));
 
   pubServeProcess.stdout.listen(task._pubServeStdOut.add);
   pubServeProcess.stderr.listen(task._pubServeStdErr.add);
@@ -65,7 +65,7 @@ ExamplesTask serveExamples(
 }
 
 class ExamplesTask extends Task {
-  final Future done;
+  final Future<TaskResult> done;
   final String dartiumCommand;
   final String pubServeCommand;
 
@@ -74,7 +74,7 @@ class ExamplesTask extends Task {
   StreamController<String> _pubServeStdErr = new StreamController();
 
   ExamplesTask(String this.dartiumCommand, String this.pubServeCommand,
-      Future this.done) {
+      Future<TaskResult> this.done) {
     done.then((_) {
       _dartiumOutput.close();
       _pubServeStdOut.close();

--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -166,14 +166,16 @@ class FilesToFormat {
 class FormatTask extends Task {
   List<String> affectedFiles = [];
   List<String> excludedFiles = [];
-  final Future done;
+  final Future<TaskResult> done;
   final String formatterCommand;
   bool isDryRun;
   List<String> unaffectedFiles = [];
 
   StreamController<String> _formatterOutput = new StreamController();
 
-  FormatTask(String this.formatterCommand, Future this.done);
+  FormatTask(String this.formatterCommand, Future<TaskResult> this.done) {
+    done.whenComplete(() => _formatterOutput.close());
+  }
 
   Stream<String> get formatterOutput => _formatterOutput.stream;
 }

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -162,7 +162,7 @@ Future testHtmlFileGenerator(
 }
 
 class GenTestRunnerTask extends Task {
-  final Future done = new Future.value();
+  final Future<TaskResult> done = new Future.value();
   List<String> excludedFiles = [];
   final String generateCommand;
   List<String> testFiles = [];

--- a/lib/src/tasks/init/api.dart
+++ b/lib/src/tasks/init/api.dart
@@ -58,6 +58,6 @@ InitTask init() {
 }
 
 class InitTask extends Task {
-  final Future done = new Future.value();
+  final Future<TaskResult> done = new Future.value();
   InitTask();
 }

--- a/lib/src/tasks/local/api.dart
+++ b/lib/src/tasks/local/api.dart
@@ -23,8 +23,7 @@ import 'package:dart_dev/src/tasks/task.dart';
 LocalTask local(String executable, Iterable<String> args) {
   TaskProcess process = new TaskProcess(executable, args);
 
-  LocalTask task = new LocalTask(
-      '$executable ${args.join(' ')}', Future.wait([process.done]));
+  LocalTask task = new LocalTask('$executable ${args.join(' ')}', process.done);
 
   process.stdout.listen(task._commandOutput.add);
   process.stderr.listen(task._commandOutput.addError);
@@ -38,12 +37,14 @@ LocalTask local(String executable, Iterable<String> args) {
 }
 
 class LocalTask extends Task {
-  final Future done;
+  final Future<TaskResult> done;
   final String localCommand;
 
   StreamController<String> _commandOutput = new StreamController();
 
-  LocalTask(String this.localCommand, Future this.done);
+  LocalTask(String this.localCommand, Future<TaskResult> this.done) {
+    done.whenComplete(() => _commandOutput.close());
+  }
 
   Stream<String> get localOutput => _commandOutput.stream;
 }

--- a/lib/src/tasks/saucelabs/xml_reporter.dart
+++ b/lib/src/tasks/saucelabs/xml_reporter.dart
@@ -22,14 +22,14 @@ String sauceResultsToXunitXml(Map results, {bool prettyXml: true}) {
         builder.element('testsuite', attributes: {
           'name': suite['name'],
           'id': suite['url'],
-          'failures': 1,
-          'skipped': 0,
-          'tests': 1,
-          'time': 0,
+          'failures': '1',
+          'skipped': '0',
+          'tests': '1',
+          'time': '0',
         }, nest: () {
           builder.element('testcase', attributes: {
             'name': '',
-            'time': 0,
+            'time': '0',
           }, nest: () {
             builder.element('failure', nest: () {
               builder.cdata('An error occurred while running this suite.\n\n'
@@ -47,7 +47,7 @@ String sauceResultsToXunitXml(Map results, {bool prettyXml: true}) {
         'id': suite['url'],
         'failures': suiteResults['failed'],
         // TODO can we even get a skipped count?
-        'skipped': 0,
+        'skipped': '0',
         'tests': suiteResults['total'],
         'time': suiteResults['duration'],
       }, nest: () {
@@ -78,7 +78,7 @@ String sauceResultsToXunitXml(Map results, {bool prettyXml: true}) {
         if (!reportedAtLeastOneTestCase) {
           builder.element('testcase', attributes: {
             'name': '(all tests in this suite)',
-            'time': 0,
+            'time': '0',
           }, nest: () {
             builder.text('All tests in this suite passed.\n\n'
                 '(Passing tests are ommitted, and this placeholder is here to '

--- a/lib/src/tasks/serve/api.dart
+++ b/lib/src/tasks/serve/api.dart
@@ -26,7 +26,7 @@ final RegExp _servingRegExp =
 /// [PubServeTask].
 ///
 /// If [port] is 0, `pub serve` will pick its own port automatically.
-PubServeTask startPubServe({int port: 0, List additionalArgs}) {
+PubServeTask startPubServe({int port: 0, List<String> additionalArgs}) {
   var pubServeExecutable = 'pub';
   var pubServeArgs = ['serve', '--port=$port'];
   if (additionalArgs != null) {
@@ -54,7 +54,7 @@ PubServeTask startPubServe({int port: 0, List additionalArgs}) {
 
   pubServeProcess.stderr.listen(task._pubServeStdErr.add);
 
-  return task;
+  return task..done.whenComplete(() => pubServeInfos.close());
 }
 
 class PubServeInfo {

--- a/lib/src/tasks/task.dart
+++ b/lib/src/tasks/task.dart
@@ -26,4 +26,16 @@ abstract class TaskResult {
   TaskResult.fail() : _successful = false;
   TaskResult.success() : _successful = true;
   bool get successful => _successful;
+
+  static Future<TaskResult> fromList(List<Future<TaskResult>> tasks) async {
+    TaskResult lastTask;
+    for (Future<TaskResult> task in tasks) {
+      var result = await task;
+      if (!result.successful) {
+        return result;
+      }
+      lastTask = result;
+    }
+    return lastTask;
+  }
 }

--- a/lib/src/tasks/task_runner/api.dart
+++ b/lib/src/tasks/task_runner/api.dart
@@ -14,7 +14,7 @@ Future<TaskRunner> runTasks(tasksToRun) async {
 }
 
 class TaskRunner extends Task {
-  final Future done = new Future.value();
+  final Future<TaskResult> done = new Future.value();
   String failedTask;
   final String stderr;
   bool successful;

--- a/lib/src/tools/selenium.dart
+++ b/lib/src/tools/selenium.dart
@@ -116,7 +116,7 @@ class SeleniumHelper {
         'params': {},
         'id': uuid,
       }));
-      return c.future;
+      return c.future..whenComplete(() => ws.close());
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
# Problem

No strong mode or lint enforcement.

# Solution

- Switch to using `analysis_options.yaml` as [`.analysis_options` is deprecated](https://www.dartlang.org/guides/language/analysis-options#the-analysis-options-file)
- Add strong mode and lints.
- `super()` initializers come last
- Wrap lists of tasks into `TaskResult.fromList` to prevent the `done` field on the tasks from being multiple types of objects.
- Close sinks when tasks are complete.

# Testing Suggestion

WIP 