### PR TITLE
DOC-5017 Add a flag for Disabling "pub serve" Standard Output for "dart_dev test"

### DIFF
--- a/lib/src/tasks/serve/api.dart
+++ b/lib/src/tasks/serve/api.dart
@@ -26,7 +26,8 @@ final RegExp _servingRegExp =
 /// [PubServeTask].
 ///
 /// If [port] is 0, `pub serve` will pick its own port automatically.
-PubServeTask startPubServe({int port: 0, List<String> additionalArgs}) {
+PubServeTask startPubServe(
+    {int port: 0, List<String> additionalArgs, bool printToStdOut: true}) {
   var pubServeExecutable = 'pub';
   var pubServeArgs = ['serve', '--port=$port'];
   if (additionalArgs != null) {
@@ -42,7 +43,9 @@ PubServeTask startPubServe({int port: 0, List<String> additionalArgs}) {
       pubServeInfos.stream, pubServeProcess.done, pubServeProcess.kill);
 
   pubServeProcess.stdout.listen((String line) {
-    task._pubServeStdOut.add(line);
+    if (printToStdOut) {
+      task._pubServeStdOut.add(line);
+    }
 
     var match = _servingRegExp.firstMatch(line);
     if (match != null) {

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -104,7 +104,7 @@ class TestCli extends TaskCli {
         TaskCli.valueOf('pub-serve', parsedArgs, config.test.pubServe);
 
     bool disablePubStdOut = TaskCli.valueOf(
-        'disable-serve-std-out', parsedArgs, defaultDisableServeStdOut);
+        'disable-serve-std-out', parsedArgs, config.test.disableServeStdOut);
 
     var pubServePort =
         TaskCli.valueOf('pub-serve-port', parsedArgs, config.test.pubServePort);

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -38,6 +38,9 @@ class TestCli extends TaskCli {
     ..addFlag('functional',
         defaultsTo: defaultFunctional,
         help: 'Includes the functional test suite.')
+    ..addFlag('disable-serve-std-out',
+        defaultsTo: defaultDisableServeStdOut,
+        help: 'Disables standard output for pub serve task.')
     ..addOption('concurrency',
         abbr: 'j',
         defaultsTo: '$defaultConcurrency',
@@ -99,6 +102,9 @@ class TestCli extends TaskCli {
 
     bool pubServe =
         TaskCli.valueOf('pub-serve', parsedArgs, config.test.pubServe);
+
+    bool disablePubStdOut = TaskCli.valueOf(
+        'disable-serve-std-out', parsedArgs, defaultDisableServeStdOut);
 
     var pubServePort =
         TaskCli.valueOf('pub-serve-port', parsedArgs, config.test.pubServePort);
@@ -193,8 +199,10 @@ A pub serve instance will not be started.''');
             pubServeArgs.add('--web-compiler=${parsedArgs['web-compiler']}');
           }
 
-          pubServeTask =
-              startPubServe(port: pubServePort, additionalArgs: pubServeArgs);
+          pubServeTask = startPubServe(
+              port: pubServePort,
+              additionalArgs: pubServeArgs,
+              printToStdOut: !disablePubStdOut);
 
           var startupLogFinished = new Completer();
           reporter.logGroup(pubServeTask.command,

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -40,5 +40,6 @@ class TestConfig extends TaskConfig {
   List<String> platforms = defaultPlatforms;
   bool pubServe = defaultPubServe;
   int pubServePort = defaultPubServePort;
+  bool disableServeStdOut = defaultDisableServeStdOut;
   List<String> unitTests = defaultUnitTests;
 }

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -21,6 +21,7 @@ const List defaultBeforeFunctional = const [];
 const int defaultConcurrency = 4;
 const bool defaultPauseAfterLoad = false;
 const bool defaultPubServe = false;
+const bool defaultDisableServeStdOut = false;
 const int defaultPubServePort = 0;
 const bool defaultIntegration = false;
 const bool defaultFunctional = false;


### PR DESCRIPTION
Hides all the ```pub serve``` clutter when running tests locally.