### PR TITLE
WP-5353 Remove unnecessary dependency on sass package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ addons:
     - fonts-tlwg-garuda
 
 before_install:
+  # Workaround for https://github.com/travis-ci/travis-ci/issues/8607
+  - sudo rm -vf /etc/apt/sources.list.d/*riak*
   # Content shell needs this font. Since it has a EULA, we need to manually
   # install it.
   #

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   platform_detect: ^1.3.2
   resource: '>=1.0.0 <3.0.0'
   rxdart: ^0.12.0
-  sass: ^0.4.2
   uuid: ^0.5.0
   webdriver: ^1.0.0
   yaml: ^2.1.0
@@ -34,7 +33,7 @@ dev_dependencies:
   dartdoc: ^0.13.0
   dart_style: ^1.0.7
   test: ^0.12.24
-  
+
 executables:
   dart_dev:
 


### PR DESCRIPTION
Pretty self-explanatory.  There is no usage of the `sass` package in this repo.

@Workiva/web-platform-pp @Workiva/ui-platform-pp 