### PR TITLE
Update Dockerfile to mirror recent changes to smithy.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:153818 as build
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
 
 # Build Environment Vars
 ARG BUILD_ID


### PR DESCRIPTION
The dockerfile builds are failing because they had fallen behind smithy.yaml while that pr was open