### PR TITLE
Add ability to create testOn annotation with vm and browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ All configuration options for the local task discovery are found on the
             <td><code>env</code></td>
             <td><code>Environment</code></td>
             <td><code>Environment.browser</code></td>
-            <td>The environment to run tests in ('vm' or 'browser')</td>
+            <td>The environment to run tests in ('vm', 'browser', 'both')</td>
         </tr>
         <tr>
             <td><code>filename</code></td>

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -66,14 +66,17 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
     }
   });
 
+  if (currentConfig.genHtml && !currentConfig.check) {
+    await testHtmlFileGenerator(
+        currentDirectory, currentConfig.filename, currentConfig.htmlHeaders);
+  }
+
   if (currentConfig.env == Environment.browser) {
-    if (currentConfig.genHtml && !currentConfig.check) {
-      await testHtmlFileGenerator(
-          currentDirectory, currentConfig.filename, currentConfig.htmlHeaders);
-    }
     runnerLines.add('@TestOn(\'browser\')');
-  } else {
+  } else if (currentConfig.env == Environment.vm) {
     runnerLines.add('@TestOn(\'vm\')');
+  } else {
+    runnerLines.add('@TestOn(\'browser || vm\')');
   }
   runnerLines.add(
       'library ${currentDirectory.replaceAll('/','.')}${currentConfig.filename};');

--- a/lib/src/tasks/gen_test_runner/config.dart
+++ b/lib/src/tasks/gen_test_runner/config.dart
@@ -26,7 +26,7 @@ const bool defaultGenHtml = false;
 const bool defaultReact = true;
 const List<String> defaultHtmlHeaders = const [];
 
-enum Environment { vm, browser }
+enum Environment { vm, browser, both }
 
 class TestRunnerConfig {
   bool check = defaultCheck;

--- a/test/integration/gen_test_runner_test.dart
+++ b/test/integration/gen_test_runner_test.dart
@@ -23,6 +23,8 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
 const String browserAndVm = 'test_fixtures/gen_test_runner/browser_and_vm';
+const String browserAndVmRunner =
+    'test_fixtures/gen_test_runner/browser_and_vm_runner';
 const String checkFail = 'test_fixtures/gen_test_runner/check_fail';
 const String checkPass = 'test_fixtures/gen_test_runner/check_pass';
 const String defaultConfig = 'test_fixtures/gen_test_runner/default_config';
@@ -99,6 +101,17 @@ void main() {
       verifyExistenceAndCleanup(
           path.join(browserAndVm, 'test/vm/generated_runner.html'),
           shouldFileExist: false);
+    });
+
+    test('should create runner with both vm and browser annotation', () async {
+      Runner runner = await generateTestRunner(browserAndVmRunner);
+      expect(runner.exitCode, isZero);
+      String runnerPath =
+          path.join(browserAndVmRunner, 'test/generated_runner.dart');
+      File testRunner = new File(runnerPath);
+      String fileContents = testRunner.readAsStringSync();
+      expect(fileContents.contains('@TestOn(\'browser || vm\')'), isTrue);
+      verifyExistenceAndCleanup(runnerPath, shouldFileExist: true);
     });
 
     group('--check flag', () {

--- a/test_fixtures/gen_test_runner/browser_and_vm_runner/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/browser_and_vm_runner/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_generator_browser_and_vm_runner
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  test: '^0.12.0'

--- a/test_fixtures/gen_test_runner/browser_and_vm_runner/test/browser/browser_test.dart
+++ b/test_fixtures/gen_test_runner/browser_and_vm_runner/test/browser/browser_test.dart
@@ -1,0 +1,10 @@
+@TestOn('browser')
+library test_generator_browser_and_vm_runner.test.browser.browser_test;
+
+import 'package:test/test.dart';
+
+main() {
+  test('browser test', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/browser_and_vm_runner/test/vm/vm_test.dart
+++ b/test_fixtures/gen_test_runner/browser_and_vm_runner/test/vm/vm_test.dart
@@ -1,0 +1,10 @@
+@TestOn('vm')
+library test_generator_browser_and_vm_runner.test.vm.vm_test;
+
+import 'package:test/test.dart';
+
+main() {
+  test('vm test', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/browser_and_vm_runner/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/browser_and_vm_runner/tool/dev.dart
@@ -1,0 +1,11 @@
+library test_generator_browser_and_vm_runner.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart';
+
+main(List<String> args) async {
+  config.genTestRunner.configs = [
+    new TestRunnerConfig(env: Environment.both, directory: 'test/'),
+  ];
+
+  await dev(args);
+}


### PR DESCRIPTION
## Issue
- There was no way to specify both `vm` and `browser` in a generated runner file.

## Changes
**Source:**
- Added an additional platform option.

**Tests:**
- added

## Areas of Regression
- gen-test-runner platform configuration and html generation

## Testing
- verify that tests work as exists

## Code Review
@Workiva/ui-platform-pp @Workiva/web-platform-pp 