### PR TITLE
WP-4726 Move executable-only deps to dev_deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: dart
 dart:
-  - 1.23.0
+  - 1.24.2
 with_content_shell: true
 before_install:
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -125,11 +125,11 @@ be expanded in the configuration as documented below.
 Add the following to your `pubspec.yaml`:
 ```yaml
 dev_dependencies:
-  coverage: "^0.7.3"
-  dart_dev: "^1.0.0"
-  dart_style: ">=0.2.0 <0.3.0"
-  dartdoc: ">=0.8.0 <=0.10.0"
-  test: "^0.12.0"
+  coverage: ^0.8.0 # dart_dev is currently untested with coverage ^0.9.0
+  dart_dev: ^1.7.8
+  dart_style: ^1.0.7
+  dartdoc: ^0.13.0
+  test: ^0.12.24
 ```
 
 #### Create an Alias (optional)

--- a/lib/src/sauce_test_harness_transformer.dart
+++ b/lib/src/sauce_test_harness_transformer.dart
@@ -171,9 +171,8 @@ class SauceTestHarnessTransformer extends Transformer
   void generateDart(Transform transform) {
     var id = transform.primaryInput.id;
 
-    transform.addOutput(new Asset.fromString(
-        id.addExtension('.sauce_browser_test.dart'),
-        '''
+    transform.addOutput(
+        new Asset.fromString(id.addExtension('.sauce_browser_test.dart'), '''
           import 'dart:async';
           import 'dart:html';
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,27 +9,33 @@ authors:
   - Max Peterson <maxwell.peterson@workiva.com>
   - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/dart_dev
+
 dependencies:
   ansicolor: ^0.0.9
   args: ^0.13.0
   browser: '>=0.10.0 <0.11.0'
   completion: ^0.1.5
-  coverage: ^0.7.3
-  dart_style: '>=0.2.4 <2.0.0'
-  dartdoc: '>=0.9.0 <0.13.0'
   fluri: ^1.1.1
+  http: ^0.11.0
   path: ^1.3.6
   platform_detect: ^1.3.2
   resource: '>=1.0.0 <3.0.0'
   rxdart: ^0.12.0
   sass: ^0.4.2
-  test: ^0.12.0
   uuid: ^0.5.0
   webdriver: ^1.0.0
   yaml: ^2.1.0
   xml: ^2.4.2
+
+dev_dependencies:
+  coverage: ^0.8.0
+  dartdoc: ^0.13.0
+  dart_style: ^1.0.7
+  test: ^0.12.24
+  
 executables:
   dart_dev:
+
 environment:
   sdk: '>=1.9.0 <2.0.0'
 

--- a/test/integration/analyze_test.dart
+++ b/test/integration/analyze_test.dart
@@ -125,7 +125,7 @@ void main() {
       expect(analysis.numErrors, equals(2));
       expect(analysis.numHints, equals(0));
       expect(analysis.exitCode, greaterThan(0));
-    });
+    }, skip: 'dartanalyzer now treats --fatal-hints as a no-op');
 
     test('should not report hints as fatal if none existed', () async {
       Analysis analysis =

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -94,7 +94,7 @@ void main() {
       expect(contentsBefore, equals(contentsAfter));
     });
 
-    group('should format an ill-formatted project', () {
+    group('on an ill-formatted project', () {
       String testProject;
 
       const allFiles = const [
@@ -110,7 +110,7 @@ void main() {
           allFiles,
           value: (file) => new File('$testProject/$file').readAsStringSync());
 
-      test('should format an ill-formatted project', () async {
+      test('should format all ill-formatted files', () async {
         var contentsBefore = getAllFilesContents();
         expect(await formatProject(testProject), isTrue);
         var contentsAfter = getAllFilesContents();
@@ -121,9 +121,7 @@ void main() {
         }
       });
 
-      test(
-          'should format only the paths specified as arguments'
-          ' within an ill-formatted project', () async {
+      test('should format only the paths specified as arguments', () async {
         // It's important that these are relative paths to the project root
         const expectedModifiedFiles = const [
           'lib/library_1.dart',


### PR DESCRIPTION
## Issue

We have a few dependencies listed in the `dependencies` section that are only there for their executables. Consumers _have_ to add those dependencies to their `pubspec.yaml` anyway in order to run their executables, so this is unnecessary and as a result, consumers may experience some version lock that would otherwise be avoidable.

## Solution

Move `coverage`, `dart_style`, `dartdoc`, and `test` from the main dependencies list to the dev dependencies list. Additionally, the readme has been updated to reflect the currently supported version ranges for these executables required by the dart_dev tasks that use them.

## Testing

- [ ] CI passes
- [ ] Pull this branch of wdesk_sdk into a few consuming projects and run these 4 tasks:
  - `ddev coverage`
  - `ddev format`
  - `ddev docs`
  - `ddev test`

## Code Review
@Workiva/web-platform-pp 