### PR TITLE
CPLAT-15446: Improve criteria for using `build_runner` for tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.6.6](https://github.com/Workiva/dart_dev/compare/3.6.6...3.6.5)
+
+- Only use build_runner to run tests if the package has direct dependencies on
+both `build_runner` _and_ `build_test` (previously we only checked for
+`build_test`). For packages that contain builder implementations, they will
+likely have a dependency on `build_test` for use in their builder tests, but
+don't need to run tests via `build_runner`.
+
 ## [3.6.5](https://github.com/Workiva/dart_dev/compare/3.6.5...3.6.4)
 
 - Widen dependency ranges to allow resolution on Dart 2.7 and Dart 2.13

--- a/test/tools/fixtures/test/has_test_runner_and_build_test/pubspec.yaml
+++ b/test/tools/fixtures/test/has_test_runner_and_build_test/pubspec.yaml
@@ -1,9 +1,0 @@
-name: has_test_runner_and_build_test
-environment:
- sdk: ">=2.7.0 <3.0.0"
-dev_dependencies:
-  build_test: any
-  test: any
-
-workiva:
-  disable_core_checks: true

--- a/test/tools/fixtures/test/has_test_runner_missing_build_test/pubspec.yaml
+++ b/test/tools/fixtures/test/has_test_runner_missing_build_test/pubspec.yaml
@@ -1,8 +1,0 @@
-name: missing_test_runner
-environment:
- sdk: ">=2.7.0 <3.0.0"
-dev_dependencies:
-  test: any
-
-workiva:
-  disable_core_checks: true

--- a/test/tools/fixtures/test/missing_test_runner/pubspec.yaml
+++ b/test/tools/fixtures/test/missing_test_runner/pubspec.yaml
@@ -1,8 +1,0 @@
-name: missing_test_runner
-environment:
- sdk: ">=2.7.0 <3.0.0"
-dev_dependencies:
-  dart_style: any
-
-workiva:
-  disable_core_checks: true

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -6,6 +6,7 @@ import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
+import 'package:test_descriptor/test_descriptor.dart' as d;
 
 import 'package:dart_dev/src/tools/test_tool.dart';
 
@@ -110,7 +111,7 @@ void main() {
       test('forwards the --release flag', () {
         final argParser = TestTool().toCommand('t').argParser;
         final argResults = argParser.parse(['--release']);
-        expect(buildArgs(argResults: argResults, useBuildTest: true),
+        expect(buildArgs(argResults: argResults, useBuildRunner: true),
             orderedEquals(['run', 'build_runner', 'test', '--release']));
       });
 
@@ -123,7 +124,7 @@ void main() {
                 argResults: argResults,
                 configuredBuildArgs: ['-o', 'test:build'],
                 configuredTestArgs: ['-P', 'unit'],
-                useBuildTest: true),
+                useBuildRunner: true),
             orderedEquals([
               'run',
               'build_runner',
@@ -150,7 +151,7 @@ void main() {
               argResults: argResults,
               configuredBuildArgs: ['-o', 'test:build'],
               configuredTestArgs: ['-P', 'unit'],
-              useBuildTest: true,
+              useBuildRunner: true,
               verbose: true),
           orderedEquals([
             'run',
@@ -172,7 +173,7 @@ void main() {
     test('does not insert a duplicate verbose flag (-v)', () {
       expect(
           buildArgs(
-              configuredBuildArgs: ['-v'], useBuildTest: true, verbose: true),
+              configuredBuildArgs: ['-v'], useBuildRunner: true, verbose: true),
           orderedEquals(['run', 'build_runner', 'test', '-v']));
     });
 
@@ -180,7 +181,7 @@ void main() {
       expect(
           buildArgs(
               configuredBuildArgs: ['--verbose'],
-              useBuildTest: true,
+              useBuildRunner: true,
               verbose: true),
           orderedEquals(['run', 'build_runner', 'test', '--verbose']));
     });
@@ -200,61 +201,137 @@ void main() {
     });
 
     test(
-        'throws UsageException if --build-args is used but build_test is not '
-        'a direct dependency', () {
-      final path =
-          'test/tools/fixtures/test/has_test_runner_missing_build_test';
+        'throws UsageException if --build-args is used but build_runner is not '
+        'a direct dependency', () async {
+      await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_test: any
+  test: any
+''').create();
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['--build-args', 'foo']);
       final context = DevToolExecutionContext(argResults: argResults);
       expect(
-          () => buildExecution(context, path: path),
+          () => buildExecution(context, path: d.sandbox),
+          throwsA(isA<UsageException>()
+            ..having((e) => e.message, 'help', contains('--build-args'))
+            ..having((e) => e.message, 'help', contains('build_runner'))));
+    });
+
+    test(
+        'throws UsageException if --build-args is used but build_test is not '
+        'a direct dependency', () async {
+      await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_runner: any
+  test: any
+''').create();
+      final argParser = TestTool().toCommand('t').argParser;
+      final argResults = argParser.parse(['--build-args', 'foo']);
+      final context = DevToolExecutionContext(argResults: argResults);
+      expect(
+          () => buildExecution(context, path: d.sandbox),
           throwsA(isA<UsageException>()
             ..having((e) => e.message, 'help', contains('--build-args'))
             ..having((e) => e.message, 'help', contains('build_test'))));
     });
 
     test('returns config exit code and logs if test is not a direct dependency',
-        () {
+        () async {
       expect(
           Logger.root.onRecord,
           emitsThrough(severeLogOf(allOf(contains('Cannot run tests'),
               contains('"test" in pubspec.yaml')))));
-
-      final path = 'test/tools/fixtures/test/missing_test_runner';
+      await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+''').create();
       final context = DevToolExecutionContext();
-      expect(
-          buildExecution(context, path: path).exitCode, ExitCode.config.code);
+      expect(buildExecution(context, path: d.sandbox).exitCode,
+          ExitCode.config.code);
     });
 
     test(
         'returns config exit code and logs if configured to run tests with '
-        'build args but build_test is not a direct dependency', () {
+        'build args but build_runner is not a direct dependency', () async {
       expect(
           Logger.root.onRecord,
           emitsThrough(severeLogOf(allOf(
-              contains('"build_test" is not a direct dependency'),
+              contains('missing a direct dependency on'),
+              contains('build_runner'),
               contains('tool/dart_dev/config.dart'),
               contains('pubspec.yaml')))));
-
-      final path =
-          'test/tools/fixtures/test/has_test_runner_missing_build_test';
+      await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_test: any
+  test: any
+''').create();
       final context = DevToolExecutionContext();
       expect(
           buildExecution(context,
-                  configuredBuildArgs: ['-o', 'test:build'], path: path)
+                  configuredBuildArgs: ['-o', 'test:build'], path: d.sandbox)
+              .exitCode,
+          ExitCode.config.code);
+    });
+
+    test(
+        'returns config exit code and logs if configured to run tests with '
+        'build args but build_test is not a direct dependency', () async {
+      expect(
+          Logger.root.onRecord,
+          emitsThrough(severeLogOf(allOf(
+              contains('missing a direct dependency on'),
+              contains('build_test'),
+              contains('tool/dart_dev/config.dart'),
+              contains('pubspec.yaml')))));
+      await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_runner: any
+  test: any
+''').create();
+      final context = DevToolExecutionContext();
+      expect(
+          buildExecution(context,
+                  configuredBuildArgs: ['-o', 'test:build'], path: d.sandbox)
               .exitCode,
           ExitCode.config.code);
     });
 
     group('returns a TestExecution', () {
-      final path =
-          'test/tools/fixtures/test/has_test_runner_missing_build_test';
+      group('in a project without build_runner', () {
+        setUp(() async {
+          await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_test: any
+  test: any
+''').create();
+        });
 
-      group('in a project without build_test', () {
         test('', () {
           final context = DevToolExecutionContext();
-          final execution = buildExecution(context, path: path);
+          final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'pub');
           expect(execution.process.args, orderedEquals(['run', 'test']));
@@ -265,7 +342,7 @@ void main() {
           final argResults = argParser.parse(['--test-args', '-n foo']);
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context,
-              configuredTestArgs: ['-P', 'unit'], path: path);
+              configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'pub');
           expect(execution.process.args,
@@ -284,7 +361,7 @@ void main() {
                   final argResults = argParser.parse(['--release']);
                   final context =
                       DevToolExecutionContext(argResults: argResults);
-                  buildExecution(context, path: path);
+                  buildExecution(context, path: d.sandbox);
                 }));
 
         test('and logs the test subprocess', () {
@@ -295,16 +372,87 @@ void main() {
           final argResults = argParser.parse(['--test-args', '-n foo']);
           final context = DevToolExecutionContext(argResults: argResults);
           buildExecution(context,
-              configuredTestArgs: ['-P', 'unit'], path: path);
+              configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
         });
       });
 
-      group('in a project with build_test', () {
-        final path = 'test/tools/fixtures/test/has_test_runner_and_build_test';
+      group('in a project without build_test', () {
+        setUp(() async {
+          await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_runner: any
+  test: any
+''').create();
+        });
 
         test('', () {
           final context = DevToolExecutionContext();
-          final execution = buildExecution(context, path: path);
+          final execution = buildExecution(context, path: d.sandbox);
+          expect(execution.exitCode, isNull);
+          expect(execution.process.executable, 'pub');
+          expect(execution.process.args, orderedEquals(['run', 'test']));
+        });
+
+        test('with args', () {
+          final argParser = TestTool().toCommand('t').argParser;
+          final argResults = argParser.parse(['--test-args', '-n foo']);
+          final context = DevToolExecutionContext(argResults: argResults);
+          final execution = buildExecution(context,
+              configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
+          expect(execution.exitCode, isNull);
+          expect(execution.process.executable, 'pub');
+          expect(execution.process.args,
+              orderedEquals(['run', 'test', '-P', 'unit', '-n', 'foo']));
+        });
+
+        test(
+            'and logs a warning if --release is used in a non-build project',
+            () => overrideAnsiOutput(false, () {
+                  expect(
+                      Logger.root.onRecord,
+                      emitsThrough(warningLogOf(
+                          contains('The --release flag is only applicable'))));
+
+                  final argParser = TestTool().toCommand('t').argParser;
+                  final argResults = argParser.parse(['--release']);
+                  final context =
+                      DevToolExecutionContext(argResults: argResults);
+                  buildExecution(context, path: d.sandbox);
+                }));
+
+        test('and logs the test subprocess', () {
+          expect(Logger.root.onRecord,
+              emitsThrough(infoLogOf(contains('pub run test -P unit -n foo'))));
+
+          final argParser = TestTool().toCommand('t').argParser;
+          final argResults = argParser.parse(['--test-args', '-n foo']);
+          final context = DevToolExecutionContext(argResults: argResults);
+          buildExecution(context,
+              configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
+        });
+      });
+
+      group('in a project with build_runner and build_test', () {
+        setUp(() async {
+          await d.file('pubspec.yaml', '''
+name: _test
+publish_to: none
+environment:
+  sdk: '>=2.7.0 <3.0.0'
+dev_dependencies:
+  build_runner: any
+  build_test: any
+  test: any
+''').create();
+        });
+
+        test('', () {
+          final context = DevToolExecutionContext();
+          final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'pub');
           expect(execution.process.args,
@@ -319,7 +467,7 @@ void main() {
           final execution = buildExecution(context,
               configuredBuildArgs: ['foo'],
               configuredTestArgs: ['-P', 'unit'],
-              path: path);
+              path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'pub');
           expect(
@@ -348,7 +496,7 @@ void main() {
           final execution = buildExecution(context,
               configuredBuildArgs: ['foo'],
               configuredTestArgs: ['-P', 'unit'],
-              path: path);
+              path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'pub');
           expect(
@@ -383,7 +531,7 @@ void main() {
           buildExecution(context,
               configuredBuildArgs: ['foo'],
               configuredTestArgs: ['-P', 'unit'],
-              path: path);
+              path: d.sandbox);
         });
       });
     });


### PR DESCRIPTION
Now only uses `build_runner` to run tests if the package has a direct dependency on both `build_runner` and `build_test` (previously we only checked for `build_test`). For packages that contain builder implementations, they will likely have a dependency on `build_test` for use in their builder tests, but don't need to run tests via `build_runner`.