### PR TITLE
CPLAT-3893 Release dart_dev 2.0.4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 2.0.3
+version: 2.0.4
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* [CPLAT-4822: Fail test task if `build_runner build` fails](https://github.com/Workiva/dart_dev/pull/291)


Requested by: @evan.weible

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.3...Workiva:release_dart_dev_2.0.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.3...2.0.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)