### PR TITLE
CPLAT-6086 Release dart_dev 2.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.0.6](https://github.com/Workiva/dart_dev/compare/2.0.5...2.0.6)
+
+- **Improvement:** On dart 2, the `test` task now properly sets a non-zero
+  exit code if the build fails. As a result, it also no longer runs a separate
+  `pub run build_runner build` prior to running tests.
+
 ## [2.0.5](https://github.com/Workiva/dart_dev/compare/2.0.4...2.0.5)
 
 - **Improvement:** Added `config.test.deleteConflictingOutputs` that when

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 2.0.5
+version: 2.0.6
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Fix result when test task fails so that correct exit code is returned](https://github.com/Workiva/dart_dev/pull/303)


Requested by: @smaifullerton-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/2.0.5...Workiva:release_dart_dev_2.0.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/2.0.5...2.0.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)