### PR TITLE
WIP Quality-of-life improvements for tests with Pub server

### DIFF
--- a/lib/src/tasks/serve/api.dart
+++ b/lib/src/tasks/serve/api.dart
@@ -41,6 +41,8 @@ PubServeTask startPubServe({int port: 0, List<String> additionalArgs}) {
   var task = new PubServeTask('$pubServeExecutable ${pubServeArgs.join(' ')}',
       pubServeInfos.stream, pubServeProcess.done, pubServeProcess.kill);
 
+  task.done.whenComplete(pubServeInfos.close);
+
   pubServeProcess.stdout.listen((String line) {
     task._pubServeStdOut.add(line);
 

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -43,18 +43,20 @@ class TestCli extends TaskCli {
         abbr: 'j',
         defaultsTo: '$defaultConcurrency',
         help: 'The number of concurrent test suites run.')
-    ..addFlag('pub-serve',
-        negatable: true,
-        defaultsTo: defaultPubServe,
-        help: 'Serves browser tests using a Pub server.')
     ..addFlag('pause-after-load',
         help: 'Pauses for debugging before any tests execute.\n'
             'Implies --concurrency=1 and --timeout=none.\n'
             'Currently only supported for browser tests.',
         negatable: false)
+    ..addFlag('pub-serve',
+        negatable: true,
+        defaultsTo: defaultPubServe,
+        help: 'Serves browser tests using a Pub server.')
     ..addOption('pub-serve-port',
-        help:
-            'Port used by the Pub server for browser tests. The default value will randomly select an open port to use.')
+        help: 'The port of the Pub server used for browser tests.\n'
+            'If unspecified, an arbitrary open port will be selected.\n'
+            'Any already running server bound to this port will be used,\n'
+            'and if there is none, a new one will be started automatically.')
     ..addOption('platform',
         abbr: 'p',
         allowMultiple: true,

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -19,6 +19,7 @@ import 'dart:io';
 
 import 'package:ansicolor/ansicolor.dart';
 import 'package:args/args.dart';
+import 'package:dart2_constant/core.dart' as core;
 import 'package:path/path.dart' as p;
 
 import 'package:dart_dev/util.dart' show reporter, isPortBound;
@@ -323,7 +324,7 @@ void printPubServeSpeedMessage(Duration startupTime) {
   final boldWhite = new AnsiPen()..white(bold: true);
   final boldYellow = new AnsiPen()..yellow(bold: true);
   final seconds =
-      (startupTime.inMilliseconds / Duration.MILLISECONDS_PER_SECOND)
+      (startupTime.inMilliseconds / core.Duration.millisecondsPerSecond)
           .toStringAsFixed(1);
   reporter.log('''
 

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -127,9 +127,16 @@ final Map<String, String> dartiumExpirationOverrideEnv = new Map.unmodifiable({
       (_newExpirationDate.millisecondsSinceEpoch / 1000).toStringAsFixed(0),
 });
 
+/// Returns whether the current environment is most likely that of an automated
+/// (continuous integration) build.
+///
+/// Environment variables are used instead of checking the stdout type, since
+/// the way that `pub run dart_dev` invokes `tool/dart_dev.dart` (without
+/// inherited stdio) prevents us of determining whether we're in an interactive
+/// terminal.
 bool inCi() {
   final env = Platform.environment;
-  if (env['CI'] == 'true') return true; // Travis
+  if (env['CI'] == 'true') return true; // Travis, etc.
   if (env['BUILD_ID'] == 'true') return true; // Workiva Build
   return false;
 }

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -126,3 +126,10 @@ final Map<String, String> dartiumExpirationOverrideEnv = new Map.unmodifiable({
   'DARTIUM_EXPIRATION_TIME':
       (_newExpirationDate.millisecondsSinceEpoch / 1000).toStringAsFixed(0),
 });
+
+bool inCi() {
+  final env = Platform.environment;
+  if (env['CI'] == 'true') return true; // Travis
+  if (env['BUILD_ID'] == 'true') return true; // Workiva Build
+  return false;
+}


### PR DESCRIPTION
This is still WIP and needs tests and a better PR description, but the gist of it is:
- Don't emit Pub server output (besides startup logs) to console when running tests locally
- Emit message recommending using a separate Pub server when running tests locally