### PR TITLE
Automatically extend the Dartium expiration date for test/coverage tasks

### DIFF
--- a/lib/src/task_process.dart
+++ b/lib/src/task_process.dart
@@ -31,9 +31,10 @@ class TaskProcess {
   StreamController<String> _stderr = new StreamController();
 
   TaskProcess(String executable, List<String> arguments,
-      {String workingDirectory}) {
+      {String workingDirectory, Map<String, String> environment}) {
     Process
-        .start(executable, arguments, workingDirectory: workingDirectory)
+        .start(executable, arguments,
+            workingDirectory: workingDirectory, environment: environment)
         .then((process) {
       _process = process;
       process.stdout

--- a/lib/src/tasks/coverage/api.dart
+++ b/lib/src/tasks/coverage/api.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:dart2_constant/convert.dart' as convert;
+import 'package:dart_dev/src/util.dart';
 import 'package:dart_dev/util.dart' show TaskProcess, getOpenPort;
 import 'package:path/path.dart' as path;
 
@@ -552,8 +553,9 @@ class CoverageTask extends Task {
     _coverageOutput.add('');
     _coverageOutput.add('Running test suite ${testPath}');
     _coverageOutput.add('$executable ${args.join(' ')}\n');
-    TaskProcess process =
-        _lastTestProcess = new TaskProcess('content_shell', args);
+    TaskProcess process = _lastTestProcess = new TaskProcess(
+        'content_shell', args,
+        environment: dartiumExpirationOverrideEnv);
 
     // Content-shell dumps render tree to stderr, which is where the test
     // results will be. The observatory port should be output to stderr as

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -20,6 +20,7 @@ import 'package:dart_dev/util.dart' show TaskProcess;
 
 import 'package:dart_dev/src/tasks/task.dart';
 import 'package:dart_dev/src/tools/selenium.dart' show SeleniumHelper;
+import 'package:dart_dev/src/util.dart';
 
 TestTask test(
     {int concurrency,
@@ -38,7 +39,8 @@ TestTask test(
   args.addAll(additionalArgs);
   args.addAll(tests);
 
-  TaskProcess process = new TaskProcess(executable, args);
+  TaskProcess process = new TaskProcess(executable, args,
+      environment: dartiumExpirationOverrideEnv);
   Completer outputProcessed = new Completer();
   TestTask task = new TestTask('$executable ${args.join(' ')}',
       Future.wait([process.done, outputProcessed.future]));

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -110,3 +110,13 @@ Future runAll(List tasks) async {
     }
   }
 }
+
+final _newExpirationDate = new DateTime.now().add(const Duration(days: 1000));
+
+/// A map of environment variables that will set the Dartium expiration
+/// to 1000 days after the current date.
+final Map<String, String> dartiumExpirationOverrideEnv = new Map.unmodifiable({
+  // This is given in seconds since epoch
+  'DARTIUM_EXPIRATION_TIME':
+      (_newExpirationDate.millisecondsSinceEpoch / 1000).toStringAsFixed(0),
+});


### PR DESCRIPTION
## Problem
Dartium has hit its built-in expiration date, and cannot run Dart code properly unless the date is overridden using the `DARTIUM_EXPIRATION_TIME` environment variable.

https://github.com/dart-lang/sdk/issues/33580

This causes tests and coverage to timeout inexplicably when running content-shell, and only with a popup warning when running in Dartium.

## Solution
Automatically set this flag in relevant processes launched by dart_dev to work around this issue and prevent frustrating content-shell failures.

## Testing:
- Run `ddev test`/`ddev coverage` in a terminal where `DARTIUM_EXPIRATION_TIME` is unset, and verify that tests pass