### PR TITLE
Pass serialized config to custom tasks via an environment variable

### DIFF
--- a/lib/src/tasks/config.dart
+++ b/lib/src/tasks/config.dart
@@ -14,6 +14,8 @@
 
 library dart_dev.src.tasks.config;
 
+import 'dart:convert';
+
 import 'package:dart_dev/src/tasks/analyze/config.dart';
 import 'package:dart_dev/src/tasks/bash_completion/config.dart';
 import 'package:dart_dev/src/tasks/copy_license/config.dart';
@@ -59,4 +61,18 @@ class Config {
 class TaskConfig {
   List after = [];
   List before = [];
+}
+
+String serializeConfig({bool pretty: false}) {
+  return new JsonEncoder.withIndent(pretty ? '  ' : null, (obj) {
+    // Attempt to convert the config into JSON.
+    try {
+      return obj.toJson();
+    } catch (_) {}
+
+    // If the given object doesn't support JSON serialization, skip it.
+    // This allows us to not implement serialization in all configs up-front,
+    // as well as not break for parts of the config that can't be serialized.
+    return null;
+  }).convert(config);
 }

--- a/lib/src/tasks/export_config/cli.dart
+++ b/lib/src/tasks/export_config/cli.dart
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:args/args.dart';
 import 'package:dart_dev/dart_dev.dart';
+import 'package:dart_dev/src/tasks/config.dart';
 import 'package:dart_dev/util.dart' show reporter;
 
 class ExportConfigCli extends TaskCli {
@@ -28,17 +28,7 @@ class ExportConfigCli extends TaskCli {
 
   @override
   Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
-    reporter.log(new JsonEncoder.withIndent('  ', (obj) {
-      // Attempt to convert the config into JSON.
-      try {
-        return obj.toJson();
-      } catch (_) {}
-
-      // If the given object doesn't support JSON serialization, skip it.
-      // This allows us to not implement serialization in all configs up-front,
-      // as well as not break for parts of the config that can't be serialized.
-      return null;
-    }).convert(config));
+    reporter.log(serializeConfig());
 
     return new CliResult.success();
   }

--- a/lib/src/tasks/local/api.dart
+++ b/lib/src/tasks/local/api.dart
@@ -18,10 +18,14 @@ import 'dart:async';
 
 import 'package:dart_dev/util.dart' show TaskProcess;
 
+import 'package:dart_dev/src/tasks/config.dart';
 import 'package:dart_dev/src/tasks/task.dart';
 
 LocalTask local(String executable, Iterable<String> args) {
-  TaskProcess process = new TaskProcess(executable, args);
+  TaskProcess process = new TaskProcess(executable, args, environment: {
+    // Make a serialized version of the config available to this task.
+    'dart_dev_config': serializeConfig(),
+  });
 
   LocalTask task = new LocalTask('$executable ${args.join(' ')}',
       Future.wait([process.done]).then((_) => null));


### PR DESCRIPTION
## Motivation
Allow custom tasks to be able to read config without running `dart_dev export-config` (which currently takes a couple seconds due to pub/dart_dev startup time)

## Solution
Somehow pass config to child custom tasks via environment variables