### PR TITLE
WP-4746 Ensure task runner waits for stdout/stderr before considering task "done"

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,11 @@ homepage: https://github.com/Workiva/dart_dev
 dependencies:
   ansicolor: ^0.0.9
   args: ^0.13.0
+  barback: ^0.15.0
   browser: '>=0.10.0 <0.11.0'
   completion: ^0.1.5
   fluri: ^1.1.1
+  html: ^0.13.0
   http: ^0.11.0
   path: ^1.3.6
   platform_detect: ^1.3.2

--- a/test_fixtures/task_runner/failing_tasks/test/simple_test.dart
+++ b/test_fixtures/task_runner/failing_tasks/test/simple_test.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import 'package:test/test.dart';
 
 void main() {
-  test('passes', () async {
+  test('fails', () async {
     await new Future.delayed(new Duration(seconds:5));
-    expect(true, isTrue);
+    expect(true, isFalse);
   });
 }

--- a/test_fixtures/task_runner/passing_tasks/test/simple_test.dart
+++ b/test_fixtures/task_runner/passing_tasks/test/simple_test.dart
@@ -1,7 +1,11 @@
+import 'dart:async';
+
 import 'package:test/test.dart';
 
 void main() {
-  test('passes', () {
+  test('passes', () async {
+    // Wait so that the test task doesn't complete too quickly.
+    await new Future.delayed(const Duration(seconds: 2));
     expect(true, isTrue);
   });
 }


### PR DESCRIPTION
## Issue

We are seeing the task-runner tests fail intermittently because the test task output is incomplete (it does not include the "All tests passed." or "Some tests failed." line that the test is looking for). I haven't been able to reproduce this locally.

## Solution

My best guess is that the task runner is considering the tasks done before the stdout/stderr streams have been completely processed due to it listening to the `exitCode` future instead of `done`.

Additionally, there were two dependencies that are being used but aren't explicitly depended on, so I've added those.

## Testing

- [ ] CI passes (maybe a couple of times?)
- [ ] `pub publish --dry-run` passes with no warnings

## Code Review

@Workiva/web-platform-pp 