### PR TITLE
AF-3695: Quit test task early if dartium or content-shell on Dart 2

### DIFF
--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -170,9 +170,15 @@ Future _run(List<String> args) async {
 
   TaskConfig config = _cliConfigs[task];
   await runAll(config.before);
-  CliResult result =
-      await _cliTasks[task].run(env.command, color: env['color']);
-  await runAll(config.after);
+  CliResult result;
+  try {
+    result = await _cliTasks[task].run(env.command, color: env['color']);
+    await runAll(config.after);
+  } on ArgumentError catch (e) {
+    reporter.error(e.message, shout: true);
+    exitCode = 1;
+    return;
+  }
 
   reporter.log('');
   if (result.successful) {

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -47,6 +47,8 @@ TestTask test(
     } else {
       args.addAll(['run', 'test']);
     }
+  } else {
+    args.addAll(['run', 'test']);
   }
 
   if (concurrency != null) {

--- a/lib/src/tasks/test/api.dart
+++ b/lib/src/tasks/test/api.dart
@@ -32,10 +32,21 @@ TestTask test(
     List<String> tests: const []}) {
   final executable = 'pub';
   final args = <String>[];
-  if (dartMajorVersion == 2 && hasImmediateDependency('build_test')) {
-    args.addAll(['run', 'build_runner', 'test', '--']);
-  } else {
-    args.addAll(['run', 'test']);
+
+  if (dartMajorVersion == 2) {
+    var invalidPlatforms = new Set.from(['dartium', 'content-shell']);
+    var foundInvalidPlatforms =
+        invalidPlatforms.intersection(platforms.toSet());
+    if (foundInvalidPlatforms.isNotEmpty) {
+      throw new ArgumentError(
+          'Test platforms that are incompatible with Dart 2 detected: $foundInvalidPlatforms');
+    }
+
+    if (hasImmediateDependency('build_test')) {
+      args.addAll(['run', 'build_runner', 'test', '--']);
+    } else {
+      args.addAll(['run', 'test']);
+    }
   }
 
   if (concurrency != null) {

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -262,11 +262,13 @@ void main() {
     }, tags: 'dart2-only');
 
     test('should not fail if using dartium on Dart1', () async {
-      expect(await runTests(projectWithPassingTests, platform: 'dartium'), equals(1));
+      expect(await runTests(projectWithPassingTests, platform: 'dartium'),
+          equals(1));
     }, tags: 'dart1-only');
 
     test('should not fail if using content-shell on Dart1', () async {
-      expect(await runTests(projectWithPassingTests, platform: 'content-shell'), equals(1));
+      expect(await runTests(projectWithPassingTests, platform: 'content-shell'),
+          equals(1));
     }, tags: 'dart1-only');
   });
 }

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -45,7 +45,8 @@ Future<int> runTests(String projectPath,
     String testName: '',
     bool runCustomPubServe: false,
     int pubServePort: 56090,
-    String webCompiler}) async {
+    String webCompiler,
+    String platform}) async {
   await Process.run('pub', ['get'], workingDirectory: projectPath);
 
   final args = <String>['run', 'dart_dev', 'test', '--no-color'];
@@ -91,6 +92,10 @@ Future<int> runTests(String projectPath,
   if (webCompiler != null) {
     webCompilerArg = '--web-compiler=${webCompiler}';
     args.add(webCompilerArg);
+  }
+
+  if (platform != null) {
+    args.addAll(['-p', platform]);
   }
 
   TaskProcess process =
@@ -245,5 +250,25 @@ void main() {
           await runTests(projectThatNeedsBuildRunner, expectBuildRunner: true),
           equals(1));
     }, tags: 'dart2-only');
+
+    test('should fail if using dartium on Dart2', () async {
+      expect(runTests(projectWithPassingTests, platform: 'dartium'),
+          throwsA(new isInstanceOf<TestFailure>()));
+    }, tags: 'dart2-only');
+
+    test('should fail if using content-shell on Dart2', () async {
+      expect(runTests(projectWithPassingTests, platform: 'content-shell'),
+          throwsA(new isInstanceOf<TestFailure>()));
+    }, tags: 'dart1-only');
+
+    test('should not fail if using dartium on Dart1', () async {
+      expect(runTests(projectWithPassingTests, platform: 'dartium'),
+          throwsA(new isInstanceOf<TestFailure>()));
+    }, tags: 'dart1-only');
+
+    test('should not fail if using content-shell on Dart1', () async {
+      expect(runTests(projectWithPassingTests, platform: 'content-shell'),
+          throwsA(new isInstanceOf<TestFailure>()));
+    }, tags: 'dart1-only');
   });
 }

--- a/test/integration/test_test.dart
+++ b/test/integration/test_test.dart
@@ -259,16 +259,14 @@ void main() {
     test('should fail if using content-shell on Dart2', () async {
       expect(runTests(projectWithPassingTests, platform: 'content-shell'),
           throwsA(new isInstanceOf<TestFailure>()));
-    }, tags: 'dart1-only');
+    }, tags: 'dart2-only');
 
     test('should not fail if using dartium on Dart1', () async {
-      expect(runTests(projectWithPassingTests, platform: 'dartium'),
-          throwsA(new isInstanceOf<TestFailure>()));
+      expect(await runTests(projectWithPassingTests, platform: 'dartium'), equals(1));
     }, tags: 'dart1-only');
 
     test('should not fail if using content-shell on Dart1', () async {
-      expect(runTests(projectWithPassingTests, platform: 'content-shell'),
-          throwsA(new isInstanceOf<TestFailure>()));
+      expect(await runTests(projectWithPassingTests, platform: 'content-shell'), equals(1));
     }, tags: 'dart1-only');
   });
 }


### PR DESCRIPTION
## Problem:
If the platform is specified as `dartium` or `content-shell` while running tests under Dart 2, we should fail early instead of doing a full build.

## Solution:
Fail early if either platform is specified with an error message

## Testing:
* CI Passes
* Switch to Dart 1, publink this branch into a Dart 1 project, and verify that the test task runs as expected.
* switch to Dart 2, publink this branch into a dart 2 project, and verify that:
	* `ddev test -p dartium` and `ddev test -p content-shell` fail early (before attempting a build
	* `ddev test -p chrome` (or any other platform which is not `dartium` or `content-shell` runs normally.
