### PR TITLE
WP-6076 widen rxdart dependency range

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   path: ^1.3.6
   platform_detect: ^1.3.2
   resource: '>=1.0.0 <3.0.0'
-  rxdart: '>=0.12.0 <0.15.0'
+  rxdart: '>=0.12.0 <0.16.0'
   uuid: ^0.5.0
   webdriver: ^1.0.0
   yaml: ^2.1.0


### PR DESCRIPTION
# Overview

The latest release of rxdart (0.15.1) fully supports DDC compilation. Widening this range allows all of Workiva to get this latest version. Most repos are stuck at ^0.12.0. The rxdart API is unchanged, so it should be an easy upgrade and rollout.

# Test
 - [ ] Use a dep override to run tests with the newest version
```
dependency_overrides:
  rxdart: 0.15.1
```