### PR TITLE
CPLAT-8469: Fix 3.2 release. Add SDK constraints to test fixtures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,26 @@
 language: dart
 
-dart:
-  - 2.3.0
-  - stable
-  - dev
+jobs:
+  include:
+    - dart: "2.4.1"
+      name: "SDK: 2.4.1"
+      script:
+        - pub run dart_dev analyze
+        - pub run dart_dev test
+    - dart: stable
+      name: "SDK: stable"
+      script:
+        - pub run dart_dev analyze
+        - pub run dependency_validator -i pedantic
+        - pub run dart_dev format --check
+        - pub run dart_dev test
+        - pub publish --dry-run
+    - dart: dev
+      name: "SDK: dev"
+      script:
+        - pub run dart_dev analyze
+        - pub run dart_dev test
 
-sudo: required
-addons:
-  chrome: stable
-
-script:
-  - pub run dependency_validator -i pedantic
-  - pub run dart_dev analyze
-  - pub run dart_dev format --check
-  - pub run dart_dev test
-  - pub publish --dry-run
+cache:
+  directories:
+    - "$HOME/.pub-cache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## [3.2.0](https://github.com/Workiva/dart_dev/compare/3.1.0...3.2.0)
+## [3.2.0 + 3.2.1](https://github.com/Workiva/dart_dev/compare/3.1.0...3.2.1)
 
 - Add an optional `String workingDirectory` parameter when creating a
   `DevTool.fromProcess()` or `ProcessTool()`.
 - Expose the `Process` created by a `ProcessTool` via a public field.
+- Fix release configuration (the 3.2.0 release did not get created properly).
+- Add SDK constraints to all of the test fixture `pubspec.yaml` files.
 
 ## [3.1.0](https://github.com/Workiva/dart_dev/compare/3.0.0...3.1.0)
 

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -8,7 +8,6 @@ import '../dart_dev_tool.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
 import '../utils/logging.dart';
 import '../utils/process_declaration.dart';
-import '../utils/run_process_and_ensure_exit.dart';
 
 final _log = Logger('Process');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.2.0
+version: 3.2.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 authors:
   - Workiva Client Platform Team <clientplatform@workiva.com>

--- a/test/functional/fixtures/analyze/failure/pubspec.yaml
+++ b/test/functional/fixtures/analyze/failure/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dart_dev_test_functional_analyze_failure
 version: 0.0.0
-
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../..

--- a/test/functional/fixtures/analyze/success/pubspec.yaml
+++ b/test/functional/fixtures/analyze/success/pubspec.yaml
@@ -1,6 +1,7 @@
 name: dart_dev_test_functional_analyze_success
 version: 0.0.0
-
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../..

--- a/test/tools/fixtures/format/has_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/has_dart_style/pubspec.yaml
@@ -1,3 +1,5 @@
 name: has_dart_style
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   dart_style: any

--- a/test/tools/fixtures/format/missing_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/missing_dart_style/pubspec.yaml
@@ -1,3 +1,5 @@
 name: missing_dart_style
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   test: any

--- a/test/tools/fixtures/test/has_test_runner_and_build_test/pubspec.yaml
+++ b/test/tools/fixtures/test/has_test_runner_and_build_test/pubspec.yaml
@@ -1,4 +1,6 @@
 name: has_test_runner_and_build_test
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   build_test: any
   test: any

--- a/test/tools/fixtures/test/has_test_runner_missing_build_test/pubspec.yaml
+++ b/test/tools/fixtures/test/has_test_runner_missing_build_test/pubspec.yaml
@@ -1,3 +1,5 @@
 name: missing_test_runner
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   test: any

--- a/test/tools/fixtures/test/missing_test_runner/pubspec.yaml
+++ b/test/tools/fixtures/test/missing_test_runner/pubspec.yaml
@@ -1,3 +1,5 @@
 name: missing_test_runner
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   dart_style: any

--- a/test/tools/fixtures/tuneup_check/has_tuneup/pubspec.yaml
+++ b/test/tools/fixtures/tuneup_check/has_tuneup/pubspec.yaml
@@ -1,3 +1,5 @@
 name: has_tuneup
+environment:
+ sdk: ">=2.3.0 <3.0.0"
 dev_dependencies:
   tuneup: any

--- a/test/tools/fixtures/tuneup_check/missing_tuneup/pubspec.yaml
+++ b/test/tools/fixtures/tuneup_check/missing_tuneup/pubspec.yaml
@@ -1,1 +1,3 @@
 name: missing_tuneup
+environment:
+ sdk: ">=2.3.0 <3.0.0"


### PR DESCRIPTION
The 3.2.0 release got created as 3.1.1. MARV should automatically use the version number in the PR from now on.