### PR TITLE
AF-3464 Release dart_dev 2.0.2

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 2.0.1
+version: 2.0.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION
Pull Requests included in release:
* [AF-3695: Quit test task early if dartium or content-shell on Dart 2](https://github.com/Workiva/dart_dev/pull/285)
* [AF-3801 fix reporter runtime error in Dart 2.1.0](https://github.com/Workiva/dart_dev/pull/287)

Requested by: @evan.weible

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.1...Workiva:release_dart_dev_2.0.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.1...2.0.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)