### PR TITLE
Treat Dart 2.13.4 as the primary SDK version for dev and CI

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.7.2, stable, dev ]
+        sdk: [ 2.7.2, 2.13.4, stable, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
@@ -46,6 +46,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v0.2
+        with:
+          sdk: 2.13.4
 
       - name: Print Dart SDK version
         run: dart --version
@@ -55,9 +57,9 @@ jobs:
         run: pub get
 
       - name: Verify formatting
-        run: pub run dart_dev format --check
+        run: dart run dart_dev format --check
         if: always() && steps.install.outcome == 'success'
 
       - name: Publish dry run
-        run: pub publish --dry-run
+        run: dart pub publish --dry-run
         if: always() && steps.install.outcome == 'success'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.6.7](https://github.com/Workiva/dart_dev/compare/3.6.7...3.6.6)
+
+- Treat Dart 2.13.4 as the primary Dart SDK for development and CI.
+
 ## [3.6.6](https://github.com/Workiva/dart_dev/compare/3.6.6...3.6.5)
 
 - Only use build_runner to run tests if the package has direct dependencies on

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.7
+FROM google/dart:2.13.4
 WORKDIR /build
 ADD pubspec.yaml /build
 RUN pub get


### PR DESCRIPTION
### Problem:
Currently we treat Dart 2.7.2 as our primary SDK target when running CI. At Workiva, we're transitioning to Dart 2.13.4 as our primary version for development. Perhaps we should treat it as our primary target in CI.

### Solution:
- Updated Dockerfile to use the google/dart:2.13.4 image.
- Updated dart_ci.yaml to explicitly run on Dart 2.13.4 and make sure we're checking formatting on that version of the SDK.
  - I left 2.7.2 in the test matrix since we technically still support older versions of Dart.