### PR TITLE
AF-1903 Release dart_dev 1.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 1.9.6
+version: 1.10.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* [clean up build](https://github.com/Workiva/dart_dev/pull/273)
* [AF-2759 V2 Prep: deprecate docs, examples, saucelabs; add dart1-only and dart2-only](https://github.com/Workiva/dart_dev/pull/275)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/1.9.6...Workiva:release_dart_dev_1.10.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/1.9.6...1.10.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)