### PR TITLE
Add Noop DevTool

### DIFF
--- a/lib/dart_dev.dart
+++ b/lib/dart_dev.dart
@@ -8,5 +8,6 @@ export 'src/tools/format_tool.dart'
     show FormatMode, Formatter, FormatterInputs, FormatTool;
 export 'src/tools/process_tool.dart' show ProcessTool;
 export 'src/tools/test_tool.dart' show TestTool;
+export 'src/tools/noop_tool.dart' show NoopTool;
 export 'src/tools/tuneup_check_tool.dart' show TuneupCheckTool;
 export 'src/tools/webdev_serve_tool.dart' show WebdevServeTool;

--- a/lib/src/tools/noop_tool.dart
+++ b/lib/src/tools/noop_tool.dart
@@ -1,0 +1,19 @@
+import 'dart:async';
+
+import 'package:io/ansi.dart';
+import 'package:io/io.dart';
+import 'package:logging/logging.dart';
+
+import '../dart_dev_tool.dart';
+
+final _log = Logger('Noop');
+
+class NoopTool extends DevTool {
+  String buildArg;
+
+  @override
+  FutureOr<int> run([DevToolExecutionContext context]) {
+    _log.severe(red.wrap(buildArg));
+    return ExitCode.config.code;
+  }
+}

--- a/test/tools/noop_tool_test.dart
+++ b/test/tools/noop_tool_test.dart
@@ -1,0 +1,20 @@
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+
+import 'package:dart_dev/src/tools/noop_tool.dart';
+
+import '../log_matchers.dart';
+
+void main() {
+  group('NoopTool', () {
+    test('(default)', () {
+      String buildArgInput = 'warning';
+      expect(Logger.root.onRecord,
+          emitsThrough(severeLogOf(contains(buildArgInput))));
+
+      var tool = NoopTool()..buildArg = buildArgInput;
+
+      tool.run(null);
+    });
+  });
+}


### PR DESCRIPTION
In DPC, we've had quite a few instances where people try to run tests in the root directory, and it appears to try to run tests despite not having a testing command defined in the config. I propose we add a NoopTool to enable us to define any command as a noop. For us, we could leverage it by assigning 'test' in root to the NoopTool, giving a concrete error message.