### PR TITLE
WP-4409 Release dart_dev 1.7.8

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.7.7
+version: 1.7.8
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [RAP-2072 Remove rate_limit dependency.](https://github.com/Workiva/dart_dev/pull/228)
* [WP-4726 Move executable-only deps to dev_deps](https://github.com/Workiva/dart_dev/pull/229)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.7.7...version-bump-dart_dev-1-7-8
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.7.7...1.7.8