### PR TITLE
Export the ArgResults utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.7.0](https://github.com/Workiva/dart_dev/compare/3.7.0...3.6.7)
+
+- Export ArgResults utilities.
+
 ## [3.6.7](https://github.com/Workiva/dart_dev/compare/3.6.7...3.6.6)
 
 - Treat Dart 2.13.4 as the primary Dart SDK for development and CI.

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,3 +1,4 @@
+export 'src/utils/arg_results_utils.dart';
 export 'src/utils/assert_no_positional_args_nor_args_after_separator.dart';
 export 'src/utils/cached_pubspec.dart';
 export 'src/utils/ensure_process_exit.dart';


### PR DESCRIPTION
### Problem:
dart_dev has some fine ArgResults utilities that are useful for authors of new dart_dev tools.

### Solution:
Added an export for `src/utils/arg_results_utils.dart`.