### PR TITLE
Add regex on ddev gen-test-runner for files you want

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ object.
 **Note:** if you plan to use the `--check` option, be sure to exclude
 the `generated_runner_test.dart` file from formatting. This can be done
 by adding it to the `config.format.exclude` list.
+
 **Note:** the `--activeTestsRegex` (or `-t`) option is meant to be used
 for local dev and iterating quickly on tests. It should be easily undone
 with a `git checkout -- <path_to/generated_runner.dart>`.

--- a/README.md
+++ b/README.md
@@ -494,8 +494,14 @@ object.
             <td>The list of runner configurations used to create individual test runners</td>
         </tr>
         <tr>
+            <td><code>activeTestsRegex</code></td>
+            <td><code>String</code></td>
+            <td><code>''</code></td>
+            <td>You can use this to speed up local dev by specifying which files you want to include. This should reduce the build time of <code>ddev test</code>, allowing you to target your specific tests and iterate quickly.</td>
+        </tr>
+        <tr>
             <td><code>check</code></td>
-            <td><code>bool/code></td>
+            <td><code>bool</code></td>
             <td><code>false</code></td>
             <td>If true, will only check to ensure the runner is up-to-date</td>
         </tr>
@@ -505,6 +511,9 @@ object.
 **Note:** if you plan to use the `--check` option, be sure to exclude
 the `generated_runner_test.dart` file from formatting. This can be done
 by adding it to the `config.format.exclude` list.
+**Note:** the `--activeTestsRegex` (or `-t`) option is meant to be used
+for local dev and iterating quickly on tests. It should be easily undone
+with a `git checkout -- <path_to/generated_runner.dart>`.
 
 #### Local Config
 All configuration options for the local task discovery are found on the

--- a/lib/src/tasks/gen_test_runner/api.dart
+++ b/lib/src/tasks/gen_test_runner/api.dart
@@ -24,6 +24,8 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
   var taskTitle = 'gen-test-runner';
   var args = ['-d ${currentConfig.directory}', '-e ${currentConfig.env}'];
   currentConfig.genHtml ? args.add('--genHtml') : args.add('--no-genHtml');
+  args.addAll(['-t', '${currentConfig.activeTestsRegex}']);
+  final regexp = new RegExp(currentConfig.activeTestsRegex);
 
   GenTestRunnerTask task =
       new GenTestRunnerTask('$taskTitle ${args.join(' ')}');
@@ -87,8 +89,12 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
 
   testFiles.forEach((File file) {
     var testPath = file.path.replaceFirst(currentDirectory, '');
-    runnerLines.add(
-        'import \'${'./' + testPath}\' as ${testPath.replaceAll('/', '_').substring(0, testPath.length - 5)};');
+    var line =
+        'import \'${'./' + testPath}\' as ${testPath.replaceAll('/', '_').substring(0, testPath.length - 5)};';
+    if (!regexp.hasMatch(testPath)) {
+      line = '//' + line;
+    }
+    runnerLines.add(line);
   });
 
   runnerLines.add('import \'package:test/test.dart\';');
