### PR TITLE
CPLAT-8080: Quote and escape the subprocess commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [3.1.1](https://github.com/Workiva/dart_dev/compare/3.1.0...3.1.1)
+
+- When printing the subprocess commands, option values with spaces are now
+  wrapped in quotes.
+
+    ```diff
+    [INFO] Running subprocess:
+    - pub run test -n Foo bar baz
+    + pub run test -n 'Foo bar baz'
+    ```
+
+  This ensures that developers can always copy & paste the subprocess commands
+  in order to run them manually when necessary.
+
 ## [3.1.0](https://github.com/Workiva/dart_dev/compare/3.0.0...3.1.0)
 
 - Update `FormatTool.getInputs()` to support an optional `followLinks` param.

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -176,10 +176,12 @@ void logCommand(
   bool verbose,
 }) {
   verbose ??= false;
-  final exeAndArgs = 'dartanalyzer ${args.join(' ')}'.trim();
+  final executable = 'dartanalyzer';
   if (entrypoints.length <= 5 || verbose) {
-    logSubprocessHeader(_log, '$exeAndArgs ${entrypoints.join(' ')}');
+    logSubprocessHeader(
+        _log, buildEscapedCommand(executable, [...args, ...entrypoints]));
   } else {
-    logSubprocessHeader(_log, '$exeAndArgs <${entrypoints.length} paths>');
+    logSubprocessHeader(_log,
+        '${buildEscapedCommand(executable, args)} <${entrypoints.length} paths>');
   }
 }

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -392,11 +392,12 @@ void logCommand(
     String executable, Iterable<String> inputs, Iterable<String> args,
     {bool verbose}) {
   verbose ??= false;
-  final exeAndArgs = '$executable ${args.join(' ')}'.trim();
   if (inputs.length <= 5 || verbose) {
-    logSubprocessHeader(_log, '$exeAndArgs ${inputs.join(' ')}');
+    logSubprocessHeader(
+        _log, buildEscapedCommand(executable, [...args, ...inputs]));
   } else {
-    logSubprocessHeader(_log, '$exeAndArgs <${inputs.length} paths>');
+    logSubprocessHeader(_log,
+        '${buildEscapedCommand(executable, args)} <${inputs.length} paths>');
   }
 }
 

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -42,7 +42,7 @@ class ProcessTool extends DevTool {
           context.argResults, context.usageException,
           commandName: context.commandName);
     }
-    logSubprocessHeader(_log, '$_executable ${_args.join(' ')}');
+    logSubprocessHeader(_log, buildEscapedCommand(_executable, _args));
     return runProcessAndEnsureExit(
         ProcessDeclaration(_executable, _args, mode: _mode),
         log: _log);

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -201,10 +201,9 @@ List<String> buildArgs({
     // 1. Statically configured args from [TestTool.testArgs]
     ...?configuredTestArgs,
     // 2. The -n|--name, -N|--plain-name, and -P|--preset options
-    ...?multiOptionValue(argResults, 'name')?.map((v) => '--name=$v'),
-    ...?multiOptionValue(argResults, 'plain-name')
-        ?.map((v) => '--plain-name=$v'),
-    ...?multiOptionValue(argResults, 'preset')?.map((v) => '--preset=$v'),
+    ...?proxyMultiOptionValue(argResults, 'name'),
+    ...?proxyMultiOptionValue(argResults, 'plain-name'),
+    ...?proxyMultiOptionValue(argResults, 'preset'),
     // 3. Args passed to --test-args
     ...?splitSingleOptionValue(argResults, 'test-args'),
     // 4. Rest args passed to this command
@@ -234,6 +233,11 @@ List<String> buildArgs({
     ...testArgs,
   ];
 }
+
+Iterable<String> proxyMultiOptionValue(ArgResults argResults, String name) =>
+    multiOptionValue(argResults, name)
+        ?.map((v) => ['--$name', v])
+        ?.expand((pair) => pair);
 
 /// Returns a declarative representation of a test process to run based on the
 /// given parameters.
@@ -307,7 +311,7 @@ TestExecution buildExecution(
       configuredTestArgs: configuredTestArgs,
       useBuildTest: hasBuildTest,
       verbose: context.verbose);
-  logSubprocessHeader(_log, 'pub ${args.join(' ')}'.trim());
+  logSubprocessHeader(_log, buildEscapedCommand('pub', args));
   return TestExecution.process(
       ProcessDeclaration('pub', args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -150,7 +150,7 @@ TuneupExecution buildExecution(
       argResults: context.argResults,
       configuredIgnoreInfos: configuredIgnoreInfos,
       verbose: context.verbose);
-  logSubprocessHeader(_log, 'pub ${args.join(' ')}');
+  logSubprocessHeader(_log, buildEscapedCommand('pub', args));
   return TuneupExecution.process(
       ProcessDeclaration('pub', args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -225,7 +225,7 @@ WebdevServeExecution buildExecution(
       configuredBuildArgs: configuredBuildArgs,
       configuredWebdevArgs: configuredWebdevArgs,
       verbose: context.verbose);
-  logSubprocessHeader(_log, 'pub ${args.join(' ')}'.trim());
+  logSubprocessHeader(_log, buildEscapedCommand('pub', args));
   return WebdevServeExecution.process(
       ProcessDeclaration('pub', args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/utils/logging.dart
+++ b/lib/src/utils/logging.dart
@@ -34,6 +34,14 @@ void attachLoggerToStdio(List<String> args) {
   Logger.root.onRecord.listen(stdIOLogListener(verbose: verbose));
 }
 
+String buildEscapedCommand(String executable, List<String> args) {
+  final quotedAndEscapedArgs = args.map((arg) {
+    if (!arg.contains(' ')) return arg;
+    return "'${arg.replaceAll("'", "\'")}'";
+  });
+  return '$executable ${quotedAndEscapedArgs.join(' ')}'.trim();
+}
+
 StringBuffer colorLog(LogRecord record, {bool verbose}) {
   verbose ??= false;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.1.0
+version: 3.1.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -58,7 +58,7 @@ void main() {
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['-n', 'foo', '-n', 'bar']);
       expect(buildArgs(argResults: argResults),
-          orderedEquals(['run', 'test', '--name=foo', '--name=bar']));
+          orderedEquals(['run', 'test', '--name', 'foo', '--name', 'bar']));
     });
 
     test('forwards the -N|--plain-name options', () {
@@ -67,14 +67,14 @@ void main() {
       expect(
           buildArgs(argResults: argResults),
           orderedEquals(
-              ['run', 'test', '--plain-name=foo', '--plain-name=bar']));
+              ['run', 'test', '--plain-name', 'foo', '--plain-name', 'bar']));
     });
 
     test('forwards the -P|--preset options', () {
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['-P', 'foo', '-P', 'bar']);
       expect(buildArgs(argResults: argResults),
-          orderedEquals(['run', 'test', '--preset=foo', '--preset=bar']));
+          orderedEquals(['run', 'test', '--preset', 'foo', '--preset', 'bar']));
     });
 
     group('with useBuildTest=false', () {

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -1,4 +1,5 @@
 @TestOn('vm')
+@Timeout(Duration(seconds: 5))
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';


### PR DESCRIPTION
# [CPLAT-8080](https://jira.atl.workiva.net/browse/CPLAT-8080)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-8080)

This helps ensure that developers can copy & paste the subprocess command
even if there are option values that contain spaces or quotes.