### PR TITLE
CPLAT-9182: Add --reporter option to TestTool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.3.0](https://github.com/Workiva/dart_dev/compare/3.2.2...3.3.0)
+
+- Added the `--reporter` option to `TestTool` so that a reporter can be selected
+  directly instead of having to use `--test-args="--reporter <reporter>"`.
+
 ## [3.2.2](https://github.com/Workiva/dart_dev/compare/3.2.1...3.2.2)
 
 - Remove unnecessary newlines from `CompoundTool` output.

--- a/doc/tools/test-tool.md
+++ b/doc/tools/test-tool.md
@@ -49,15 +49,35 @@ Run dart tests in this package.
 
 Usage: dart_dev test [files or directories...]
 ======== Selecting Tests
--n, --name          A substring of the name of the test to run.
-                    Regular expression syntax is supported.
-                    If passed multiple times, tests must match all substrings.
+-n, --name              A substring of the name of the test to run.
+                        Regular expression syntax is supported.
+                        If passed multiple times, tests must match all substrings.
 
--N, --plain-name    A plain-text substring of the name of the test to run.
-                    If passed multiple times, tests must match all substrings.
+-N, --plain-name        A plain-text substring of the name of the test to run.
+                        If passed multiple times, tests must match all substrings.
 
 ======== Running Tests
--P, --preset        The configuration preset(s) to use.
+-P, --preset            The configuration preset(s) to use.
+    --[no-]release      Build with release mode defaults for builders.
+                        This only applies in projects that run tests with build_runner.
+
+======== Output
+    --reporter          The runner used to print test results.
+
+          [compact]     A single line, updated continuously.
+          [expanded]    A separate line for each update.
+          [json]        A machine-readable format (see https://goo.gl/gBsV1a).
+
+======== Other Options
+    --test-stdout       Write the test process stdout to this file path.
+    --test-args         Args to pass to the test runner process.
+                        Run "pub run test -h -v" to see all available options.
+
+    --build-args        Args to pass to the build runner process.
+                        Run "pub run build_runner test -h -v" to see all available options.
+                        Note: these args are only applicable if the current project depends on "build_test".
+
+-h, --help              Print this usage information.
 ```
 
 Additionally, in projects that use `build_runner` to run tests, the `TestTool`

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -67,6 +67,19 @@ class TestTool extends DevTool {
     ..addFlag('release',
         help: 'Build with release mode defaults for builders.\n'
             'This only applies in projects that run tests with build_runner.')
+    ..addSeparator('======== Output')
+    ..addOption('reporter',
+        help: 'The runner used to print test results.',
+        allowed: [
+          'compact',
+          'expanded',
+          'json'
+        ],
+        allowedHelp: {
+          'compact': 'A single line, updated continuously.',
+          'expanded': 'A separate line for each update.',
+          'json': 'A machine-readable format (see https://goo.gl/gBsV1a).'
+        })
     ..addSeparator('======== Other Options')
     ..addOption('test-stdout',
         help: 'Write the test process stdout to this file path.')
@@ -200,14 +213,17 @@ List<String> buildArgs({
     // process in this order:
     // 1. Statically configured args from [TestTool.testArgs]
     ...?configuredTestArgs,
-    // 2. The -n|--name, -N|--plain-name, and -P|--preset options
+    // 2. The --reporter option.
+    if (argResults?.wasParsed('reporter') ?? false)
+      '--reporter=' + singleOptionValue(argResults, 'reporter'),
+    // 3. The -n|--name, -N|--plain-name, and -P|--preset options
     ...?multiOptionValue(argResults, 'name')?.map((v) => '--name=$v'),
     ...?multiOptionValue(argResults, 'plain-name')
         ?.map((v) => '--plain-name=$v'),
     ...?multiOptionValue(argResults, 'preset')?.map((v) => '--preset=$v'),
-    // 3. Args passed to --test-args
+    // 4. Args passed to --test-args
     ...?splitSingleOptionValue(argResults, 'test-args'),
-    // 4. Rest args passed to this command
+    // 5. Rest args passed to this command
     ...?argResults?.rest,
   ];
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.2.2
+version: 3.3.0
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -77,6 +77,13 @@ void main() {
           orderedEquals(['run', 'test', '--preset=foo', '--preset=bar']));
     });
 
+    test('forwards the --reporter option', () {
+      final argParser = TestTool().toCommand('t').argParser;
+      final argResults = argParser.parse(['--reporter', 'expanded']);
+      expect(buildArgs(argResults: argResults),
+          orderedEquals(['run', 'test', '--reporter=expanded']));
+    });
+
     group('with useBuildTest=false', () {
       test('combines configured args with cli args (in that order)', () {
         final argParser = TestTool().toCommand('t').argParser;


### PR DESCRIPTION

The `--reporter` option is a commonly used option when running tests. This PR adds it to `TestTool` so that it can be used directly with `ddev test` instead of having to use `--test-args` to configure it.

```bash
# before
$ ddev test --test-args="--reporter expanded"
# now
$ ddev test --reporter expanded
```

Note: the `-r` abbreviation was intentionally **not** added because it conflicts with the abbreviation for the `--release` flag used when running tests via `build_runner`. In other words, when running tests via `ddev test`, the `-r` abbreviation has no meaning and the full option name (either `--release` or `--reporter`) should be used to avoid ambiguity.