### PR TITLE
AF-1625 Release dart_dev 1.9.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.9.4
+version: 1.9.5
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [AF-1870 Widen uuid range for Dart 2](https://github.com/Workiva/dart_dev/pull/269)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.9.4...Workiva:release_dart_dev_1_9_5
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.9.4...1.9.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)