### PR TITLE
RM-94762 Release dart_dev 3.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
+## [3.6.5](https://github.com/Workiva/dart_dev/compare/3.6.5...3.6.4)
+
+- Widen dependency ranges to allow resolution on Dart 2.7 and Dart 2.13
+- Switch to GitHub actions for CI
+
 ## [3.6.4](https://github.com/Workiva/dart_dev/compare/3.6.4...3.6.1)
 
 - Widen `analyzer` constraint to `>=0.39.0 <0.42.0`
 
 ## [3.6.1](https://github.com/Workiva/dart_dev/compare/3.6.0...3.6.1)
 
-- Fix issue where tests that load a deferred library would throw an exception 
+- Fix issue where tests that load a deferred library would throw an exception
   when run with `pub run dart_dev test --path/to/file.dart`.
 
 ## [3.6.0](https://github.com/Workiva/dart_dev/compare/3.5.0...3.6.0)
@@ -273,7 +278,7 @@ _September 8, 2015_
 
 - Documentation generation via the
   [dartdoc](https://github.com/dart-lang/dartdoc) package.
-  
+
 ### Changes
 
 - **Improvement:** The `coverage` task now checks for the `lcov` dependency

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.6.4
+version: 3.6.5
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Use Github actions for CI (Bye Travis 👋)](https://github.com/Workiva/dart_dev/pull/348)
	* [DE-630: Delete docs.yaml file for Workiva/dart_dev](https://github.com/Workiva/dart_dev/pull/350)
	* [Widen Dependency Ranges Blocking Dart 2.13](https://github.com/Workiva/dart_dev/pull/352)


Requested by: @aaronlademann-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/3.6.4...Workiva:release_dart_dev_3.6.5
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/3.6.4...3.6.5

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?pull_number=353&repo_name=Workiva%2Fdart_dev)