### PR TITLE
AF-1870 Widen uuid range for Dart 2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   platform_detect: ^1.3.2
   resource: '>=1.0.0 <3.0.0'
   rxdart: '>=0.12.0 <0.17.0'
-  uuid: ^0.5.0
+  uuid: '>=0.5.0 <2.0.0'
   webdriver: ^1.0.0
   yaml: ^2.1.0
   xml: ^2.4.2


### PR DESCRIPTION
## Description

In order to allow dart_dev to be installed in other packages using Dart 2 (dev channel), the `uuid` range needs to be widened.

## Testing
- [ ] CI passes
- [ ] This branch can be installed on the Dart 2 dev channel

## Code Review
@Workiva/app-frameworks 
@robbecker-wf 