### PR TITLE
WP-4905 Release dart_dev 1.8.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.8.0
+version: 1.8.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [WP-5353 Remove unnecessary dependency on sass package](https://github.com/Workiva/dart_dev/pull/238)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.0-alpha...Workiva:release_dart_dev_1_8_1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.0-alpha...1.8.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)