### PR TITLE
CPLAT-4822: Fail test task if `build_runner build` fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [2.0.4](https://github.com/Workiva/dart_dev/compare/2.0.3...2.0.4)
+
+- **Bug Fix:** When on Dart 2 and the package has a dependency on `build_test`,
+  the `test` task will now properly exit with a non-zero exit code if the build
+  fails.
+
+## [2.0.3](https://github.com/Workiva/dart_dev/compare/2.0.2...2.0.3)
+
+- **Feature:** Use `--disable-serve-std-out` or set
+  `config.test.disableServeStdOut = true` with the `test` task to silence the
+  pub serve output.
+
+## [2.0.2](https://github.com/Workiva/dart_dev/compare/2.0.1...2.0.2)
+
+- **Improvement:** The test task now fails early if running on Dart 2 with
+  either the `dartium` or `content-shell` platforms are selected.
+
+- **Bug Fix:** Prevent a null exception in the reporter when running on Dart
+  >=2.1.0.
+
 ## [2.0.1](https://github.com/Workiva/dart_dev/compare/2.0.0...2.0.1)
 
 _December 11, 2018_

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -18,7 +18,8 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 
-import 'package:dart_dev/util.dart' show reporter, isPortBound;
+import 'package:dart_dev/util.dart'
+    show hasImmediateDependency, isPortBound, reporter, TaskProcess;
 
 import 'package:dart_dev/src/platform_util/api.dart' as platform_util;
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -181,6 +182,17 @@ class TestCli extends TaskCli {
 
     if (pauseAfterLoad) {
       testArgs.add('--pause-after-load');
+    }
+
+    if (dartMajorVersion == 2 && hasImmediateDependency('build_test')) {
+      final buildProcess =
+          new TaskProcess('pub', ['run', 'build_runner', 'build']);
+      reporter.logGroup('pub run build_runner build',
+          outputStream: buildProcess.stdout, errorStream: buildProcess.stderr);
+      final buildExitCode = await buildProcess.exitCode;
+      if (buildExitCode != 0) {
+        return new CliResult.fail('Build failed - cannot run tests.');
+      }
     }
 
     PubServeTask pubServeTask;

--- a/test/integration/dart_x_only_test.dart
+++ b/test/integration/dart_x_only_test.dart
@@ -131,7 +131,7 @@ void main() {
       });
 
       test('runs an executable', () async {
-        final result = await runDart2Only(['dartdoc']);
+        final result = await runDart2Only(['pub']);
         expect(result.skipped, isFalse);
         expect(result.exitCode, 0);
       });


### PR DESCRIPTION
# [CPLAT-4822](https://jira.atl.workiva.net/browse/CPLAT-4822)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-4822)

## Problem

On Dart 2, the `test` task currently runs tests via `build_runner test`, but unfortunately this command does not exit with a non-zero exit code if the build fails, which means that the dart_dev `test` task can appear as though it passed when in fact no tests were even run.

## Solution

When necessary, run `build runner build` first and fail early if it exits with a non-zero exit code. If it succeeds, then we can proceed to run the tests via `build_runner test`, knowing that they will actually run.

## Testing

- [ ] CI passes
- [ ] Verify this behavior against the latest react_tracing dart2 branch, which is where we discovered this issue

## Code Review
@maxwellpeterson-wf @smaifullerton-wk @seanburke-wf 