### PR TITLE
AF-1872 Release dart_dev 1.9.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.9.5
+version: 1.9.6
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pulls Included in Release:
* [Update webdriver dep for Dart 2 compatibility](https://github.com/Workiva/dart_dev/pull/271)


Requested by: @maxpeterson-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.9.5...Workiva:release_dart_dev_1_9_6
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.9.5...1.9.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)