### PR TITLE
Update webdriver dep for Dart 2 compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   resource: '>=1.0.0 <3.0.0'
   rxdart: '>=0.12.0 <0.17.0'
   uuid: '>=0.5.0 <2.0.0'
-  webdriver: ^1.0.0
+  webdriver: ">=1.0.0 <3.0.0"
   yaml: ^2.1.0
   xml: ^2.4.2
 


### PR DESCRIPTION
We will need to be able to fetch `webdriver 2.x.x` when on Dart 2.

Expand acceptable dependency range on `webdriver` to include 2.0