### PR TITLE
AF-2823 Release dart_dev 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.1](https://github.com/Workiva/dart_dev/compare/2.0.0...2.0.1)
+
+_December 11, 2018_
+
+- **Bug Fix:** The format task now ignores the `.dart_tool/` directory. Prior to
+  this, it would try to format `.dart` files in `.dart_tool/`, often resulting
+  in `ProcessException: Argument list too long` errors.
+
 ## [2.0.0](https://github.com/Workiva/dart_dev/compare/1.10.1...2.0.0)
 _October 11, 2018_
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 2.0.0
+version: 2.0.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* [Don't format files in .dart_tool](https://github.com/Workiva/dart_dev/pull/283)


Requested by: @maxwell.peterson

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.0...Workiva:release_dart_dev_2.0.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.0...2.0.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)