### PR TITLE
Don't format files in .dart_tool

### DIFF
--- a/lib/src/tasks/format/api.dart
+++ b/lib/src/tasks/format/api.dart
@@ -136,6 +136,8 @@ FilesToFormat getFilesToFormat({
         if (pathParts.contains('packages')) continue;
         // Skip contents of .pub directories.
         if (pathParts.contains('.pub')) continue;
+        // Skip contents of .dart_tool directories.
+        if (pathParts.contains('.dart_tool')) continue;
 
         // Skip excluded files.
         bool isExcluded = exclude.any((excluded) =>

--- a/test/integration/format_test.dart
+++ b/test/integration/format_test.dart
@@ -288,5 +288,13 @@ void main() {
       String contentsAfter = file.readAsStringSync();
       expect(contentsBefore, equals(contentsAfter));
     });
+
+    test('should skip files in ".dart_tool" when excludes specified', () async {
+      File file = new File('$projectWithExclusions/lib/.dart_tool/main.dart');
+      String contentsBefore = file.readAsStringSync();
+      expect(await formatProject(projectWithExclusions), isTrue);
+      String contentsAfter = file.readAsStringSync();
+      expect(contentsBefore, equals(contentsAfter));
+    });
   });
 }

--- a/test_fixtures/format/exclusions/lib/.dart_tool/main.dart
+++ b/test_fixtures/format/exclusions/lib/.dart_tool/main.dart
@@ -1,0 +1,9 @@
+library main;
+
+List longList = ['one', 'two', 'three', 'four', 'five', 'six', 'seven', 'eight', 'nine', 'ten'];
+
+void doStuff(
+  content
+  )   {
+      print( content );
+}


### PR DESCRIPTION
## Problem
Files in `.dart_tool` were getting formatted, resulting in errors like `ProcessException: Argument list too long` since there were so many.

## Solution
Add an exclude to `.dart_tool`, similar to the ones for `packages` and `.pub`

## Testing
- Verify CI passes