### PR TITLE
WP-4762 Release dart_dev 1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,41 @@
 language: dart
+sudo: required
+
 dart:
   - 1.24.2
-with_content_shell: true
+
+addons:
+  apt:
+    packages:
+    - ttf-kochi-mincho
+    - ttf-kochi-gothic
+    - ttf-dejavu
+    - ttf-indic-fonts
+    - fonts-tlwg-garuda
+
 before_install:
-  - export DISPLAY=:99.0
-  - ./tool/setup_dartium.sh
-  - export PATH=$PATH":$PWD"
-  - sh -e /etc/init.d/xvfb start
+  # Content shell needs this font. Since it has a EULA, we need to manually
+  # install it.
+  #
+  # TODO: remove this and use "sudo: false" when travis-ci/travis-ci#4714 is
+  # fixed.
+  - sudo apt-get update -yq
+  - sudo sh -c "echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | debconf-set-selections"
+  - sudo apt-get install msttcorefonts -qq
+
+  - mkdir -p bin
+  - export PATH="$PATH:`pwd`/bin/"
+  - ln -s `which chromium-browser` bin/google-chrome
+
+  - wget "http://gsdview.appspot.com/dart-archive/channels/stable/release/latest/dartium/content_shell-linux-x64-release.zip"
+  - unzip content_shell-linux-x64-release.zip
+  - ln -s `pwd`/`echo drt-linux-*`/content_shell bin/content_shell
+
+  -  export DISPLAY=:99.0
+  -  ./tool/setup_dartium.sh
+  -  export PATH=$PATH":$PWD"
+  -  sh -e /etc/init.d/xvfb start
+
 script:
   - pub run dart_dev format --check
   - pub run dart_dev analyze

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.7.8
+version: 1.8.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-4898 Allow web-compiler flag to be passed through dart_dev to test task](https://github.com/Workiva/dart_dev/pull/235)


Requested by: @jayudey-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.7.8...version-bump-dart_dev-1-8-0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.7.8...1.8.0