### PR TITLE
Widen Dependency Ranges Blocking Dart 2.13

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pub get
 
       - name: Validate dependencies
-        run: pub run dependency_validator -i pedantic over_react_format
+        run: pub run dependency_validator -i pedantic over_react_format meta
         if: always() && steps.install.outcome == 'success'
 
       - name: Analyze project source

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.4.1, stable, dev ]
+        sdk: [ 2.7.2, stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: pub get
 
       - name: Validate dependencies
-        run: pub run dependency_validator -i pedantic over_react_format meta
+        run: pub run dependency_validator -i pedantic,over_react_format,meta
         if: always() && steps.install.outcome == 'success'
 
       - name: Analyze project source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.5
+FROM google/dart:2.7
 WORKDIR /build
 ADD pubspec.yaml /build
 RUN pub get

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,6 @@ dependencies:
 dev_dependencies:
   dependency_validator: ^1.3.0
   matcher: ^0.12.5
-  test: ^1.6.4
+  test: ^1.15.7
   test_descriptor: ^1.2.0
   test_process: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
 dev_dependencies:
   dependency_validator: ^1.3.0
   matcher: ^0.12.5
+  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   test: ^1.15.7
   test_descriptor: ^1.2.0
   test_process: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   completion: ^0.2.1+1
   glob: ^1.1.7
   io: ^0.3.3
+  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   logging: ^0.11.3+2
   path: ^1.6.2
   pedantic: ^1.7.0
@@ -25,7 +26,6 @@ dependencies:
 dev_dependencies:
   dependency_validator: ^1.3.0
   matcher: ^0.12.5
-  meta: ">=1.2.2 <1.7.0" # Workaround to avoid https://github.com/dart-lang/sdk/issues/46142
   test: ^1.15.7
   test_descriptor: ^1.2.0
   test_process: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.39.0 <0.42.0"

--- a/test/functional/documentation_test.dart
+++ b/test/functional/documentation_test.dart
@@ -59,7 +59,7 @@ String pubspecWithPackages(Set<String> packages) {
   final buffer = StringBuffer()
     ..writeln('name: doc_test')
     ..writeln('environment:')
-    ..writeln('  sdk: ">=2.3.0 <3.0.0"')
+    ..writeln('  sdk: ">=2.7.0 <3.0.0"')
     ..writeln('dependencies:');
   for (final package in packages) {
     var constraint =

--- a/test/functional/fixtures/analyze/failure/pubspec.yaml
+++ b/test/functional/fixtures/analyze/failure/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_dev_test_functional_analyze_failure
 version: 0.0.0
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../..

--- a/test/functional/fixtures/analyze/success/pubspec.yaml
+++ b/test/functional/fixtures/analyze/success/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_dev_test_functional_analyze_success
 version: 0.0.0
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../..

--- a/test/tools/fixtures/format/has_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/has_dart_style/pubspec.yaml
@@ -1,6 +1,6 @@
 name: has_dart_style
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   dart_style: any
 

--- a/test/tools/fixtures/format/missing_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/missing_dart_style/pubspec.yaml
@@ -1,6 +1,6 @@
 name: missing_dart_style
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   test: any
 

--- a/test/tools/fixtures/test/has_test_runner_and_build_test/pubspec.yaml
+++ b/test/tools/fixtures/test/has_test_runner_and_build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: has_test_runner_and_build_test
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   build_test: any
   test: any

--- a/test/tools/fixtures/test/has_test_runner_missing_build_test/pubspec.yaml
+++ b/test/tools/fixtures/test/has_test_runner_missing_build_test/pubspec.yaml
@@ -1,6 +1,6 @@
 name: missing_test_runner
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   test: any
 

--- a/test/tools/fixtures/test/missing_test_runner/pubspec.yaml
+++ b/test/tools/fixtures/test/missing_test_runner/pubspec.yaml
@@ -1,6 +1,6 @@
 name: missing_test_runner
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   dart_style: any
 

--- a/test/tools/fixtures/tuneup_check/has_tuneup/pubspec.yaml
+++ b/test/tools/fixtures/tuneup_check/has_tuneup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: has_tuneup
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 dev_dependencies:
   tuneup: any
 

--- a/test/tools/fixtures/tuneup_check/missing_tuneup/pubspec.yaml
+++ b/test/tools/fixtures/tuneup_check/missing_tuneup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: missing_tuneup
 environment:
- sdk: ">=2.3.0 <3.0.0"
+ sdk: ">=2.7.0 <3.0.0"
 
 workiva:
   disable_core_checks: true


### PR DESCRIPTION
## Motivation
In order for projects to be compatible with Dart 2.13, there are dependencies that need to have their ranges widened. 
For a list of dependencies expected to be changed, see the dependencies section of the Dart 2.12+ [wiki page](https://wiki.atl.workiva.net/pages/viewpage.action?pageId=189370832).

Another necessary change is the removal of `build_vm_compilers`. If this is the case, additional clean up may need to be done, such as removing the associated config from `build.yaml` or updating how tests are run. A member of Client Platform will be following up with PRs that have CI failures to resolve any issues or perform necessary clean up.

For any questions or concerns, don't hesitate to reach us in the #support-client-plat Slack channel!

## Changes
- Update specific dependencies to be compatible with Dart 2.13.
- Remove `build_vm_compilers` if it was present

## QA
- CI passes

[_Created by Sourcegraph batch change `Workiva/dart_213_dependency_range_widen`._](https://sourcegraph.wk-dev.wdesk.org/organizations/Workiva/batch-changes/dart_213_dependency_range_widen)