### PR TITLE
af_new_drydock_image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ sudo: required
 dart:
   - stable
 
+env:
+  - DARTIUM_EXPIRATION_TIME="1577836800"
+
 addons:
   apt:
     packages:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:179735 as build
+FROM drydock-prod.workiva.net/workiva/smithy-runner-generator:355624 as build
 
 # Build Environment Vars
 ARG BUILD_ID

--- a/test_fixtures/test/needs_pub_serve/tool/dev.dart
+++ b/test_fixtures/test/needs_pub_serve/tool/dev.dart
@@ -6,7 +6,7 @@ main(List<String> args) async {
   config.test
     ..pubServe = true
     ..unitTests = ['test/unit_test.dart']
-    ..platforms = ['content-shell'];
+    ..platforms = ['dartium'];
 
   await dev(args);
 }

--- a/test_fixtures/test/needs_pub_serve/tool/dev.dart
+++ b/test_fixtures/test/needs_pub_serve/tool/dev.dart
@@ -6,7 +6,7 @@ main(List<String> args) async {
   config.test
     ..pubServe = true
     ..unitTests = ['test/unit_test.dart']
-    ..platforms = ['dartium'];
+    ..platforms = ['content-shell'];
 
   await dev(args);
 }


### PR DESCRIPTION
## Purpose

The following pull request has been created by App Frameworks to help move consumers to the latest Smithy image. This was done because of an issue with Dartium and Content-Shell that would fail your CIs. Please seethis [Wiki Question](https://wiki.atl.workiva.net/cq/viewquestion.action?id=96308901&answerId=96308907)for additional context.

## Changes

The following changes have been made:
* All instances of the production Smithy image have been updated to `drydock-prod.workiva.net/workiva/smithy-runner-generator:355624`.

## Questions

If you have any questions, please reach out to us in the Support:H5 / Dart Hipchat room