@@ -110,8 +116,12 @@ Future<GenTestRunnerTask> genTestRunner(TestRunnerConfig currentConfig) async {
 
   testFiles.forEach((File file) {
     var testPath = file.path.replaceFirst(currentDirectory, '');
-    runnerLines.add(
-        '  ${testPath.replaceAll('/', '_').substring(0, testPath.length - 5)}.main();');
+    var line =
+        '${testPath.replaceAll('/', '_').substring(0, testPath.length - 5)}.main();';
+    if (!regexp.hasMatch(testPath)) {
+      line = '//' + line;
+    }
+    runnerLines.add('  $line');
   });
 
   runnerLines.add('}');

--- a/lib/src/tasks/gen_test_runner/cli.dart
+++ b/lib/src/tasks/gen_test_runner/cli.dart
@@ -36,6 +36,10 @@ class GenTestRunnerCli extends TaskCli {
         defaultsTo: defaultCheck,
         negatable: false,
         help: 'Check whether the generated runner is up-to-date')
+    ..addOption('activeTestsRegex',
+        abbr: 't',
+        defaultsTo: defaultRegex,
+        help: 'Comments out tests that do not match given regex')
     ..addOption('config',
         help:
             'Configuration options should be performed in local dev.dart file');
@@ -48,6 +52,7 @@ class GenTestRunnerCli extends TaskCli {
     GenResultGroup results = new GenResultGroup();
 
     bool check = parsedArgs['check'];
+    String activeTestsRegex = parsedArgs['activeTestsRegex'];
 
     for (var currentConfig in config.genTestRunner.configs) {
       if (!new Directory(currentConfig.directory).existsSync()) {
@@ -56,6 +61,7 @@ class GenTestRunnerCli extends TaskCli {
       }
 
       currentConfig.check = check;
+      currentConfig.activeTestsRegex = activeTestsRegex;
 
       GenTestRunnerTask task = await genTestRunner(currentConfig);
       await task.done;

--- a/lib/src/tasks/gen_test_runner/config.dart
+++ b/lib/src/tasks/gen_test_runner/config.dart
@@ -22,6 +22,7 @@ const List<String> defaultPreTestCommands = const [];
 const String defaultDirectory = 'test/';
 const Environment defaultEnv = Environment.browser;
 const String defaultFilename = 'generated_runner';
+const String defaultRegex = '';
 const bool defaultGenHtml = false;
 const bool defaultReact = true;
 const List<String> defaultHtmlHeaders = const [];
@@ -35,6 +36,7 @@ class TestRunnerConfig {
   String directory = defaultDirectory;
   Environment env = defaultEnv;
   String filename = defaultFilename;
+  String activeTestsRegex = defaultRegex;
   bool genHtml = defaultGenHtml;
   List<String> htmlHeaders = defaultHtmlHeaders;
 
@@ -44,6 +46,7 @@ class TestRunnerConfig {
       String this.directory: defaultDirectory,
       Environment this.env: defaultEnv,
       String this.filename: defaultFilename,
+      String this.activeTestsRegex: defaultRegex,
       bool this.genHtml: defaultGenHtml,
       List<String> this.htmlHeaders: defaultHtmlHeaders});
 }

--- a/test/integration/gen_test_runner_test.dart
+++ b/test/integration/gen_test_runner_test.dart
@@ -27,7 +27,8 @@ const String browserAndVmRunner =
     'test_fixtures/gen_test_runner/browser_and_vm_runner';
 const String checkFail = 'test_fixtures/gen_test_runner/check_fail';
 const String checkPass = 'test_fixtures/gen_test_runner/check_pass';
-const String activeTestsRegex = 'test_fixtures/gen_test_runner/active_tests_regex';
+const String activeTestsRegex =
+    'test_fixtures/gen_test_runner/active_tests_regex';
 const String defaultConfig = 'test_fixtures/gen_test_runner/default_config';
 
 Future<Runner> generateTestRunner(String projectPath,

--- a/test_fixtures/gen_test_runner/active_tests_regex/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/active_tests_regex/pubspec.yaml
@@ -1,0 +1,6 @@
+name: test_generator_browser_and_vm_runner
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+  test: any

--- a/test_fixtures/gen_test_runner/active_tests_regex/pubspec.yaml
+++ b/test_fixtures/gen_test_runner/active_tests_regex/pubspec.yaml
@@ -1,4 +1,4 @@
-name: test_generator_browser_and_vm_runner
+name: test_active_tests_regex
 version: 0.0.0
 dev_dependencies:
   dart_dev:

--- a/test_fixtures/gen_test_runner/active_tests_regex/test/inactive/inactive_test.dart
+++ b/test_fixtures/gen_test_runner/active_tests_regex/test/inactive/inactive_test.dart
@@ -1,4 +1,4 @@
-@TestOn('vm')
+@TestOn('browser')
 library test_active_tests_regex.test.inactive.inactive_test;
 
 import 'package:test/test.dart';

--- a/test_fixtures/gen_test_runner/active_tests_regex/test/inactive/inactive_test.dart
+++ b/test_fixtures/gen_test_runner/active_tests_regex/test/inactive/inactive_test.dart
@@ -1,0 +1,10 @@
+@TestOn('vm')
+library test_active_tests_regex.test.inactive.inactive_test;
+
+import 'package:test/test.dart';
+
+main() {
+  test('inactive test', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/active_tests_regex/test/totally_active/totally_active_test.dart
+++ b/test_fixtures/gen_test_runner/active_tests_regex/test/totally_active/totally_active_test.dart
@@ -1,0 +1,10 @@
+@TestOn('browser')
+library test_active_tests_regex.test.totally_active.totally_active_test;
+
+import 'package:test/test.dart';
+
+main() {
+  test('totally active test', () {
+    expect(true, isTrue);
+  });
+}

--- a/test_fixtures/gen_test_runner/active_tests_regex/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/active_tests_regex/tool/dev.dart
@@ -1,4 +1,4 @@
-library test_generator_browser_and_vm_runner.tool.dev;
+library test_active_tests_regex.tool.dev;
 
 import 'package:dart_dev/dart_dev.dart';
 

--- a/test_fixtures/gen_test_runner/active_tests_regex/tool/dev.dart
+++ b/test_fixtures/gen_test_runner/active_tests_regex/tool/dev.dart
@@ -1,0 +1,7 @@
+library test_generator_browser_and_vm_runner.tool.dev;
+
+import 'package:dart_dev/dart_dev.dart';
+
+main(List<String> args) async {
+  await dev(args);
+}


### PR DESCRIPTION
## Problem
In local dev, the gen-test-runner can become quite massive. This is a problem because a developer might just want to run tests for a particular file. That's achieved currently with `ddev test -n DesiredFileRegex`. However, it might take 40 seconds to build the binary because we import everything, then execute the tests in 3 seconds. This is a massive waste of developer time.

## Solution
Provide a quick and dirty line-commentor that takes in a regex of file names to leave behind and generates the test runner with that.

## Usage
Let's say a developer wants to run the tests located in their project at `test/a_massive_project/happy_dev/first_file_test.dart` and `test/a_massive_project/happy_dev/second_file_test.dart`.
1. Run `ddev gen-test-runner -t happy_dev`
2. Run `ddev test`
3. Decide you also want to run `test/a_massive_project/indecisive_dev/third_file_test.dart`.
4. Go into the generated test runner dart file and uncomment the two lines with `indecisive_dev`.
   - Alternatively, run `ddev gen-test-runner --activeTestsRegex happy_dev|indecisive_dev`

## Reviewers
@evanweible-wf @georgelesica-wf @jayudey-wf you've been shamelessly git-blame identified as good reviewers