### PR TITLE
CPLAT-6557: Add release flag and config option to test task

### DIFF
--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -57,7 +57,7 @@ class TestCli extends TaskCli {
         negatable: false)
     ..addFlag('delete-conflicting-outputs',
         help: 'Deletes conflicting outputs during the build', negatable: false)
-    ..addFlag('release', abbr: '-r', negatable: true, help: 'Runs tests in release mode (i.e. compiled via dart2js).')
+    ..addFlag('release', abbr: 'r', negatable: true, help: 'Runs tests in release mode (i.e. compiled via dart2js).')
     ..addOption('pub-serve-port',
         help:
             'Port used by the Pub server for browser tests. The default value will randomly select an open port to use.')

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -57,6 +57,7 @@ class TestCli extends TaskCli {
         negatable: false)
     ..addFlag('delete-conflicting-outputs',
         help: 'Deletes conflicting outputs during the build', negatable: false)
+    ..addFlag('release', abbr: '-r', negatable: true, help: 'Runs tests in release mode (i.e. compiled via dart2js).')
     ..addOption('pub-serve-port',
         help:
             'Port used by the Pub server for browser tests. The default value will randomly select an open port to use.')
@@ -131,6 +132,11 @@ class TestCli extends TaskCli {
         parsedArgs,
         config.test.deleteConflictingOutputs);
 
+    bool release = TaskCli.valueOf(
+        'release',
+        parsedArgs,
+        config.test.release);
+
     // CLI user can specify individual test files to run.
     bool individualTestsSpecified = parsedArgs.rest.isNotEmpty;
 
@@ -194,6 +200,9 @@ class TestCli extends TaskCli {
 
     if (deleteConflictingOutputs) {
       buildArgs.add('--delete-conflicting-outputs');
+    }
+    if (release) {
+      buildArgs.add('--release');
     }
 
     PubServeTask pubServeTask;

--- a/lib/src/tasks/test/cli.dart
+++ b/lib/src/tasks/test/cli.dart
@@ -57,7 +57,10 @@ class TestCli extends TaskCli {
         negatable: false)
     ..addFlag('delete-conflicting-outputs',
         help: 'Deletes conflicting outputs during the build', negatable: false)
-    ..addFlag('release', abbr: 'r', negatable: true, help: 'Runs tests in release mode (i.e. compiled via dart2js).')
+    ..addFlag('release',
+        abbr: 'r',
+        negatable: true,
+        help: 'Runs tests in release mode (i.e. compiled via dart2js).')
     ..addOption('pub-serve-port',
         help:
             'Port used by the Pub server for browser tests. The default value will randomly select an open port to use.')
@@ -132,10 +135,7 @@ class TestCli extends TaskCli {
         parsedArgs,
         config.test.deleteConflictingOutputs);
 
-    bool release = TaskCli.valueOf(
-        'release',
-        parsedArgs,
-        config.test.release);
+    bool release = TaskCli.valueOf('release', parsedArgs, config.test.release);
 
     // CLI user can specify individual test files to run.
     bool individualTestsSpecified = parsedArgs.rest.isNotEmpty;
@@ -201,6 +201,7 @@ class TestCli extends TaskCli {
     if (deleteConflictingOutputs) {
       buildArgs.add('--delete-conflicting-outputs');
     }
+
     if (release) {
       buildArgs.add('--release');
     }

--- a/lib/src/tasks/test/config.dart
+++ b/lib/src/tasks/test/config.dart
@@ -20,28 +20,30 @@ const List defaultAfterFunctional = const [];
 const List defaultBeforeFunctional = const [];
 const int defaultConcurrency = 4;
 const bool defaultDeleteConflictingOutputs = false;
-const bool defaultPauseAfterLoad = false;
-const bool defaultPubServe = false;
 const bool defaultDisableServeStdOut = false;
-const int defaultPubServePort = 0;
-const bool defaultIntegration = false;
 const bool defaultFunctional = false;
+const List<String> defaultFunctionalTests = const [];
+const bool defaultIntegration = false;
 const List<String> defaultIntegrationTests = const [];
+const bool defaultPauseAfterLoad = false;
+const List<String> defaultPlatforms = const [];
+const bool defaultPubServe = false;
+const int defaultPubServePort = 0;
+const bool defaultRelease = false;
 const bool defaultUnit = true;
 const List<String> defaultUnitTests = const ['test/'];
-const List<String> defaultFunctionalTests = const [];
-const List<String> defaultPlatforms = const [];
 
 class TestConfig extends TaskConfig {
   List afterFunctionalTests = defaultAfterFunctional;
   List beforeFunctionalTests = defaultBeforeFunctional;
   int concurrency = defaultConcurrency;
   bool deleteConflictingOutputs = defaultDeleteConflictingOutputs;
+  bool disableServeStdOut = defaultDisableServeStdOut;
   List<String> functionalTests = defaultFunctionalTests;
   List<String> integrationTests = defaultIntegrationTests;
   List<String> platforms = defaultPlatforms;
   bool pubServe = defaultPubServe;
   int pubServePort = defaultPubServePort;
-  bool disableServeStdOut = defaultDisableServeStdOut;
+  bool release = defaultRelease;
   List<String> unitTests = defaultUnitTests;
 }


### PR DESCRIPTION
### Overview:

Sometimes, consumers want to run tests on dart2js compiled code in Dart 2. This technically _can_ be done via an args separator, but this doesn't provide help info through the test task, and it also doesn't allow for a config option to be set. 

This adds a top level flag to the test task, and a config option, for running tests in release mode. 

### Testing:
* publink into any package consuming dart_dev
* Verify that `ddev test` runs normally on Dart 1 and Dart 2.
* Verify that `ddev test -r` and `ddev test --release` run a build via dart2js in Dart 2, and has no effect on Dart 1.
* Verify that adding a test config option in `dev.dart` to `release = true` runs tests in release mode by default.
* Verify that the command line flag takes precedent over the config option.