### PR TITLE
Release with direct-commit enabled, fix constraint, add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.6.3](https://github.com/Workiva/dart_dev/compare/3.6.3...3.6.1)
+
+- Widen `analyzer` constraint to `>=0.39.0 <0.42.0`
+
 ## [3.6.1](https://github.com/Workiva/dart_dev/compare/3.6.0...3.6.1)
 
 - Fix issue where tests that load a deferred library would throw an exception 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
  sdk: ">=2.3.0 <3.0.0"
 
 dependencies:
-  analyzer: ">0.39.0 <0.42.0"
+  analyzer: ">=0.39.0 <0.42.0"
   args: ^1.5.2
   async: ^2.3.0
   build_runner: ^1.7.0


### PR DESCRIPTION
The 3.6.2 release was tagged without pubspec.yaml being updated due to direct commit not being enabled.

As a result, we have to drop that release and just do a new one: 3.6.3.

This PR also adds a changelog entry for this new release, and fixes a mistake in https://github.com/Workiva/dart_dev/pull/346 when converting from caret syntax, in which the lower bound was defined using `>` instead of `>=`.