### PR TITLE
Expand build filters to deal with deferred libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [3.6.1](https://github.com/Workiva/dart_dev/compare/3.6.0...3.6.1)
+
+- Fix issue where tests that load a deferred library would throw an exception 
+  when run with `pub run dart_dev test --path/to/file.dart`.
+
 ## [3.6.0](https://github.com/Workiva/dart_dev/compare/3.5.0...3.6.0)
 
 - Support a faster format command for better integration with JetBrains file

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -332,7 +332,7 @@ Iterable<String> buildFiltersForTestArgs(List<String> testInputs) {
   final filters = <String>[];
   for (final input in testInputs ?? []) {
     if (input.endsWith('.dart')) {
-      filters..add('$input.*_test.dart.js')..add(dartExtToHtml(input));
+      filters..add('$input.*_test.dart.js*')..add(dartExtToHtml(input));
     } else {
       filters.add('$input**');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.6.0
+version: 3.6.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 


### PR DESCRIPTION
Trying to load a deferred library with `loadLibrary()` will fail when running `ddev test --release path/to/file.dart`

Example: When deferred loading [this library](https://github.com/Workiva/doc_plat_client/blob/a5437efa719b6ed982999a32af4005e530e8966b/subpackages/text_doc_client/lib/src/embedded/text/experiences/paginated/paginated_text_experience.dart#L136) I get the following error:

```
there was a severe error DeferredLoadException: 'Loading http://localhost:61228/iVZPmn0JCIzkrO7nKP3qRcDJd2dZYG%2B3/test/unit/generated_runner_test.dart.browser_test.dart.js_18.part.js failed: Instance of 'Event'
event log:
 - _loadHunk: generated_runner_test.dart.browser_test.dart.js_18.part.js
 - download: generated_runner_test.dart.browser_test.dart.js_18.part.js from http://localhost:61228/iVZPmn0JCIzkrO7nKP3qRcDJd2dZYG%2B3/test/unit/generated_runner_test.dart.browser_test.dart.js_18.part.js
 - download failed: generated_runner_test.dart.browser_test.dart.js_18.part.js (context: js-failure-wrapper)
'
```

[Test Run](https://wf-skynet-hrd.appspot.com/apps/test/smithy/2456119/1/doc_plat_client/unit-tests-text_doc_client#summary) (exception is swallowed in try/catch)

This is what my `.dart_tool/build` looks like.
![Screen Shot 2020-09-18 at 12 46 50 PM](https://user-images.githubusercontent.com/4479792/93628963-15493880-f9ad-11ea-87c2-ff550503969e.png)

I updated dart_dev to include these parts in the build-filters so tests can successfully use `loadLibrary()`