### PR TITLE
Widen analyzer range to allow latest version (0.41.x)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  analyzer: ^0.39.0
+  analyzer: ">0.39.0 <0.42.0"
   args: ^1.5.2
   async: ^2.3.0
   build_runner: ^1.7.0


### PR DESCRIPTION
## Motivation
To unlock the latest analyzer package version, as well as the latest versions of many packages that depend on it, including build packages, we need to widen the version range for this package.

## Solution
Widen version range to allow analyzer 0.41.x, the latest minor version.

No other changes were necessary

## Testing instructions
Verify locally that there are no analysis issues in this repo when using analyzer 0.41.x

Unfortunately, Dart 2.7.2 (which is what we use in CI) still can't resolve to this latest analyzer version due to SDK dependency constraints on this `build` package, so this has to be tested locally, with an SDK of at least Dart 2.9.

Also, with the constraint as-is, for some reason `pub upgrade analyzer` won't resolve the latest version, but you can force it to resolve to analyzer 0.41.x by temporarily making the analyzer dependency `^0.41.0`.
```diff
-analyzer: ">0.39.0 <0.42.0"
+analyzer: ^0.41.0
```