### PR TITLE
CPLAT-4831 Release dart_dev 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.0.5](https://github.com/Workiva/dart_dev/compare/2.0.4...2.0.5)
+
+- **Improvement:** Added `config.test.deleteConflictingOutputs` that when
+  enabled will include the `--delete-conflicting-outputs` flag when running
+  tests via `build_runner`.
+
+- **Bug Fix:** Fix a type-related RTE in the `TaskProcess` class.
+
 ## [2.0.4](https://github.com/Workiva/dart_dev/compare/2.0.3...2.0.4)
 
 - **Bug Fix:** When on Dart 2 and the package has a dependency on `build_test`,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 2.0.4
+version: 2.0.5
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-3300: CP Code Review and PR Merging Team agreement update](https://github.com/Workiva/dart_dev/pull/295)
	* [CPLAT-6014 Fix Dart2 RTE](https://github.com/Workiva/dart_dev/pull/299)
	* [Add test config option to delete conflicting outputs by default in Dart 2](https://github.com/Workiva/dart_dev/pull/300)
	* [CPLAT-6078: Commit dart1 pubspec.lock files for all test fixtures.](https://github.com/Workiva/dart_dev/pull/301)


Requested by: @smaifullerton-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.4...Workiva:release_dart_dev_2.0.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.4...2.0.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)