### PR TITLE
CPLAT-6218 Add sass task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ test_reports/
 /test_fixtures/docs/docs/doc/api/
 /test_fixtures/format/changes_needed_temp/
 /test_fixtures/needs_build_runner/.dart_tool
+/test_fixtures/sass/fake_consumer_package
+/test_fixtures/coverage/functional_test/pubspec.lock

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ development requirements:
 - Consistent code formatting
 - Static analysis to detect issues
 - Documentation generation
+- CSS generation using the Dart Sass compiler
 - Examples for manual testing/exploration
 - Applying a LICENSE file to all source files
 - Running dart unit tests on Sauce Labs
@@ -85,6 +86,7 @@ local tasks.
 - **Coverage:** collects coverage over test suites (unit, integration, and functional) and generates a report. Uses the [`coverage` package](https://github.com/dart-lang/coverage).
 - **Code Formatting:** runs the [`dartfmt` tool from the `dart_style` package](https://github.com/dart-lang/dart_style) over source code.
 - **Static Analysis:** runs the [`dartanalyzer`](https://www.dartlang.org/tools/analyzer/) over source code.
+- **Compiling Sass:** runs the [`compile_sass` tool from the `w_common` package](https://github.com/workiva/w_common).
 - **Applying a License to Source Files:** copies a LICENSE file to all applicable files.
 - **Generate a test runner file:** that allows for faster test execution.
 - **Running dart unit tests on Sauce Labs:** compiles dart unit tests that can be run in the browser and executes them on various platforms using Sauce Labs.
@@ -240,6 +242,7 @@ ddev format
 ddev gen-test-runner
 ddev task-runner
 ddev test
+ddev sass
 
 # without the alias
 pub run dart_dev analyze
@@ -249,6 +252,7 @@ pub run dart_dev format
 pub run dart_dev gen-test-runner
 pub run dart_dev task-runner
 pub run dart_dev test
+pub run dart_dev sass
 ```
 
 Add the `-h` flag to any of the above commands to receive additional help

--- a/bin/compile_sass_proxy.dart
+++ b/bin/compile_sass_proxy.dart
@@ -1,0 +1,41 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A proxy for the `compile_sass` executable from w_common.
+///
+/// Present so that dart_dev consumers do not have to have a direct dependency
+/// on w_common in order to run `pub run dart_dev sass`.
+///
+/// __Do not run directly - run `pub run dart_dev sass` instead.__
+library dart_dev.bin.compile_sass_proxy;
+
+import 'dart:io';
+
+import 'package:dart_dev/src/tasks/sass/api.dart'
+    show intentionalInternalProxyArg;
+import 'package:dart_dev/util.dart' show reporter;
+import 'package:w_common/sass.dart' as wc_compile_sass;
+
+main(List<String> args) async {
+  if (!args.contains(intentionalInternalProxyArg)) {
+    exitCode = 1;
+    reporter.error(
+        '[UNSUPPORTED]: Do not run `pub run dart_dev compile_sass_proxy` directly.\n\n'
+        'Run `pub run dart_dev sass` instead.');
+    return;
+  }
+
+  args.remove(intentionalInternalProxyArg);
+  await wc_compile_sass.main(args);
+}

--- a/lib/src/dart_dev_cli.dart
+++ b/lib/src/dart_dev_cli.dart
@@ -18,6 +18,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:dart_dev/src/tasks/sass/cli.dart';
 import 'package:dart_dev/util.dart' show reporter;
 
 import 'package:dart_dev/src/tasks/cli.dart';
@@ -63,6 +64,7 @@ dev(List<String> args) async {
   registerTask(new InitCli(), config.init);
   registerTask(new TaskRunnerCli(), config.taskRunner);
   registerTask(new TestCli(), config.test);
+  registerTask(new SassCli(), config.sass);
 
   try {
     LocalCli.discover(config.local.taskPaths).forEach((task, exec) {

--- a/lib/src/tasks/config.dart
+++ b/lib/src/tasks/config.dart
@@ -22,6 +22,7 @@ import 'package:dart_dev/src/tasks/dart_x_only/config.dart';
 import 'package:dart_dev/src/tasks/format/config.dart';
 import 'package:dart_dev/src/tasks/gen_test_runner/config.dart';
 import 'package:dart_dev/src/tasks/init/config.dart';
+import 'package:dart_dev/src/tasks/sass/config.dart';
 import 'package:dart_dev/src/tasks/task_runner/config.dart';
 import 'package:dart_dev/src/tasks/test/config.dart';
 import 'package:dart_dev/src/tasks/local/config.dart';
@@ -41,6 +42,7 @@ class Config {
   InitConfig init = new InitConfig();
   TaskRunnerConfig taskRunner = new TaskRunnerConfig();
   TestConfig test = new TestConfig();
+  SassConfig sass = new SassConfig();
 
   Map<String, dynamic> toJson() => {
         'analyze': analyze,
@@ -53,6 +55,7 @@ class Config {
         'init': init,
         'taskRunner': taskRunner,
         'test': test,
+        'sass': sass,
       };
 }
 

--- a/lib/src/tasks/sass/api.dart
+++ b/lib/src/tasks/sass/api.dart
@@ -1,0 +1,111 @@
+// Copyright 2015 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library dart_dev.src.tasks.format.api;
+
+import 'dart:async';
+
+import 'package:args/args.dart';
+import 'package:dart_dev/src/tasks/sass/cli.dart';
+import 'package:meta/meta.dart';
+import 'package:w_common/sass.dart' as wc;
+import 'package:dart_dev/util.dart' show TaskProcess;
+
+import 'package:dart_dev/src/tasks/task.dart';
+
+const String intentionalInternalProxyArg = '--iprx=true';
+
+SassTask sass({
+  @required String sourceDir,
+  @required String outputDir,
+  @required List<String> watchDirs,
+  bool release: false,
+  bool preReleaseCheck: false,
+  ArgResults parsedArgs,
+}) {
+  var executable = 'pub';
+  var args = <String>[
+    'run',
+    'dart_dev:compile_sass_proxy',
+    intentionalInternalProxyArg,
+  ];
+
+  final reservedArgs = <String, dynamic>{
+    '--${wc.sourceDirArg}': sourceDir,
+    '--${wc.outputDirArg}': outputDir,
+    '--${wc.watchDirsArg}': watchDirs,
+    '--${wc.outputStyleArg}': release ? 'compressed' : 'expanded',
+    // Make sure the file name matches the un-minified checked in source when the release option is set.
+    '--${wc.compressedOutputStyleFileExtensionArg}': release
+        ? parsedArgs[wc.expandedOutputStyleFileExtensionArg]
+        : parsedArgs[wc.compressedOutputStyleFileExtensionArg],
+  };
+
+  reservedArgs.forEach((argName, argValue) {
+    if (argValue != null) {
+      if (argName == '--${wc.outputDirArg}' &&
+          argValue == reservedArgs['--${wc.sourceDirArg}']) return;
+      if (argName == '--${wc.compressedOutputStyleFileExtensionArg}' &&
+          argValue == '--${wc.compressedOutputStyleFileExtensionDefaultValue}')
+        return;
+      if (argName == '--${wc.expandedOutputStyleFileExtensionArg}' &&
+          argValue == '--${wc.expandedOutputStyleFileExtensionDefaultValue}')
+        return;
+
+      args.add('$argName=$argValue');
+    }
+  });
+
+  for (var arg in parsedArgs.arguments
+      .where((_arg) => !reservedArgs.keys.any((key) => _arg.startsWith(key)))) {
+    if (arg == '--$releaseArgName' || arg == '-$releaseArgAbbr') continue;
+
+    args.add(arg);
+  }
+
+  for (var arg in parsedArgs.rest
+      .where((_arg) => !reservedArgs.keys.any((key) => _arg.startsWith(key)))) {
+    args.add(arg);
+  }
+
+  if (preReleaseCheck) {
+    args
+      ..removeWhere((arg) => arg.contains('--${wc.outputStyleArg}'))
+      ..add('--${wc.outputStyleArg}=expanded')
+      ..add('--check');
+  }
+
+  final process = new TaskProcess(executable, args);
+  final task = new SassTask(
+      '$executable ${args.join(' ')}', process.done.then((_) => null));
+  process.stdout.listen(task._sassOutput.add);
+  process.stderr.listen(task._sassOutput.addError);
+  process.exitCode.then((code) {
+    task.successful = code <= 0;
+  });
+
+  return task;
+}
+
+class SassTask extends Task {
+  @override
+  final Future<Null> done;
+  final String sassCommand;
+
+  StreamController<String> _sassOutput = new StreamController();
+
+  SassTask(String this.sassCommand, this.done);
+
+  Stream<String> get sassOutput => _sassOutput.stream;
+}

--- a/lib/src/tasks/sass/cli.dart
+++ b/lib/src/tasks/sass/cli.dart
@@ -1,0 +1,103 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library dart_dev.src.tasks.sass.cli;
+
+import 'dart:async';
+
+import 'package:args/args.dart';
+import 'package:dart_dev/util.dart' show reporter;
+import 'package:w_common/sass.dart' as wc;
+
+import 'package:dart_dev/src/tasks/sass/api.dart';
+import 'package:dart_dev/src/tasks/cli.dart';
+import 'package:dart_dev/src/tasks/config.dart';
+
+const String releaseArgName = 'release';
+const String releaseArgAbbr = 'r';
+
+class SassCli extends TaskCli {
+  @override
+  final ArgParser argParser = wc.sassCliArgs
+    ..addSeparator('-' * 80)
+    ..addFlag(releaseArgName,
+        negatable: false,
+        abbr: releaseArgAbbr,
+        help:
+            'Whether to compile minified CSS for bundling with a pub package. \n'
+            'Typically only set during a CI run. \n'
+            'A check of the unminified output will be performed first.');
+
+  @override
+  final String command = 'sass';
+
+  @override
+  String get usage =>
+      '${super.usage} [.scss file(s)...] \n\n${argParser.usage}';
+
+  @override
+  Future<CliResult> run(ArgResults parsedArgs, {bool color: true}) async {
+    bool help = TaskCli.valueOf('help', parsedArgs, false);
+    if (help) {
+      print(usage);
+      return new CliResult.success();
+    }
+
+    String sourceDir =
+        TaskCli.valueOf(wc.sourceDirArg, parsedArgs, config.sass.sourceDir);
+    String outputDir = TaskCli.valueOf(
+        wc.outputDirArg, parsedArgs, config.sass.outputDir ?? sourceDir);
+    List<String> watchDirs =
+        TaskCli.valueOf(wc.watchDirsArg, parsedArgs, config.sass.watchDirs);
+    bool release =
+        TaskCli.valueOf(releaseArgName, parsedArgs, config.sass.release);
+
+    if (release && !parsedArgs['help']) {
+      // If running in "release mode", we want to first run a check on the committed (unminified) CSS output
+      // and then immediately run it again to generate a minified copy using the same .scss sources to be
+      // tar'd up for pub package assets in CI
+      SassTask checkTask = sass(
+        sourceDir: sourceDir,
+        outputDir: outputDir,
+        watchDirs: watchDirs,
+        release: false,
+        preReleaseCheck: true,
+        parsedArgs: parsedArgs,
+      );
+      if (checkTask.sassCommand != null) {
+        reporter.logGroup(checkTask.sassCommand,
+            outputStream: checkTask.sassOutput);
+      }
+      await checkTask.done;
+
+      if (!checkTask.successful) return new CliResult.fail();
+    }
+
+    SassTask task = sass(
+      sourceDir: sourceDir,
+      outputDir: outputDir,
+      watchDirs: watchDirs,
+      release: release,
+      parsedArgs: parsedArgs,
+    );
+    if (task.sassCommand != null) {
+      reporter.logGroup(task.sassCommand, outputStream: task.sassOutput);
+    }
+    await task.done;
+
+    if (!task.successful) return new CliResult.fail('Sass compilation failed.');
+
+    return new CliResult.success('Sass compilation completed successfully');
+  }
+}

--- a/lib/src/tasks/sass/config.dart
+++ b/lib/src/tasks/sass/config.dart
@@ -1,0 +1,33 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library dart_dev.src.tasks.sass.config;
+
+import 'package:w_common/sass.dart' as wc;
+
+import 'package:dart_dev/src/tasks/config.dart';
+
+class SassConfig extends TaskConfig {
+  String sourceDir = wc.sourceDirDefaultValue;
+  String outputDir;
+  List<String> watchDirs;
+  bool release = false;
+
+  Map<String, dynamic> toJson() => {
+        'sourceDir': sourceDir,
+        'outputDir': outputDir,
+        'watchDirs': watchDirs,
+        'minify': false,
+      };
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,14 +15,17 @@ dependencies:
   args: '>=0.13.7 <2.0.0'
   dart2_constant: ^1.0.1
   path: ^1.3.6
+  meta: ^1.0.0
   resource: '>=1.0.0 <3.0.0'
   uuid: '>=0.5.0 <2.0.0'
+  w_common: ^1.19.0
   yaml: ^2.1.0
 
 dev_dependencies:
   coverage: '>=0.9.3 <0.13.0'
   dart_style: ^1.0.7
   dependency_validator: ^1.1.0
+  glob: ^1.1.7
   test: '>=0.12.24 <2.0.0'
 
 executables:
@@ -34,3 +37,4 @@ environment:
 transformers:
   - test/pub_serve:
       $include: test/**_test{.*,}.dart
+

--- a/test/integration/sass_test.dart
+++ b/test/integration/sass_test.dart
@@ -1,0 +1,328 @@
+@TestOn('vm')
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:w_common/sass.dart' as wc;
+
+import '../utils/sass_task_test_utils.dart';
+
+void main() {
+  group('sass task', () {
+    setUpAll(() async {
+      consumerPackageFixtureInstance = new ConsumerPackageFixture();
+      consumerPackageFixtureInstance.generate();
+      final ProcessResult initialPubGetProcess = await Process.run(
+          'pub', ['get'],
+          workingDirectory: consumerPackageFixtureInstance.projectRoot);
+      expect(initialPubGetProcess.exitCode, 0,
+          reason:
+              '\nInitial pub get failed in the ${consumerPackageFixtureInstance.projectRoot} directory: \n${initialPubGetProcess.stderr}');
+    });
+
+    tearDownAll(() {
+      consumerPackageFixtureInstance.destroy();
+      consumerPackageFixtureInstance = null;
+    });
+
+    test(
+        'should compile sass using the default sourceDir when no config is present',
+        () async {
+      simulatePkgWithNoSassConfig();
+      final expectedCssDirectoryPath = path.join(
+          consumerPackageFixtureInstance.projectRoot, wc.outputDirDefaultValue);
+      expect(
+          new File(path.join(expectedCssDirectoryPath, 'test.scss'))
+              .existsSync(),
+          isTrue,
+          reason:
+              'test.scss must exist within $expectedCssDirectoryPath for this test to be valid');
+
+      final result = await compileConsumerSass();
+      expect(result.exitCode, 0, reason: result.stdErr);
+      sharedCssOutputExpectations(expectedCssDirectoryPath);
+    });
+
+    group('should compile sass as expected when a sourceDir is specified', () {
+      setUp(() {
+        expect(wc.sourceDirDefaultValue, isNot(nonDefaultSourceDir),
+            reason:
+                'This test has no point if the sourceDir is being set to the same path as what the script defaults to');
+      });
+
+      test('via the `config.sass.sourceDir` value in dev.dart', () async {
+        simulatePkgWithCustomSourceDirWithSassConfig();
+        final expectedCssDirectoryPath = path.join(
+            consumerPackageFixtureInstance.projectRoot, nonDefaultSourceDir);
+        expect(
+            new File(path.join(expectedCssDirectoryPath, 'test.scss'))
+                .existsSync(),
+            isTrue,
+            reason:
+                'test.scss must exist within $expectedCssDirectoryPath for this test to be valid');
+
+        final result = await compileConsumerSass();
+        expect(result.exitCode, 0, reason: result.stdErr);
+        sharedCssOutputExpectations(expectedCssDirectoryPath);
+      });
+
+      group('via CLI argument', () {
+        test('when there is no `config.sass.sourceDir` value in dev.dart',
+            () async {
+          simulatePkgWithCustomSourceDirWithoutSassConfig();
+          final expectedCssDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultSourceDir);
+          expect(
+              new File(path.join(expectedCssDirectoryPath, 'test.scss'))
+                  .existsSync(),
+              isTrue,
+              reason:
+                  'test.scss must exist within $expectedCssDirectoryPath for this test to be valid');
+
+          final result = await compileConsumerSass(
+              additionalArgs: ['--sourceDir=$nonDefaultSourceDir']);
+          expect(result.exitCode, 0, reason: result.stdErr);
+          sharedCssOutputExpectations(expectedCssDirectoryPath);
+        });
+
+        test(
+            'when there is a different `config.sass.sourceDir` value in dev.dart',
+            () async {
+          simulatePkgWithCustomSourceDirWithOverriddenSassConfig();
+          final expectedCssDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultSourceDir);
+          expect(
+              new File(path.join(expectedCssDirectoryPath, 'test.scss'))
+                  .existsSync(),
+              isTrue,
+              reason:
+                  'test.scss must exist within $expectedCssDirectoryPath for this test to be valid');
+
+          final result = await compileConsumerSass(
+              additionalArgs: ['--sourceDir=$nonDefaultSourceDir']);
+          expect(result.exitCode, 0, reason: result.stdErr);
+          sharedCssOutputExpectations(expectedCssDirectoryPath);
+        });
+      });
+    });
+
+    group('should compile sass as expected when an outputDir is specified', () {
+      setUp(() {
+        expect(wc.outputDirDefaultValue, isNot(nonDefaultOutputDir),
+            reason:
+                'This test has no point if the outputDir is being set to the same path as what the script defaults to');
+      });
+
+      test('via the `config.sass.outputDir` value in dev.dart', () async {
+        simulatePkgWithCustomOutputDirWithSassConfig();
+        final expectedCssDirectoryPath = path.join(
+            consumerPackageFixtureInstance.projectRoot, nonDefaultOutputDir);
+        final expectedSourceDirectoryPath = path.join(
+            consumerPackageFixtureInstance.projectRoot,
+            wc.sourceDirDefaultValue);
+        expect(
+            new File(path.join(expectedSourceDirectoryPath, 'test.scss'))
+                .existsSync(),
+            isTrue,
+            reason:
+                'test.scss must exist within $expectedSourceDirectoryPath for this test to be valid');
+        createNonDefaultOutputDir(expectedCssDirectoryPath);
+
+        final result = await compileConsumerSass();
+        expect(result.exitCode, 0, reason: result.stdErr);
+        sharedCssOutputExpectations(expectedCssDirectoryPath);
+      });
+
+      group('via CLI argument', () {
+        test('when there is no `config.sass.outputDir` value in dev.dart',
+            () async {
+          simulatePkgWithNoSassConfig();
+          final expectedCssDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultOutputDir);
+          final expectedSourceDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot,
+              wc.sourceDirDefaultValue);
+          expect(
+              new File(path.join(expectedSourceDirectoryPath, 'test.scss'))
+                  .existsSync(),
+              isTrue,
+              reason:
+                  'test.scss must exist within $expectedSourceDirectoryPath for this test to be valid');
+          createNonDefaultOutputDir(expectedCssDirectoryPath);
+
+          final result = await compileConsumerSass(
+              additionalArgs: ['--outputDir=$nonDefaultOutputDir']);
+          expect(result.exitCode, 0, reason: result.stdErr);
+          sharedCssOutputExpectations(expectedCssDirectoryPath);
+        });
+
+        test(
+            'when there is a different `config.sass.sourceDir` value in dev.dart',
+            () async {
+          simulatePkgWithCustomOutputDirWithOverriddenSassConfig();
+          final expectedCssDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultOutputDir);
+          final expectedSourceDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot,
+              wc.sourceDirDefaultValue);
+          expect(
+              new File(path.join(expectedSourceDirectoryPath, 'test.scss'))
+                  .existsSync(),
+              isTrue,
+              reason:
+                  'test.scss must exist within $expectedSourceDirectoryPath for this test to be valid');
+          createNonDefaultOutputDir(expectedCssDirectoryPath);
+
+          final result = await compileConsumerSass(
+              additionalArgs: ['--outputDir=$nonDefaultOutputDir']);
+          expect(result.exitCode, 0, reason: result.stdErr);
+          sharedCssOutputExpectations(expectedCssDirectoryPath);
+        });
+      });
+    });
+
+    group(
+        'should compile sass as expected when sourceDir and outputDir are both specified',
+        () {
+      setUp(() {
+        expect(wc.sourceDirDefaultValue, isNot(nonDefaultSourceDir),
+            reason:
+                'This test has no point if the sourceDir is being set to the same path as what the script defaults to');
+        expect(wc.outputDirDefaultValue, isNot(nonDefaultOutputDir),
+            reason:
+                'This test has no point if the outputDir is being set to the same path as what the script defaults to');
+      });
+
+      test('via the `config.sass` values in dev.dart', () async {
+        simulatePkgWithCustomSourceAndOutputDirWithSassConfig();
+        final expectedCssDirectoryPath = path.join(
+            consumerPackageFixtureInstance.projectRoot, nonDefaultOutputDir);
+        final expectedSourceDirectoryPath = path.join(
+            consumerPackageFixtureInstance.projectRoot, nonDefaultSourceDir);
+        expect(
+            new File(path.join(expectedSourceDirectoryPath, 'test.scss'))
+                .existsSync(),
+            isTrue,
+            reason:
+                'test.scss must exist within $expectedSourceDirectoryPath for this test to be valid');
+        createNonDefaultOutputDir(expectedCssDirectoryPath);
+
+        final result = await compileConsumerSass();
+        expect(result.exitCode, 0, reason: result.stdErr);
+        sharedCssOutputExpectations(expectedCssDirectoryPath);
+      });
+
+      group('via CLI argument', () {
+        test('when there is no `config.sass.sourceDir` value in dev.dart',
+            () async {
+          simulatePkgWithCustomSourceAndOutputDirWithoutSassConfig();
+          final expectedCssDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultOutputDir);
+          final expectedSourceDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultSourceDir);
+          expect(
+              new File(path.join(expectedSourceDirectoryPath, 'test.scss'))
+                  .existsSync(),
+              isTrue,
+              reason:
+                  'test.scss must exist within $expectedSourceDirectoryPath for this test to be valid');
+          createNonDefaultOutputDir(expectedCssDirectoryPath);
+
+          final result = await compileConsumerSass(additionalArgs: [
+            '--sourceDir=$nonDefaultSourceDir',
+            '--outputDir=$nonDefaultOutputDir',
+          ]);
+          expect(result.exitCode, 0, reason: result.stdErr);
+          sharedCssOutputExpectations(expectedCssDirectoryPath);
+        });
+
+        test(
+            'when there is a different `config.sass.sourceDir` value in dev.dart',
+            () async {
+          simulatePkgWithCustomSourceAndOutputDirWithOverriddenSassConfig();
+          final expectedCssDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultOutputDir);
+          final expectedSourceDirectoryPath = path.join(
+              consumerPackageFixtureInstance.projectRoot, nonDefaultSourceDir);
+          expect(
+              new File(path.join(expectedSourceDirectoryPath, 'test.scss'))
+                  .existsSync(),
+              isTrue,
+              reason:
+                  'test.scss must exist within $expectedSourceDirectoryPath for this test to be valid');
+          createNonDefaultOutputDir(expectedCssDirectoryPath);
+
+          final result = await compileConsumerSass(additionalArgs: [
+            '--sourceDir=$nonDefaultSourceDir',
+            '--outputDir=$nonDefaultOutputDir',
+          ]);
+          expect(result.exitCode, 0, reason: result.stdErr);
+          sharedCssOutputExpectations(expectedCssDirectoryPath);
+        });
+      });
+    });
+
+    group('when the -r flag is set', () {
+      group('should verify that the checked-in unminified source is up-to-date',
+          () {
+        String generatedCssFilePath;
+        String scssSourceFilePath;
+        File generatedCssFile;
+
+        setUp(() {
+          simulatePkgWithNoSassConfig();
+        });
+
+        group('and compile a minified version of the file if it is', () {
+          setUp(() async {
+            final sourceDir = path.join(
+                consumerPackageFixtureInstance.projectRoot,
+                consumerPackageFixtureInstance.sourceDir);
+            scssSourceFilePath = path.join(sourceDir, 'test.scss');
+            generatedCssFilePath = path.join(sourceDir, 'test.css');
+            await compileConsumerSass();
+            generatedCssFile = new File(generatedCssFilePath);
+            expect(generatedCssFile.existsSync(), isTrue,
+                reason: '$generatedCssFilePath should have been generated');
+            expect(
+                generatedCssFile.readAsStringSync(), expectedUnMinifiedSource,
+                reason:
+                    'The unminified CSS source is different than what these tests will expect');
+          });
+
+          test('', () async {
+            final result = await compileConsumerSass(additionalArgs: ['-r']);
+            expect(result.exitCode, 0, reason: result.stdErr);
+
+            generatedCssFile = new File(generatedCssFilePath);
+            expect(generatedCssFile.existsSync(), isTrue,
+                reason: '$generatedCssFilePath should have been generated');
+            expect(generatedCssFile.readAsStringSync(), expectedMinifiedSource,
+                reason: 'The CSS source should have been minified');
+          });
+        });
+
+        test('and fail the build if it is not', () async {
+          new File(scssSourceFilePath)
+              .writeAsStringSync('.modified { display: none; }');
+          final result = await compileConsumerSass(additionalArgs: ['-r']);
+          expect(result.exitCode, isNot(0));
+        });
+      });
+    });
+  });
+}

--- a/test/utils/sass_task_test_utils.dart
+++ b/test/utils/sass_task_test_utils.dart
@@ -1,0 +1,307 @@
+// Copyright 2019 Workiva Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:dart_dev/util.dart' show TaskProcess;
+import 'package:w_common/sass.dart' as wc;
+
+ConsumerPackageFixture consumerPackageFixtureInstance;
+
+const String nonDefaultSourceDir = 'lib/';
+const String nonDefaultOutputDir = 'lib/css/';
+const String consumerPackageFixtureRoot = 'test_fixtures/sass';
+
+class SassCompileResult {
+  final int exitCode;
+  final String stdErr;
+
+  SassCompileResult(this.exitCode, [this.stdErr]);
+}
+
+/// Runs the sass task via dart_dev using the [additionalArgs]
+/// provided in the [ConsumerPackageFixture.projectRoot] value of [consumerPackageFixtureInstance].
+Future<SassCompileResult> compileConsumerSass(
+    {List<String> additionalArgs: const <String>[]}) async {
+  var args = ['run', 'dart_dev', 'sass']..addAll(additionalArgs);
+  TaskProcess sassTaskProcess = new TaskProcess('pub', args,
+      workingDirectory: consumerPackageFixtureInstance.projectRoot);
+  String sassTaskStdErr = '';
+  sassTaskProcess.stderr.listen((line) => sassTaskStdErr += '$line\n');
+
+  await sassTaskProcess.done;
+  final sassTaskExitCode = await sassTaskProcess.exitCode;
+  return new SassCompileResult(sassTaskExitCode, sassTaskStdErr);
+}
+
+/// Generates a test fixture for use by `sass_test.dart` consisting of a fake consumer package
+/// that depends on dart_dev, and has some .scss source files for the dart_dev sass task to compile into CSS.
+class ConsumerPackageFixture {
+  String get sourceDir => _sourceDir;
+  String _sourceDir;
+
+  String get sourceDirConfigValue => _sourceDirConfigValue;
+  String _sourceDirConfigValue;
+
+  String get outputDir => _outputDir;
+  String _outputDir;
+
+  String get outputDirConfigValue => _outputDirConfigValue;
+  String _outputDirConfigValue;
+
+  String get projectRoot => _projectRoot;
+  String _projectRoot;
+
+  String get projectName => 'fake_consumer_package';
+
+  ConsumerPackageFixture({
+    String sourceDir: wc.sourceDirDefaultValue,
+    String sourceDirConfigValue,
+    String outputDir: wc.outputDirDefaultValue,
+    String outputDirConfigValue,
+  }) {
+    _sourceDir = sourceDir;
+    _sourceDirConfigValue = sourceDirConfigValue;
+    _outputDir = outputDir;
+    _outputDirConfigValue = outputDirConfigValue;
+    _projectRoot = '$consumerPackageFixtureRoot/$projectName';
+  }
+
+  void generate({bool includePubspec: true}) {
+    if (includePubspec) {
+      _createPubspecFile();
+    }
+    _createDevFile();
+    _createSassEntryPointFile();
+    _createSassRelativeImportFile();
+    _createSassPackageImportFile();
+  }
+
+  void regenerate(
+      {String newSourceDir = wc.sourceDirDefaultValue,
+      String newSourceDirConfigValue,
+      String newOutputDir = wc.outputDirDefaultValue,
+      String newOutputDirConfigValue}) {
+    final cssFilesPreviouslyGenerated =
+        new Glob('${projectRoot}/**.css', recursive: true).listSync();
+    for (var generatedCssFile in cssFilesPreviouslyGenerated) {
+      generatedCssFile.deleteSync();
+    }
+    final cssMapFilesPreviouslyGenerated =
+        new Glob('${projectRoot}/**.css.map', recursive: true).listSync();
+    for (var generatedCssMapFile in cssMapFilesPreviouslyGenerated) {
+      generatedCssMapFile.deleteSync();
+    }
+
+    _sourceDir = newSourceDir;
+    _sourceDirConfigValue = newSourceDirConfigValue;
+    _outputDir = newOutputDir;
+    _outputDirConfigValue = newOutputDirConfigValue;
+    generate(includePubspec: false);
+  }
+
+  void destroy() {
+    final projectRootDir = new Directory(_projectRoot);
+    if (projectRootDir.existsSync()) {
+      projectRootDir.deleteSync(recursive: true);
+    }
+  }
+
+  void _createDevFile() {
+    final devFile =
+        new File(path.join(path.join(_projectRoot, 'tool'), 'dev.dart'));
+    if (!devFile.existsSync()) {
+      devFile.createSync(recursive: true);
+    }
+
+    String configValues = '';
+    if (sourceDirConfigValue != null) {
+      configValues += 'config.sass.sourceDir = \'${sourceDirConfigValue}\';';
+    }
+
+    if (outputDirConfigValue != null) {
+      configValues +=
+          '\n  config.sass.outputDir = \'${outputDirConfigValue}\';';
+    }
+
+    devFile.writeAsStringSync('''
+library tool.dev;
+
+import 'package:dart_dev/dart_dev.dart';
+
+main(args) async {
+  $configValues
+  await dev(args);
+}
+    ''');
+  }
+
+  void _createPubspecFile() {
+    final pubspecFile = new File(path.join(_projectRoot, 'pubspec.yaml'));
+    if (!pubspecFile.existsSync()) {
+      pubspecFile.createSync(recursive: true);
+    }
+
+    pubspecFile.writeAsStringSync('''
+name: $projectName
+version: 0.0.0
+dev_dependencies:
+  dart_dev:
+    path: ../../..
+    ''');
+  }
+
+  void _createSassEntryPointFile() {
+    final sassEntryPointFile =
+        new File(path.join(path.join(_projectRoot, sourceDir), 'test.scss'));
+    if (!sassEntryPointFile.existsSync()) {
+      sassEntryPointFile.createSync(recursive: true);
+    }
+    String packageLocation = sourceDir;
+    if (sourceDir.startsWith('lib/')) {
+      packageLocation = sourceDir.substring(4);
+    }
+
+    sassEntryPointFile.writeAsStringSync('''
+.selector1 {
+  color: black;
+}
+
+@import 'package:$projectName/${packageLocation}package_import';
+@import 'relative_import';
+    ''');
+  }
+
+  void _createSassRelativeImportFile() {
+    final sassRelativeImportFile = new File(
+        path.join(path.join(_projectRoot, sourceDir), '_relative_import.scss'));
+    if (!sassRelativeImportFile.existsSync()) {
+      sassRelativeImportFile.createSync(recursive: true);
+    }
+
+    sassRelativeImportFile.writeAsStringSync('''
+.relative-import {
+  color: blue;
+}
+    ''');
+  }
+
+  void _createSassPackageImportFile() {
+    final sassPackageImportFile = new File(
+        path.join(path.join(_projectRoot, sourceDir), '_package_import.scss'));
+    if (!sassPackageImportFile.existsSync()) {
+      sassPackageImportFile.createSync(recursive: true);
+    }
+
+    sassPackageImportFile.writeAsStringSync('''
+.package-import {
+  color: blue;
+}
+    ''');
+  }
+}
+
+const String expectedUnMinifiedSource = '''.selector1 {
+  color: black;
+}
+
+.package-import {
+  color: blue;
+}
+
+.relative-import {
+  color: blue;
+}
+
+/*# sourceMappingURL=test.css.map */''';
+
+const String expectedMinifiedSource =
+    '.selector1{color:#000}.package-import{color:blue}.relative-import{color:blue}\n\n/*# sourceMappingURL=test.css.map */';
+
+void sharedCssOutputExpectations(String expectedCssDirectoryPath) {
+  final expectedCssDir = new Directory(expectedCssDirectoryPath);
+  expect(expectedCssDir.existsSync(), isTrue,
+      reason: '$expectedCssDir does not exist.');
+  expect(new Glob('${expectedCssDir.path}**.css', recursive: true).listSync(),
+      isNotEmpty,
+      reason: '$expectedCssDir does not have any CSS files in it.');
+}
+
+void createNonDefaultOutputDir(String dir) {
+  final nonDefaultOutputDir = new Directory(dir);
+  if (!nonDefaultOutputDir.existsSync()) {
+    nonDefaultOutputDir.createSync(recursive: true);
+  }
+
+  addTearDown(() {
+    nonDefaultOutputDir.deleteSync(recursive: true);
+  });
+}
+
+void simulatePkgWithNoSassConfig() {
+  consumerPackageFixtureInstance.regenerate();
+}
+
+void simulatePkgWithCustomSourceDirWithoutSassConfig() {
+  consumerPackageFixtureInstance.regenerate(newSourceDir: nonDefaultSourceDir);
+}
+
+void simulatePkgWithCustomSourceDirWithSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newSourceDir: nonDefaultSourceDir,
+      newSourceDirConfigValue: nonDefaultSourceDir);
+}
+
+void simulatePkgWithCustomSourceDirWithOverriddenSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newSourceDir: nonDefaultSourceDir,
+      newSourceDirConfigValue: 'something_that_should_be_overridden/');
+}
+
+void simulatePkgWithCustomOutputDirWithSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newOutputDir: nonDefaultOutputDir,
+      newOutputDirConfigValue: nonDefaultOutputDir);
+}
+
+void simulatePkgWithCustomOutputDirWithOverriddenSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newOutputDir: nonDefaultOutputDir,
+      newOutputDirConfigValue: 'something_that_should_be_overridden/');
+}
+
+void simulatePkgWithCustomSourceAndOutputDirWithoutSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newSourceDir: nonDefaultSourceDir, newOutputDir: nonDefaultOutputDir);
+}
+
+void simulatePkgWithCustomSourceAndOutputDirWithSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newSourceDir: nonDefaultSourceDir,
+      newOutputDir: nonDefaultOutputDir,
+      newSourceDirConfigValue: nonDefaultSourceDir,
+      newOutputDirConfigValue: nonDefaultOutputDir);
+}
+
+void simulatePkgWithCustomSourceAndOutputDirWithOverriddenSassConfig() {
+  consumerPackageFixtureInstance.regenerate(
+      newSourceDir: nonDefaultSourceDir,
+      newOutputDir: nonDefaultOutputDir,
+      newSourceDirConfigValue: 'some_source_dir_that_should_be_overridden/',
+      newOutputDirConfigValue: 'some_output_dir_that_should_be_overridden/');
+}

--- a/test_fixtures/coverage/browser/pubspec.yaml
+++ b/test_fixtures/coverage/browser/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coverage_browser
 version: 0.0.0
 dev_dependencies:
-  coverage: "^0.7.2"
+  coverage: '>=0.7.2 <0.13.0'
   dart_dev:
     path: ../../..
   test: "^0.12.0"

--- a/test_fixtures/coverage/browser_needs_pub_serve/pubspec.yaml
+++ b/test_fixtures/coverage/browser_needs_pub_serve/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coverage_browser_needs_pub_serve
 version: 0.0.0
 dev_dependencies:
-  coverage: "^0.7.2"
+  coverage: '>=0.7.2 <0.13.0'
   dart_dev:
     path: ../../..
   test: "^0.12.0"

--- a/test_fixtures/coverage/failing_test/pubspec.yaml
+++ b/test_fixtures/coverage/failing_test/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coverage_failing_test
 version: 0.0.0
 dev_dependencies:
-  coverage: "^0.7.2"
+  coverage: '>=0.7.2 <0.13.0'
   dart_dev:
     path: ../../..
   test: "^0.12.0"

--- a/test_fixtures/coverage/functional_test/pubspec.yaml
+++ b/test_fixtures/coverage/functional_test/pubspec.yaml
@@ -2,7 +2,7 @@ name: functional_test
 version: 0.0.0
 dev_dependencies:
   browser: any
-  coverage: "^0.7.3"
+  coverage: '>=0.7.3 <0.13.0'
   dependency_validator: ^1.1.0
   test: '^0.12.0'
   webdriver: '^1.0.0'

--- a/test_fixtures/coverage/non_test_file/pubspec.yaml
+++ b/test_fixtures/coverage/non_test_file/pubspec.yaml
@@ -1,7 +1,7 @@
 name: non_test_file
 version: 0.0.0
 dev_dependencies:
-  coverage: "^0.7.2"
+  coverage: '>=0.7.3 <0.13.0'
   dart_dev:
     path: ../../..
   test: "^0.12.0"

--- a/test_fixtures/coverage/vm/pubspec.yaml
+++ b/test_fixtures/coverage/vm/pubspec.yaml
@@ -1,7 +1,7 @@
 name: coverage_vm
 version: 0.0.0
 dev_dependencies:
-  coverage: "^0.7.2"
+  coverage: '>=0.7.2 <0.13.0'
   dart_dev:
     path: ../../..
   test: "^0.12.0"

--- a/test_fixtures/task_runner/passing_tasks/pubspec.yaml
+++ b/test_fixtures/task_runner/passing_tasks/pubspec.yaml
@@ -5,4 +5,3 @@ dev_dependencies:
     path: ../../..
   dart_style: any
   test: any
-


### PR DESCRIPTION
Adds a sass task  which can be used like so:

```pub run dart_dev sass```

or

```pub run dart_dev sass --watch```

is what consumers would run locally - to compile stuff in whatever sourceDir the consumer has configured using the `expanded` output style. e.g. in wdesk_sdk’s case - in `wdesk_sdk/tool/dev.dart`, there would be:

```config.sass.sourceDir = 'lib/';```

then, in CI, consumers should run

```pub run dart_dev sass -r```

that command will run two things under the hood:

```pub run dart_dev sass --check```

and then _if that does not fail_:

```pub run dart_dev sass --outputStyle=compressed```

which will generate the minified output which will get bundled up with the pub artifact.