### PR TITLE
CPLAT-9175: Only log newlines in verbose mode for compound tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.2.2](https://github.com/Workiva/dart_dev/compare/3.2.1...3.2.2)
+
+- Remove unnecessary newlines from `CompoundTool` output.
+- Remove deprecated `authors` field from `pubspec.yaml`
+
 ## [3.2.0 + 3.2.1](https://github.com/Workiva/dart_dev/compare/3.1.0...3.2.1)
 
 - Add an optional `String workingDirectory` parameter when creating a

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -79,8 +79,7 @@ mixin CompoundToolMixin on DevTool {
       if (!shouldRunTool(_specs[i].when, code)) continue;
       final newCode =
           await _specs[i].tool.run(contextForTool(context, _specs[i]));
-      _log.fine('Step ${i + 1}/${_specs.length} done (code: $newCode)');
-      _log.info('\n\n');
+      _log.fine('Step ${i + 1}/${_specs.length} done (code: $newCode)\n');
       if (code == 0) {
         code = newCode;
       }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.2.1
+version: 3.2.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,6 @@
 name: dart_dev
 version: 3.2.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
-authors:
-  - Workiva Client Platform Team <clientplatform@workiva.com>
-  - Dustin Lessard <dustin.lessard@workiva.com>
-  - Evan Weible <evan.weible@workiva.com>
-  - Jay Udey <jay.udey@workiva.com>
-  - Max Peterson <maxwell.peterson@workiva.com>
-  - Trent Grover <trent.grover@workiva.com>
 homepage: https://github.com/Workiva/dart_dev
 
 environment:


### PR DESCRIPTION
When originally added, the `CompoundTool` added two newlines between the output of each individual tool. But, it's perfectly valid for compound tools to have steps that don't output anything (either all the time or conditionally), which leads to unnecessary whitespace.

This PR removes these two new-lines and replaces it with a single newline that is only printed in verbose mode. In other words, it's up to the authors of `CompoundTool`s to add extra newlines to the output as needed.

---

Also removed the deprecated `authors` field from pubspec.yaml.