### PR TITLE
AF-348 WIP spike out using dart_build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ script:
   - pub run dart_dev analyze
   - cd test_fixtures/coverage/functional_test/
   - pub get
-  - pub run dependency_validator -i browser,coverage
+  - pub run dependency_validator -i browser,coverage,dart_build
   - pub run dart_build build
   - cd -
   - pub run dart_dev test --integration

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
   -  sh -e /etc/init.d/xvfb start
 
 script:
-  - pub run dependency_validator -i browser,coverage,dart_style,dartdoc,test
+  - pub run dependency_validator -i browser,coverage,dart_style,dartdoc,test,dart_build
   - pub run dart_dev format --check
   - pub run dart_dev analyze
   - cd test_fixtures/coverage/functional_test/

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   - cd test_fixtures/coverage/functional_test/
   - pub get
   - pub run dependency_validator -i browser,coverage
-  - pub build
+  - pub run dart_build build
   - cd -
   - pub run dart_dev test --integration
   - pub run dart_dev coverage --integration --no-html

--- a/lib/src/tasks/serve/api.dart
+++ b/lib/src/tasks/serve/api.dart
@@ -28,7 +28,7 @@ final RegExp _servingRegExp =
 /// If [port] is 0, `pub serve` will pick its own port automatically.
 PubServeTask startPubServe({int port: 0, List<String> additionalArgs}) {
   var pubServeExecutable = 'pub';
-  var pubServeArgs = ['serve', '--port=$port'];
+  var pubServeArgs = ['run', 'dart_build', 'serve', '--port=$port'];
   if (additionalArgs != null) {
     pubServeArgs.addAll(additionalArgs);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,11 +29,7 @@ dependencies:
   xml: ^2.4.2
 
 dev_dependencies:
-  dart_build:
-    git:
-      url: git://github.com/Workiva/dart_build.git
-      ref: initial_dart1_functionality # uncomment this one for Dart 1
-      #ref: dart2 # uncomment this one for Dart 2
+  dart_build: ^0.1.0
   coverage: '>=0.9.3 <0.11.0'
   dartdoc: '>=0.14.1 <0.19.0'
   dart_style: ^1.0.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,11 @@ dependencies:
   xml: ^2.4.2
 
 dev_dependencies:
+  dart_build:
+    git:
+      url: git://github.com/Workiva/dart_build.git
+      ref: initial_dart1_functionality # uncomment this one for Dart 1
+      #ref: dart2 # uncomment this one for Dart 2
   coverage: '>=0.9.3 <0.11.0'
   dartdoc: '>=0.14.1 <0.19.0'
   dart_style: ^1.0.7
@@ -38,8 +43,8 @@ dev_dependencies:
 executables:
   dart_dev:
 
-environment:
-  sdk: '>=1.9.0 <2.0.0'
+# environment: # Commented out to allow installing under both Dart 1 and Dart 2
+  # sdk: '>=1.9.0 <2.0.0'
 
 transformers:
   - test/pub_serve:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,8 +39,8 @@ dev_dependencies:
 executables:
   dart_dev:
 
-# environment: # Commented out to allow installing under both Dart 1 and Dart 2
-  # sdk: '>=1.9.0 <2.0.0'
+environment:
+  sdk: '>=1.9.0 <=2.0.0'
 
 transformers:
   - test/pub_serve:

--- a/test_fixtures/analyze/errors/pubspec.yaml
+++ b/test_fixtures/analyze/errors/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/analyze/hints/pubspec.yaml
+++ b/test_fixtures/analyze/hints/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/analyze/lints/pubspec.yaml
+++ b/test_fixtures/analyze/lints/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/analyze/no_issues/pubspec.yaml
+++ b/test_fixtures/analyze/no_issues/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/analyze/strong/pubspec.yaml
+++ b/test_fixtures/analyze/strong/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/analyze/warnings/pubspec.yaml
+++ b/test_fixtures/analyze/warnings/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/copy_license/has_licenses/pubspec.yaml
+++ b/test_fixtures/copy_license/has_licenses/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/copy_license/license_with_empty_lines/pubspec.yaml
+++ b/test_fixtures/copy_license/license_with_empty_lines/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/copy_license/no_license_file/pubspec.yaml
+++ b/test_fixtures/copy_license/no_license_file/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/copy_license/no_licenses/pubspec.yaml
+++ b/test_fixtures/copy_license/no_licenses/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/coverage/browser/pubspec.yaml
+++ b/test_fixtures/coverage/browser/pubspec.yaml
@@ -4,4 +4,5 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   test: "^0.12.0"

--- a/test_fixtures/coverage/browser_needs_pub_serve/pubspec.yaml
+++ b/test_fixtures/coverage/browser_needs_pub_serve/pubspec.yaml
@@ -4,6 +4,7 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   test: "^0.12.0"
 transformers:
   # Add the necessary `test` package transformer

--- a/test_fixtures/coverage/failing_test/pubspec.yaml
+++ b/test_fixtures/coverage/failing_test/pubspec.yaml
@@ -4,4 +4,5 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   test: "^0.12.0"

--- a/test_fixtures/coverage/functional_test/pubspec.yaml
+++ b/test_fixtures/coverage/functional_test/pubspec.yaml
@@ -8,3 +8,4 @@ dev_dependencies:
   webdriver: '^1.0.0'
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/coverage/no_coverage_package/pubspec.yaml
+++ b/test_fixtures/coverage/no_coverage_package/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/coverage/non_test_file/pubspec.yaml
+++ b/test_fixtures/coverage/non_test_file/pubspec.yaml
@@ -4,4 +4,5 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   test: "^0.12.0"

--- a/test_fixtures/coverage/vm/pubspec.yaml
+++ b/test_fixtures/coverage/vm/pubspec.yaml
@@ -4,4 +4,5 @@ dev_dependencies:
   coverage: "^0.7.2"
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   test: "^0.12.0"

--- a/test_fixtures/docs/docs/pubspec.yaml
+++ b/test_fixtures/docs/docs/pubspec.yaml
@@ -3,4 +3,5 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   dartdoc: ^0.9.0

--- a/test_fixtures/docs/no_dartdoc_package/pubspec.yaml
+++ b/test_fixtures/docs/no_dartdoc_package/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/examples/examples_dir/pubspec.yaml
+++ b/test_fixtures/examples/examples_dir/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/examples/no_examples_dir/pubspec.yaml
+++ b/test_fixtures/examples/no_examples_dir/pubspec.yaml
@@ -3,3 +3,4 @@ name: no_examples_dir
   dev_dependencies:
     dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/export_config/with_format_config/pubspec.yaml
+++ b/test_fixtures/export_config/with_format_config/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/export_config/with_no_config/pubspec.yaml
+++ b/test_fixtures/export_config/with_no_config/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/format/changes_needed/pubspec.yaml
+++ b/test_fixtures/format/changes_needed/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  dart_build: ^0.1.0

--- a/test_fixtures/format/exclusions/pubspec.yaml
+++ b/test_fixtures/format/exclusions/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  dart_build: ^0.1.0

--- a/test_fixtures/format/inclusions/pubspec.yaml
+++ b/test_fixtures/format/inclusions/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  dart_build: ^0.1.0

--- a/test_fixtures/format/inclusions_deprecated/pubspec.yaml
+++ b/test_fixtures/format/inclusions_deprecated/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  dart_build: ^0.1.0

--- a/test_fixtures/format/no_changes_needed/pubspec.yaml
+++ b/test_fixtures/format/no_changes_needed/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
+  dart_build: ^0.1.0

--- a/test_fixtures/format/no_dart_style/pubspec.yaml
+++ b/test_fixtures/format/no_dart_style/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/gen_test_runner/browser_and_vm/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/browser_and_vm/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: '^0.12.0'
+  dart_build: ^0.1.0

--- a/test_fixtures/gen_test_runner/browser_and_vm_runner/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/browser_and_vm_runner/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: '^0.12.0'
+  dart_build: ^0.1.0

--- a/test_fixtures/gen_test_runner/check_fail/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/check_fail/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: '^0.12.0'
+  dart_build: ^0.1.0

--- a/test_fixtures/gen_test_runner/check_pass/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/check_pass/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: '^0.12.0'
+  dart_build: ^0.1.0

--- a/test_fixtures/gen_test_runner/default_config/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/default_config/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: '^0.12.0'
+  dart_build: ^0.1.0

--- a/test_fixtures/init/initialized/pubspec.yaml
+++ b/test_fixtures/init/initialized/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/init/uninitialized/pubspec.yaml
+++ b/test_fixtures/init/uninitialized/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/local/follow_symlinks/pubspec.yaml
+++ b/test_fixtures/local/follow_symlinks/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/local/good_tasks/pubspec.yaml
+++ b/test_fixtures/local/good_tasks/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/local/no_executable/pubspec.yaml
+++ b/test_fixtures/local/no_executable/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/local/no_follow_symlinks/pubspec.yaml
+++ b/test_fixtures/local/no_follow_symlinks/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/local/no_tasks/pubspec.yaml
+++ b/test_fixtures/local/no_tasks/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/task_runner/failing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/failing_tasks/pubspec.yaml
@@ -5,3 +5,4 @@ dev_dependencies:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
   test: "^0.12.0"
+  dart_build: ^0.1.0

--- a/test_fixtures/task_runner/passing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/passing_tasks/pubspec.yaml
@@ -5,4 +5,4 @@ dev_dependencies:
     path: ../../..
   dart_style: ">=0.1.8 <0.3.0"
   test: "^0.12.0"
-
+  dart_build: ^0.1.0

--- a/test_fixtures/test/default_unit/pubspec.yaml
+++ b/test_fixtures/test/default_unit/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: ^0.12.33
+  dart_build: ^0.1.0

--- a/test_fixtures/test/failing/pubspec.yaml
+++ b/test_fixtures/test/failing/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: ^0.12.33
+  dart_build: ^0.1.0

--- a/test_fixtures/test/needs_pub_serve/pubspec.yaml
+++ b/test_fixtures/test/needs_pub_serve/pubspec.yaml
@@ -3,6 +3,7 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0
   test: ^0.12.33
   barback: ^0.15.2
 transformers:

--- a/test_fixtures/test/no_test_package/pubspec.yaml
+++ b/test_fixtures/test/no_test_package/pubspec.yaml
@@ -3,3 +3,4 @@ version: 0.0.0
 dev_dependencies:
   dart_dev:
     path: ../../..
+  dart_build: ^0.1.0

--- a/test_fixtures/test/passing/pubspec.yaml
+++ b/test_fixtures/test/passing/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: ^0.12.33
+  dart_build: ^0.1.0

--- a/test_fixtures/test/passingIntegration/pubspec.yaml
+++ b/test_fixtures/test/passingIntegration/pubspec.yaml
@@ -4,3 +4,4 @@ dev_dependencies:
   dart_dev:
     path: ../../..
   test: ^0.12.33
+  dart_build: ^0.1.0


### PR DESCRIPTION
# Changes
We'd like to  ease the transition to Dart 2 so this runs dart_build instead of running pub serve directly. dart_build internally runs pub serve or build_runner depending on the version of Dart being used.

Note: failing builds due to dart_build not being open sourced yet. Once that is OSS things should start passing.
