### PR TITLE
RM-110307 Release dart_dev 3.6.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.6.5
+version: 3.6.6
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [CPLAT-15446: Improve criteria for using `build_runner` for tests](https://github.com/Workiva/dart_dev/pull/354)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/3.6.5...Workiva:release_dart_dev_3.6.6
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/3.6.5...3.6.6

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?pull_number=355&repo_name=Workiva%2Fdart_dev)