### PR TITLE
RM-114253 Release dart_dev 3.6.7

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.6.6
+version: 3.6.7
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Treat Dart 2.13.4 as the primary SDK version for dev and CI](https://github.com/Workiva/dart_dev/pull/356)


Requested by: @todbachman-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/3.6.6...Workiva:release_dart_dev_3.6.7
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/3.6.6...3.6.7

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?pull_number=357&repo_name=Workiva%2Fdart_dev)