### PR TITLE
AF-3801 fix reporter runtime error in Dart 2.1.0

### DIFF
--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -93,7 +93,10 @@ class Reporter {
       color && message.isNotEmpty ? pen(message) : message;
 
   void _log(IOSink sink, String message, {bool shout: false}) {
-    if (quiet && !shout) return;
+    // This may look like a strange conditional, but please leave it.
+    // Somehow when using the tearoff `reporter.log` the `quiet` variable
+    // is null, which causes a runtime error when running tests in Dart 2.1.0
+    if (quiet == true && shout != true) return;
     sink.writeln(message);
   }
 }

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -30,7 +30,11 @@ class Reporter {
   bool color = true;
   bool quiet = false;
 
-  Reporter({bool this.color, bool this.quiet});
+  Reporter({this.color: true, this.quiet: false}) {
+    // Do an additional check here to make sure nulls were not passed
+    color ??= true;
+    quiet ??= false;
+  }
 
   String colorBlue(String message) => _color(_blue, message);
 
@@ -93,10 +97,11 @@ class Reporter {
       color && message.isNotEmpty ? pen(message) : message;
 
   void _log(IOSink sink, String message, {bool shout: false}) {
-    // This may look like a strange conditional, but please leave it.
-    // Somehow when using the tearoff `reporter.log` the `quiet` variable
-    // is null, which causes a runtime error when running tests in Dart 2.1.0
-    if (quiet == true && shout != true) return;
+    // Ensure that even if quiet or shout are null, the conditional
+    // will result in a boolean
+    if (quiet == true && shout != true) {
+      return;
+    }
     sink.writeln(message);
   }
 }

--- a/lib/src/reporter.dart
+++ b/lib/src/reporter.dart
@@ -27,22 +27,27 @@ final AnsiPen _red = new AnsiPen()..red();
 final AnsiPen _yellow = new AnsiPen()..yellow();
 
 class Reporter {
-  bool color = true;
-  bool quiet = false;
+  bool _color;
+  bool _quiet;
 
-  Reporter({this.color: true, this.quiet: false}) {
-    // Do an additional check here to make sure nulls were not passed
-    color ??= true;
-    quiet ??= false;
+  Reporter({color: true, quiet: false}) {
+    this.color = color;
+    this.quiet = quiet;
   }
 
-  String colorBlue(String message) => _color(_blue, message);
+  bool get color => _color;
+  bool get quiet => _quiet;
 
-  String colorGreen(String message) => _color(_green, message);
+  set color(bool b) => _color = b ?? true;
+  set quiet(bool b) => _quiet = b ?? false;
 
-  String colorRed(String message) => _color(_red, message);
+  String colorBlue(String message) => _colorMessage(_blue, message);
 
-  String colorYellow(String message) => _color(_yellow, message);
+  String colorGreen(String message) => _colorMessage(_green, message);
+
+  String colorRed(String message) => _colorMessage(_red, message);
+
+  String colorYellow(String message) => _colorMessage(_yellow, message);
 
   void log(String message, {bool shout: false}) {
     _log(stdout, message, shout: shout);
@@ -93,15 +98,11 @@ class Reporter {
     _log(stderr, colorYellow(message), shout: shout);
   }
 
-  String _color(AnsiPen pen, String message) =>
+  String _colorMessage(AnsiPen pen, String message) =>
       color && message.isNotEmpty ? pen(message) : message;
 
   void _log(IOSink sink, String message, {bool shout: false}) {
-    // Ensure that even if quiet or shout are null, the conditional
-    // will result in a boolean
-    if (quiet == true && shout != true) {
-      return;
-    }
+    if (quiet && !shout) return;
     sink.writeln(message);
   }
 }


### PR DESCRIPTION
# Overview
Under Dart 2.1.0, when running tests that use `reporter.log`. The `quiet` variable would be null somehow and cause a runtime error in the conditional check in the `_log` method. 
I imagine this is caused by something like checked mode when running tests. I could not reproduce this runtime error when running a similar thing on the command line (prod mode).

An example failing build due to this error: https://ci.webfilings.com/build/1585120

# Changes
- Don't allow these to variables to be null

# Testing
- CI passes
- See passing build using this branch: https://github.com/Workiva/over_react_format/pull/25