### PR TITLE
CPLAT-8451: Add optional `workingDirectory` param for ProcessTool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.2.0](https://github.com/Workiva/dart_dev/compare/3.1.0...3.2.0)
+
+- Add an optional `String workingDirectory` parameter when creating a
+  `DevTool.fromProcess()` or `ProcessTool()`.
+- Expose the `Process` created by a `ProcessTool` via a public field.
+
 ## [3.1.0](https://github.com/Workiva/dart_dev/compare/3.0.0...3.1.0)
 
 - Update `FormatTool.getInputs()` to support an optional `followLinks` param.

--- a/lib/src/dart_dev_tool.dart
+++ b/lib/src/dart_dev_tool.dart
@@ -17,8 +17,9 @@ abstract class DevTool {
       FunctionTool(function, argParser: argParser);
 
   factory DevTool.fromProcess(String executable, List<String> args,
-          {ProcessStartMode mode}) =>
-      ProcessTool(executable, args, mode: mode);
+          {ProcessStartMode mode, String workingDirectory}) =>
+      ProcessTool(executable, args,
+          mode: mode, workingDirectory: workingDirectory);
 
   /// The argument parser for this tool, if needed.
   ///

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dart_dev/src/utils/start_process_and_ensure_exit.dart';
 import 'package:logging/logging.dart';
 
 import '../dart_dev_tool.dart';
@@ -25,14 +26,20 @@ final _log = Logger('Process');
 /// It is also possible to run this tool directly in a dart script:
 ///     ProcessTool(exe, args).run();
 class ProcessTool extends DevTool {
-  ProcessTool(String executable, List<String> args, {ProcessStartMode mode})
+  ProcessTool(String executable, List<String> args,
+      {ProcessStartMode mode, String workingDirectory})
       : _args = args,
         _executable = executable,
-        _mode = mode;
+        _mode = mode,
+        _workingDirectory = workingDirectory;
 
   final List<String> _args;
   final String _executable;
   final ProcessStartMode _mode;
+  final String _workingDirectory;
+
+  Process get process => _process;
+  Process _process;
 
   @override
   FutureOr<int> run([DevToolExecutionContext context]) async {
@@ -43,8 +50,10 @@ class ProcessTool extends DevTool {
           commandName: context.commandName);
     }
     logSubprocessHeader(_log, '$_executable ${_args.join(' ')}');
-    return runProcessAndEnsureExit(
-        ProcessDeclaration(_executable, _args, mode: _mode),
+    _process = await startProcessAndEnsureExit(
+        ProcessDeclaration(_executable, _args,
+            mode: _mode, workingDirectory: _workingDirectory),
         log: _log);
+    return _process.exitCode;
   }
 }

--- a/lib/src/utils/process_declaration.dart
+++ b/lib/src/utils/process_declaration.dart
@@ -4,6 +4,8 @@ class ProcessDeclaration {
   final List<String> args;
   final String executable;
   final ProcessStartMode mode;
+  final String workingDirectory;
 
-  ProcessDeclaration(this.executable, this.args, {this.mode});
+  ProcessDeclaration(this.executable, this.args,
+      {this.mode, this.workingDirectory});
 }

--- a/lib/src/utils/start_process_and_ensure_exit.dart
+++ b/lib/src/utils/start_process_and_ensure_exit.dart
@@ -5,12 +5,12 @@ import 'package:logging/logging.dart';
 import 'process_declaration.dart';
 import 'ensure_process_exit.dart';
 
-Future<int> runProcessAndEnsureExit(ProcessDeclaration processDeclaration,
+Future<Process> startProcessAndEnsureExit(ProcessDeclaration processDeclaration,
     {Logger log}) async {
   final process = await Process.start(
       processDeclaration.executable, processDeclaration.args,
       mode: processDeclaration.mode ?? ProcessStartMode.normal,
       workingDirectory: processDeclaration.workingDirectory);
   ensureProcessExit(process, log: log);
-  return process.exitCode;
+  return process;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.1.0
+version: 3.2.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
@@ -15,6 +17,15 @@ void main() {
     test('forwards the returned exit code', () async {
       final tool = DevTool.fromProcess('false', []);
       expect(await tool.run(), isNonZero);
+    });
+
+    test('can run from a custom working directory', () async {
+      final tool = DevTool.fromProcess('pwd', [], workingDirectory: 'lib')
+          as ProcessTool;
+      expect(await tool.run(), isZero);
+      final stdout =
+          (await tool.process.stdout.transform(utf8.decoder).join('')).trim();
+      expect(stdout, endsWith('/dart_dev/lib'));
     });
 
     test('throws UsageException when args are present', () {


### PR DESCRIPTION
# [CPLAT-8451](https://jira.atl.workiva.net/browse/CPLAT-8451)
![Issue Status](http://bender.workiva.org:9000/Bender/status/CPLAT-8451)

Additions to `ProcessTool`:
- Add optional `workingDirectory` constructor param.
- Make the `Process` instance created by the tool available via a public field on `ProcessTool`.