### PR TITLE
Add comments to unblock Dart 2.12

### DIFF
--- a/bin/dart_dev.dart
+++ b/bin/dart_dev.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'package:dart_dev/src/executable.dart' as executable;
 
 void main(List<String> args) => executable.run(args);

--- a/test/functional/analyze_tool_functional_test.dart
+++ b/test/functional/analyze_tool_functional_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 @Timeout(Duration(seconds: 20))
 import 'package:test/test.dart';

--- a/test/functional/documentation_test.dart
+++ b/test/functional/documentation_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 /// Scans the project for Dart code blocks in markdown files and runs static
 /// analysis on each to ensure that all of our documentation is valid.
 ///

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';

--- a/test/tools/compound_tool_test.dart
+++ b/test/tools/compound_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:dart_dev/dart_dev.dart';

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'dart:io';
 

--- a/test/tools/function_tool_test.dart
+++ b/test/tools/function_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 import 'dart:convert';
 
 @TestOn('vm')

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';

--- a/test/tools/tuneup_check_tool_test.dart
+++ b/test/tools/tuneup_check_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'dart:io';
 

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';

--- a/test/utils/arg_results_utils_test.dart
+++ b/test/utils/arg_results_utils_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:dart_dev/src/utils/arg_results_utils.dart';

--- a/test/utils/assert_no_positional_args_before_separator_test.dart
+++ b/test/utils/assert_no_positional_args_before_separator_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 import 'package:args/args.dart';
 import 'package:test/test.dart';

--- a/test/utils/format_tool_builder_test.dart
+++ b/test/utils/format_tool_builder_test.dart
@@ -1,3 +1,5 @@
+// @dart=2.7
+// ^ Do not remove until migrated to null safety. More info at https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832
 @TestOn('vm')
 
 import 'package:analyzer/dart/analysis/utilities.dart';


### PR DESCRIPTION
Adds null safety opt-out comments to Dart entry points to prepare for Dart 2.12+
Please reach out to #support-client-plat with any questions.

[_Created by Sourcegraph batch change `Workiva/add_dart2_9_comments`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/add_dart2_9_comments)