### PR TITLE
WP-5356 Release dart_dev 1.8.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.8.1
+version: 1.8.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [Upgrade rxdart](https://github.com/Workiva/dart_dev/pull/240)
* [Update content_shell window size in coverage task](https://github.com/Workiva/dart_dev/pull/241)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.0-alpha...Workiva:release_dart_dev_1_8_2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.0-alpha...1.8.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)