### PR TITLE
Release dart_dev 3.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.6.3](https://github.com/Workiva/dart_dev/compare/3.6.3...3.6.1)
+## [3.6.4](https://github.com/Workiva/dart_dev/compare/3.6.4...3.6.1)
 
 - Widen `analyzer` constraint to `>=0.39.0 <0.42.0`
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.6.1
+version: 3.6.4
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 


### PR DESCRIPTION


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/3.6.3...Workiva:release_dart_dev_3.6.4
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/3.6.3...3.6.4

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?pull_number=349&repo_name=Workiva%2Fdart_dev)