### PR TITLE
CPLAT-15507: ddev should use new dart CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,9 @@ memorized or referenced in order to run said task.
 Consider formatting as an example. The default approach to formatting files is
 to run `dartfmt -w .`. But, some projects may want to exclude certain files that
 would otherwise be formatted by this command. Or, some projects may want to use
-`dart run dart_style:format` instead of `dartfmt` or `dart format` instead of 
-`dartfmt`. Currently, there is no project-level configuration supported by the 
-formatter, so these sorts of things just have to be documented in a `README.md` 
-or `CONTRIBUTING.md`.
+`pub run dart_style:format` instead of `dart format`. Currently, there is no
+project-level configuration supported by the formatter, so these sorts of things
+just have to be documented in a `README.md` or `CONTRIBUTING.md`.
 
 With `dart_dev`, this can be accomplished like so:
 
@@ -145,10 +144,10 @@ Using existing tooling provided by (or conventionalized by) the Dart community
 should always be the goal, but the reality is that there are gaps. Certain use
 cases can be made more convenient and new use cases may arise.
 
-Consider test running as an example. For simple projects, `dart run test` is
+Consider test running as an example. For simple projects, `dart test` is
 sufficient. In fact, the test package supports a huge amount of project-level
 configuration via `dart_test.yaml`, which means that for projects that are
-properly configured, `dart run test` just works.
+properly configured, `dart test` just works.
 
 Unfortunately, at this time, projects that rely on builders must run tests via
 `dart run build_runner test`. Based on the project, you would need to know which
@@ -157,13 +156,13 @@ test command should be run.
 With `dart_dev`, the `TestTool` handles this automatically by checking the
 project's `pubspec.yaml` for a dependency on `build_test`. If present, tests
 will be run via `dart run build_runner test`, otherwise it falls back to the
-default of `dart run test`.
+default of `dart test`.
 
 ```bash
 # In a project without a `build_test` dependency:
 $ ddev test
 [INFO] Running subprocess:
-dart run test
+dart test
 ----------------------------
 00:01 +75: All tests passed!
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ By default, this provides three core tasks:
 Run any of these tools via the `dart_dev` command-line app:
 
 ```bash
-$ pub run dart_dev analyze
+$ dart run dart_dev analyze
 [INFO] Running subprocess:
 dartanalyzer .
 --------------------------
@@ -51,7 +51,7 @@ No issues found!
 > We recommend adding a `ddev` alias:
 >
 > ```bash
-> alias ddev='pub run dart_dev'
+> alias ddev='dart run dart_dev'
 > ```
 
 Additional Dart developer tools can be added and every tool can be configured.
@@ -79,7 +79,7 @@ final config = {
 Most Dart projects eventually share a common set of development requirements
 (e.g. static analysis, formatting, test running, serving, etc.). The Dart SDK
 along with some core packages supply the necessary tooling for these developer
-tasks (e.g. `dartanalyzer`, `dartfmt`, or `pub run test`).
+tasks (e.g. `dartanalyzer`, `dartfmt`, or `dart run test`).
 
 While the core tooling gets us far, there are two areas in which we feel it
 falls short:
@@ -110,7 +110,7 @@ memorized or referenced in order to run said task.
 Consider formatting as an example. The default approach to formatting files is
 to run `dartfmt -w .`. But, some projects may want to exclude certain files that
 would otherwise be formatted by this command. Or, some projects may want to use
-`pub run dart_style:format` instead of `dartfmt`. Currently, there is no
+`dart run dart_style:format` instead of `dartfmt`. Currently, there is no
 project-level configuration supported by the formatter, so these sorts of things
 just have to be documented in a `README.md` or `CONTRIBUTING.md`.
 
@@ -131,7 +131,7 @@ final config = {
 ```bash
 $ ddev format
 [INFO] Running subprocess:
-pub run dart_style:format -w <3 paths>
+dart run dart_style:format -w <3 paths>
 --------------------------------------
 Unchanged ./lib/foo.dart
 Unchanged ./lib/src/bar.dart
@@ -144,25 +144,25 @@ Using existing tooling provided by (or conventionalized by) the Dart community
 should always be the goal, but the reality is that there are gaps. Certain use
 cases can be made more convenient and new use cases may arise.
 
-Consider test running as an example. For simple projects, `pub run test` is
+Consider test running as an example. For simple projects, `dart run test` is
 sufficient. In fact, the test package supports a huge amount of project-level
 configuration via `dart_test.yaml`, which means that for projects that are
-properly configured, `pub run test` just works.
+properly configured, `dart run test` just works.
 
 Unfortunately, at this time, projects that rely on builders must run tests via
-`pub run build_runner test`. Based on the project, you would need to know which
+`dart run build_runner test`. Based on the project, you would need to know which
 test command should be run.
 
 With `dart_dev`, the `TestTool` handles this automatically by checking the
 project's `pubspec.yaml` for a dependency on `build_test`. If present, tests
-will be run via `pub run build_runner test`, otherwise it falls back to the
-default of `pub run test`.
+will be run via `dart run build_runner test`, otherwise it falls back to the
+default of `dart run test`.
 
 ```bash
 # In a project without a `build_test` dependency:
 $ ddev test
 [INFO] Running subprocess:
-pub run test
+dart run test
 ----------------------------
 00:01 +75: All tests passed!
 
@@ -170,7 +170,7 @@ pub run test
 # In a project with a `build_test` dependency:
 $ ddev test
 [INFO] Running subprocess:
-pub run build_runner test
+dart run build_runner test
 ----------------------------
 [INFO] Generating build script completed, took 425ms
 [INFO] Creating build script snapshot... completed, took 13.6s
@@ -187,7 +187,7 @@ Running tests...
 ```
 
 Additionally, `TestTool` automatically applies [`--build-filter`][build-filter]
-options to the `pub run build_runner test` command to help reduce build time and
+options to the `dart run build_runner test` command to help reduce build time and
 speed up dev iteration when running a subset of the available tests.
 
 Generally speaking, these dart tool abstractions provide a place to address

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Run any of these tools via the `dart_dev` command-line app:
 ```bash
 $ dart run dart_dev analyze
 [INFO] Running subprocess:
-dartanalyzer .
+dart analyze .
 --------------------------
 Analyzing dart_dev...
 No issues found!
@@ -79,7 +79,7 @@ final config = {
 Most Dart projects eventually share a common set of development requirements
 (e.g. static analysis, formatting, test running, serving, etc.). The Dart SDK
 along with some core packages supply the necessary tooling for these developer
-tasks (e.g. `dartanalyzer`, `dartfmt`, or `dart run test`).
+tasks (e.g. `dart analyze`, `dart format`, or `dart test`).
 
 While the core tooling gets us far, there are two areas in which we feel it
 falls short:
@@ -110,9 +110,10 @@ memorized or referenced in order to run said task.
 Consider formatting as an example. The default approach to formatting files is
 to run `dartfmt -w .`. But, some projects may want to exclude certain files that
 would otherwise be formatted by this command. Or, some projects may want to use
-`dart run dart_style:format` instead of `dartfmt`. Currently, there is no
-project-level configuration supported by the formatter, so these sorts of things
-just have to be documented in a `README.md` or `CONTRIBUTING.md`.
+`dart run dart_style:format` instead of `dartfmt` or `dart format` instead of 
+`dartfmt`. Currently, there is no project-level configuration supported by the 
+formatter, so these sorts of things just have to be documented in a `README.md` 
+or `CONTRIBUTING.md`.
 
 With `dart_dev`, this can be accomplished like so:
 
@@ -222,7 +223,7 @@ final config = {
 
   // Override a target by including it after `...coreConfig`:
   'format': FormatTool()
-    ..formatter = Formatter.dartStyle,
+    ..formatter = Formatter.dartFormat,
 
   // Add a custom target:
   'github': ProcessTool(

--- a/doc/tools/test-tool.md
+++ b/doc/tools/test-tool.md
@@ -18,23 +18,23 @@ final config = {
 
 ## `test` vs `build_runner test`
 
-Historically, `pub run test` has been the canonical way to run Dart tests.
+Historically, `dart run test` has been the canonical way to run Dart tests.
 With the introduction of the [build system][build-system], there is now a second
 way to run tests. Projects that rely on builder outputs must run tests via
-`pub run build_runner test`.
+`dart run build_runner test`.
 
 The `TestTool` will make this choice for you. If the current project has a
-dependency on `build_test`, it will run `pub run build_runner test`. Otherwise
-it will default to running `pub run test`.
+dependency on `build_test`, it will run `dart run build_runner test`. Otherwise
+it will default to running `dart run test`.
 
 > It [appears][test-future] as though the long term goal is to integrate the
-> build system into the test runner so that `pub run test` is once again the
+> build system into the test runner so that `dart run test` is once again the
 > canonical way to run tests.
 
 ## Default behavior
 
-By default this tool will run `pub run test`, unless there is a dependency on
-`build_test`, in which case it will run `pub run build_runner test`.
+By default this tool will run `dart run test`, unless there is a dependency on
+`build_test`, in which case it will run `dart run build_runner test`.
 
 ## Running a subset of tests
 
@@ -71,10 +71,10 @@ Usage: dart_dev test [files or directories...]
 ======== Other Options
     --test-stdout       Write the test process stdout to this file path.
     --test-args         Args to pass to the test runner process.
-                        Run "pub run test -h -v" to see all available options.
+                        Run "dart run test -h -v" to see all available options.
 
     --build-args        Args to pass to the build runner process.
-                        Run "pub run build_runner test -h -v" to see all available options.
+                        Run "dart run build_runner test -h -v" to see all available options.
                         Note: these args are only applicable if the current project depends on "build_test".
 
 -h, --help              Print this usage information.
@@ -89,7 +89,7 @@ iterating on tests much more efficient.
 ```bash
 $ ddev test test/foo/bar/ test/baz_test.dart
 [INFO] Running subprocess:
-pub run build_runner test --build-filter=test/foo/bar/** --build-filter=test/baz_test.dart.*_test.dart.js --build-filter=test/baz_test.html -- test/foo/bar/ test/baz_test.dart
+dart run build_runner test --build-filter=test/foo/bar/** --build-filter=test/baz_test.dart.*_test.dart.js --build-filter=test/baz_test.html -- test/foo/bar/ test/baz_test.dart
 ----------------------------------------------------------------------------
 ```
 

--- a/doc/tools/test-tool.md
+++ b/doc/tools/test-tool.md
@@ -18,22 +18,22 @@ final config = {
 
 ## `test` vs `build_runner test`
 
-Historically, `dart run test` has been the canonical way to run Dart tests.
+Historically, `dart test` has been the canonical way to run Dart tests.
 With the introduction of the [build system][build-system], there is now a second
 way to run tests. Projects that rely on builder outputs must run tests via
 `dart run build_runner test`.
 
 The `TestTool` will make this choice for you. If the current project has a
 dependency on `build_test`, it will run `dart run build_runner test`. Otherwise
-it will default to running `dart run test`.
+it will default to running `dart test`.
 
 > It [appears][test-future] as though the long term goal is to integrate the
-> build system into the test runner so that `dart run test` is once again the
+> build system into the test runner so that `dart test` is once again the
 > canonical way to run tests.
 
 ## Default behavior
 
-By default this tool will run `dart run test`, unless there is a dependency on
+By default this tool will run `dart test`, unless there is a dependency on
 `build_test`, in which case it will run `dart run build_runner test`.
 
 ## Running a subset of tests
@@ -71,7 +71,7 @@ Usage: dart_dev test [files or directories...]
 ======== Other Options
     --test-stdout       Write the test process stdout to this file path.
     --test-args         Args to pass to the test runner process.
-                        Run "dart run test -h -v" to see all available options.
+                        Run "dart test -h -v" to see all available options.
 
     --build-args        Args to pass to the build runner process.
                         Run "dart run build_runner test -h -v" to see all available options.

--- a/doc/tools/tuneup-check-tool.md
+++ b/doc/tools/tuneup-check-tool.md
@@ -30,12 +30,12 @@ final config = {
 
 ## Default behavior
 
-By default this tool will run `pub run tuneup check` which will analyze all dart
+By default this tool will run `dart run tuneup check` which will analyze all dart
 files in the current project.
 
 ## Ignoring info outputs
 
-By default, `pub run tuneup check` will include "info"-level analysis messages
+By default, `dart run tuneup check` will include "info"-level analysis messages
 in its output and fail if there are any. You can tell tuneup to ignore these:
 
 ```dart

--- a/doc/tools/webdev-serve-tool.md
+++ b/doc/tools/webdev-serve-tool.md
@@ -16,7 +16,7 @@ final config = {
 
 ## Default behavior
 
-By default this tool will run `pub global run webdev serve` which will build the
+By default this tool will run `dart pub global run webdev serve` which will build the
 `web/` directory using the Dart Dev Compiler and serve it on port 8080.
 
 ## Configuration

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -16,13 +16,14 @@ import '../utils/run_process_and_ensure_exit.dart';
 final _log = Logger('Analyze');
 
 /// A dart_dev tool that runs the `dartanalyzer` or `dart analyze` on the current project.
+/// If the `useDartAnalyze` flag is not specified it will default to `dartanalyzer`.
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
 ///     import 'package:dart_dev/dart_dev.dart';
 ///
 ///     final config = {
-///       'analyze': AnalyzeTool(),
+///       'analyze': AnalyzeTool() ..useDartAnalyze = true,
 ///     };
 ///
 /// This will make it available via the `dart_dev` command-line app like so:
@@ -82,7 +83,8 @@ class AnalyzeTool extends DevTool {
   }
 }
 
-/// Returns a combined list of args for the `dartanalyzer` process.
+/// Returns a combined list of args for the `dartanalyzer`
+/// or `dart analyze` process.
 ///
 /// If [configuredAnalyzerArgs] is non-null, they will be included first.
 ///
@@ -151,6 +153,9 @@ Iterable<String> buildEntrypoints({List<Glob> include, String root}) {
 /// If non-null, [path] will override the current working directory for any
 /// operations that require it. This is intended for use by tests.
 ///
+/// If true, [useDartAnalyze] will utilize `dart analyze` for analysis.
+/// If null, it will default to utilze `dartanalyzer`.
+///
 /// The [AnalyzeTool] can be tested almost completely via this function by
 /// enumerating all of the possible parameter variations and making assertions
 /// on the declarative output.
@@ -192,8 +197,8 @@ ProcessDeclaration buildProcess(
 void logCommand(
   Iterable<String> args,
   Iterable<String> entrypoints, {
-  bool verbose,
   bool useDartAnalyzer,
+  bool verbose,
 }) {
   useDartAnalyzer ??= false;
   verbose ??= false;

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -26,7 +26,7 @@ final _log = Logger('Analyze');
 ///     };
 ///
 /// This will make it available via the `dart_dev` command-line app like so:
-///     pub run dart_dev analyze
+///     dart run dart_dev analyze
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -45,7 +45,12 @@ class AnalyzeTool extends DevTool {
   /// Run `dartanalyzer -h -v` to see all available args.
   List<String> analyzerArgs;
 
-  final supportedAnalyzerArgs = ['-v', '--verbose', '--fatal-warnings', '--fatal-infos'];
+  final supportedAnalyzerArgs = [
+    '-v',
+    '--verbose',
+    '--fatal-warnings',
+    '--fatal-infos'
+  ];
 
   /// The globs to include as entry points to run static analysis on.
   ///
@@ -70,20 +75,21 @@ class AnalyzeTool extends DevTool {
 
   @override
   FutureOr<int> run([DevToolExecutionContext context]) {
-      useDartAnalyze ??= false;
-      filterUnsupportedAnalyzerArgs();
-      return runProcessAndEnsureExit(
-          buildProcess(context ?? DevToolExecutionContext(),
-              configuredAnalyzerArgs: analyzerArgs, include: include, useDartAnalyze: useDartAnalyze),
-          log: _log);
+    useDartAnalyze ??= false;
+    filterUnsupportedAnalyzerArgs();
+    return runProcessAndEnsureExit(
+        buildProcess(context ?? DevToolExecutionContext(),
+            configuredAnalyzerArgs: analyzerArgs,
+            include: include,
+            useDartAnalyze: useDartAnalyze),
+        log: _log);
   }
 
   void filterUnsupportedAnalyzerArgs() {
     if (useDartAnalyze) {
-       analyzerArgs?.removeWhere((arg) => !supportedAnalyzerArgs.contains(arg));
+      analyzerArgs?.removeWhere((arg) => !supportedAnalyzerArgs.contains(arg));
     }
   }
-
 }
 
 /// Returns a combined list of args for the `dartanalyzer` process.
@@ -95,12 +101,11 @@ class AnalyzeTool extends DevTool {
 ///
 /// If [verbose] is true and the verbose flag (`-v`) is not already included, it
 /// will be added.
-Iterable<String> buildArgs({
-  ArgResults argResults,
-  List<String> configuredAnalyzerArgs,
-  bool verbose,
-  bool useDartAnalyze
-}) {
+Iterable<String> buildArgs(
+    {ArgResults argResults,
+    List<String> configuredAnalyzerArgs,
+    bool verbose,
+    bool useDartAnalyze}) {
   verbose ??= false;
   final args = <String>[
     // Combine all args that should be passed through to the dart executable in
@@ -179,7 +184,8 @@ ProcessDeclaration buildProcess(
   final args = buildArgs(
       argResults: context.argResults,
       configuredAnalyzerArgs: configuredAnalyzerArgs,
-      verbose: context.verbose, useDartAnalyze: useDartAnalyze);
+      verbose: context.verbose,
+      useDartAnalyze: useDartAnalyze);
   final entrypoints = buildEntrypoints(include: include, root: path);
   logCommand(args, entrypoints, verbose: context.verbose);
   return ProcessDeclaration(analyzerCommand, [...args, ...entrypoints],

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -191,7 +191,8 @@ ProcessDeclaration buildProcess(
       verbose: context.verbose,
       useDartAnalyze: useDartAnalyze);
   final entrypoints = buildEntrypoints(include: include, root: path);
-  logCommand(args, entrypoints, verbose: context.verbose);
+  logCommand(args, entrypoints,
+      verbose: context.verbose, useDartAnalyzer: useDartAnalyze);
   return ProcessDeclaration(analyzerCommand, [...args, ...entrypoints],
       mode: ProcessStartMode.inheritStdio);
 }
@@ -205,9 +206,11 @@ void logCommand(
   Iterable<String> args,
   Iterable<String> entrypoints, {
   bool verbose,
+  bool useDartAnalyzer,
 }) {
   verbose ??= false;
-  final exeAndArgs = 'dart analyze ${args.join(' ')}'.trim();
+  final exeAndArgs =
+      '${useDartAnalyzer ? "dart " : "dartanalyzer"} ${args.join(' ')}'.trim();
   if (entrypoints.length <= 5 || verbose) {
     logSubprocessHeader(_log, '$exeAndArgs ${entrypoints.join(' ')}');
   } else {

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -36,7 +36,7 @@ final _log = Logger('Analyze');
 ///       'analyze': AnalyzeTool()
 ///         ..analyzerArgs = ['--fatal-infos']
 ///         ..include = [Glob('.'), Glob('other/**.dart')],
-///         ..useDartAnalyze = false
+///         ..useDartAnalyze = true
 ///     };
 ///
 /// It is also possible to run this tool directly in a dart script:
@@ -94,14 +94,15 @@ class AnalyzeTool extends DevTool {
 Iterable<String> buildArgs(
     {ArgResults argResults,
     List<String> configuredAnalyzerArgs,
-    bool verbose,
-    bool useDartAnalyze}) {
+    bool useDartAnalyze,
+    bool verbose}) {
+  useDartAnalyze ??= false;
   verbose ??= false;
   final args = <String>[
     // Combine all args that should be passed through to the analyzer in
     // this order:
     // 1. The analyze command if using dart analyze
-    useDartAnalyze ? 'analyze' : null,
+    if (useDartAnalyze) 'analyze',
     // 2. Statically configured args from [AnalyzeTool.analyzerArgs]
     ...?configuredAnalyzerArgs,
     // 3. Args passed to --analyzer-args
@@ -110,7 +111,6 @@ Iterable<String> buildArgs(
   if (verbose && !args.contains('-v') && !args.contains('--verbose')) {
     args.add('-v');
   }
-  args.removeWhere((item) => item == null);
   return args;
 }
 
@@ -161,6 +161,7 @@ ProcessDeclaration buildProcess(
   String path,
   bool useDartAnalyze,
 }) {
+  useDartAnalyze ??= false;
   if (context.argResults != null) {
     final analyzerUsed = useDartAnalyze ? 'dart analyze' : 'dartanalyzer';
     assertNoPositionalArgsNorArgsAfterSeparator(
@@ -170,7 +171,7 @@ ProcessDeclaration buildProcess(
             'Arguments can be passed to the "${analyzerUsed}" process via '
             'the --analyzer-args option.');
   }
-  final analyzerCommand = useDartAnalyze ? 'dart' : 'dartanalyzer';
+  final executable = useDartAnalyze ? 'dart' : 'dartanalyzer';
   final args = buildArgs(
       argResults: context.argResults,
       configuredAnalyzerArgs: configuredAnalyzerArgs,
@@ -179,7 +180,7 @@ ProcessDeclaration buildProcess(
   final entrypoints = buildEntrypoints(include: include, root: path);
   logCommand(args, entrypoints,
       verbose: context.verbose, useDartAnalyzer: useDartAnalyze);
-  return ProcessDeclaration(analyzerCommand, [...args, ...entrypoints],
+  return ProcessDeclaration(executable, [...args, ...entrypoints],
       mode: ProcessStartMode.inheritStdio);
 }
 
@@ -194,6 +195,7 @@ void logCommand(
   bool verbose,
   bool useDartAnalyzer,
 }) {
+  useDartAnalyzer ??= false;
   verbose ??= false;
   final exeAndArgs =
       '${useDartAnalyzer ? "dart" : "dartanalyzer"} ${args.join(' ')}'.trim();

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -96,6 +96,7 @@ Iterable<String> buildArgs(
     bool verbose,
     bool useDartAnalyze}) {
   verbose ??= false;
+  print('poo');
   final args = <String>[
     // Combine all args that should be passed through to the analyzer in
     // this order:
@@ -110,6 +111,7 @@ Iterable<String> buildArgs(
     args.add('-v');
   }
   args.removeWhere((item) => item == null);
+  print('ajw args ${args}');
   return args;
 }
 
@@ -169,7 +171,7 @@ ProcessDeclaration buildProcess(
             'Arguments can be passed to the "${analyzerUsed}" process via '
             'the --analyzer-args option.');
   }
-  final analyzerCommand = useDartAnalyze ? 'dart' : 'dartanalyzer';
+  final analyzerCommand = useDartAnalyze ? 'dart ' : 'dartanalyzer';
   final args = buildArgs(
       argResults: context.argResults,
       configuredAnalyzerArgs: configuredAnalyzerArgs,
@@ -196,6 +198,7 @@ void logCommand(
   verbose ??= false;
   final exeAndArgs =
       '${useDartAnalyzer ? "dart" : "dartanalyzer"} ${args.join(' ')}'.trim();
+
   if (entrypoints.length <= 5 || verbose) {
     logSubprocessHeader(_log, '$exeAndArgs ${entrypoints.join(' ')}');
   } else {

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -96,7 +96,6 @@ Iterable<String> buildArgs(
     bool verbose,
     bool useDartAnalyze}) {
   verbose ??= false;
-  print('poo');
   final args = <String>[
     // Combine all args that should be passed through to the analyzer in
     // this order:
@@ -111,7 +110,6 @@ Iterable<String> buildArgs(
     args.add('-v');
   }
   args.removeWhere((item) => item == null);
-  print('ajw args ${args}');
   return args;
 }
 
@@ -171,7 +169,7 @@ ProcessDeclaration buildProcess(
             'Arguments can be passed to the "${analyzerUsed}" process via '
             'the --analyzer-args option.');
   }
-  final analyzerCommand = useDartAnalyze ? 'dart ' : 'dartanalyzer';
+  final analyzerCommand = useDartAnalyze ? 'dart' : 'dartanalyzer';
   final args = buildArgs(
       argResults: context.argResults,
       configuredAnalyzerArgs: configuredAnalyzerArgs,

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -67,11 +67,17 @@ class AnalyzeTool extends DevTool {
   String description = 'Run static analysis on dart files in this package.';
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) =>
-      runProcessAndEnsureExit(
+  FutureOr<int> run([DevToolExecutionContext context]) {
+      filterUnsupportedAnalyzerArgs();
+      return runProcessAndEnsureExit(
           buildProcess(context ?? DevToolExecutionContext(),
               configuredAnalyzerArgs: analyzerArgs, include: include),
           log: _log);
+  }
+
+  void filterUnsupportedAnalyzerArgs() =>
+    analyzerArgs?.removeWhere((arg) => !supportedAnalyzerArgs.contains(arg));
+    
 }
 
 /// Returns a combined list of args for the `dartanalyzer` process.
@@ -91,7 +97,7 @@ Iterable<String> buildArgs({
 }) {
   verbose ??= false;
   final args = <String>[
-    // Combine all args that should be passed through to the dart command in
+    // Combine all args that should be passed through to the dart executable in
     // this order:
     // 1. The analyze command
     'analyze',

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -46,13 +46,6 @@ class AnalyzeTool extends DevTool {
   /// Run `dartanalyzer -h -v` or `dart analyze -h -v` to see all available args.
   List<String> analyzerArgs;
 
-  final supportedDartAnalyzeArgs = [
-    '-v',
-    '--verbose',
-    '--fatal-warnings',
-    '--fatal-infos'
-  ];
-
   /// The globs to include as entry points to run static analysis on.
   ///
   /// The default is `.` (e.g. `dartanalyzer .`) which runs analysis on all Dart
@@ -79,20 +72,12 @@ class AnalyzeTool extends DevTool {
   @override
   FutureOr<int> run([DevToolExecutionContext context]) {
     useDartAnalyze ??= false;
-    filterUnsupportedAnalyzerArgs();
     return runProcessAndEnsureExit(
         buildProcess(context ?? DevToolExecutionContext(),
             configuredAnalyzerArgs: analyzerArgs,
             include: include,
             useDartAnalyze: useDartAnalyze),
         log: _log);
-  }
-
-  void filterUnsupportedAnalyzerArgs() {
-    if (useDartAnalyze) {
-      analyzerArgs
-          ?.removeWhere((arg) => !supportedDartAnalyzeArgs.contains(arg));
-    }
   }
 }
 
@@ -112,7 +97,7 @@ Iterable<String> buildArgs(
     bool useDartAnalyze}) {
   verbose ??= false;
   final args = <String>[
-    // Combine all args that should be passed through to the dart executable in
+    // Combine all args that should be passed through to the analyzer in
     // this order:
     // 1. The analyze command if using dart analyze
     useDartAnalyze ? 'analyze' : null,
@@ -197,7 +182,7 @@ ProcessDeclaration buildProcess(
       mode: ProcessStartMode.inheritStdio);
 }
 
-/// Logs the `dartanalyzer` command that will be run by [AnalyzeTool] so that
+/// Logs the `dartanalyzer` or `dart analyze` command that will be run by [AnalyzeTool] so that
 /// consumers can run it directly for debugging purposes.
 ///
 /// Unless [verbose] is true, the list of entrypoints will be abbreviated to
@@ -210,7 +195,7 @@ void logCommand(
 }) {
   verbose ??= false;
   final exeAndArgs =
-      '${useDartAnalyzer ? "dart " : "dartanalyzer"} ${args.join(' ')}'.trim();
+      '${useDartAnalyzer ? "dart" : "dartanalyzer"} ${args.join(' ')}'.trim();
   if (entrypoints.length <= 5 || verbose) {
     logSubprocessHeader(_log, '$exeAndArgs ${entrypoints.join(' ')}');
   } else {

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -45,6 +45,8 @@ class AnalyzeTool extends DevTool {
   /// Run `dartanalyzer -h -v` to see all available args.
   List<String> analyzerArgs;
 
+  final supportedAnalyzerArgs = ['-v', '--verbose', '--fatal-warnings', '--fatal-infos'];
+
   /// The globs to include as entry points to run static analysis on.
   ///
   /// The default is `.` (e.g. `dartanalyzer .`) which runs analysis on all Dart
@@ -81,6 +83,7 @@ class AnalyzeTool extends DevTool {
 ///
 /// If [verbose] is true and the verbose flag (`-v`) is not already included, it
 /// will be added.
+// ajw
 Iterable<String> buildArgs({
   ArgResults argResults,
   List<String> configuredAnalyzerArgs,
@@ -88,11 +91,13 @@ Iterable<String> buildArgs({
 }) {
   verbose ??= false;
   final args = <String>[
-    // Combine all args that should be passed through to the dartanalyzer in
+    // Combine all args that should be passed through to the dart command in
     // this order:
-    // 1. Statically configured args from [AnalyzeTool.analyzerArgs]
+    // 1. The analyze command
+    'analyze',
+    // 2. Statically configured args from [AnalyzeTool.analyzerArgs]
     ...?configuredAnalyzerArgs,
-    // 2. Args passed to --analyzer-args
+    // 3. Args passed to --analyzer-args
     ...?splitSingleOptionValue(argResults, 'analyzer-args'),
   ];
   if (verbose && !args.contains('-v') && !args.contains('--verbose')) {
@@ -152,7 +157,7 @@ ProcessDeclaration buildProcess(
         context.argResults, context.usageException,
         commandName: context.commandName,
         usageFooter:
-            'Arguments can be passed to the "dartanalyzer" process via '
+            'Arguments can be passed to the "dart analyze" process via '
             'the --analyzer-args option.');
   }
   final args = buildArgs(
@@ -161,7 +166,7 @@ ProcessDeclaration buildProcess(
       verbose: context.verbose);
   final entrypoints = buildEntrypoints(include: include, root: path);
   logCommand(args, entrypoints, verbose: context.verbose);
-  return ProcessDeclaration('dartanalyzer', [...args, ...entrypoints],
+  return ProcessDeclaration('dart', [...args, ...entrypoints],
       mode: ProcessStartMode.inheritStdio);
 }
 
@@ -176,7 +181,7 @@ void logCommand(
   bool verbose,
 }) {
   verbose ??= false;
-  final exeAndArgs = 'dartanalyzer ${args.join(' ')}'.trim();
+  final exeAndArgs = 'dart analyze ${args.join(' ')}'.trim();
   if (entrypoints.length <= 5 || verbose) {
     logSubprocessHeader(_log, '$exeAndArgs ${entrypoints.join(' ')}');
   } else {

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -31,7 +31,7 @@ final _log = Logger('Format');
 ///     };
 ///
 /// This will make it available via the `dart_dev` command-line app like so:
-///     pub run dart_dev format
+///     dart run dart_dev format
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
@@ -61,12 +61,11 @@ class FormatTool extends DevTool {
 
   /// The formatter to run, one of:
   /// - `dartfmt` (provided by the SDK)
-  /// - `pub run dart_style:format` (provided by the `dart_style` package)
+  /// - `dart run dart_style:format` (provided by the `dart_style` package)
   Formatter formatter = Formatter.dartfmt;
 
-  /// The formatter to run, one of:
+  /// The formatter to run:
   /// - `dart format` (provided by the SDK >= 10)
-  /// - `pub run dart_style:format` (provided by the `dart_style` package)
   Formatter dartFormatter = Formatter.dartFormat;
 
   /// The args to pass to the formatter process run by this command.
@@ -334,7 +333,7 @@ enum Formatter {
 /// [FormatTool] will start.
 ///
 /// [executableArgs] will be included first and are only needed when using the
-/// `dart_style:format` executable (e.g. `pub run dart_style:format`).
+/// `dart_style:format` executable (e.g. `dart run dart_style:format`).
 ///
 /// Next, [mode] will be mapped to the appropriate formatter arg(s), e.g. `-w`,
 /// and included.
@@ -531,7 +530,7 @@ FormatExecution buildExecution(
 ///
 /// - [Formatter.dartfmt] -> `dartfmt`
 /// - [Formatter.dartFormat] -> `dart format`
-/// - [Formatter.dartStyle] -> `pub run dart_style:format`
+/// - [Formatter.dartStyle] -> `dart run dart_style:format`
 ProcessDeclaration buildProcess([Formatter formatter]) {
   switch (formatter) {
     case Formatter.dartStyle:

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -534,7 +534,7 @@ FormatExecution buildExecution(
 ProcessDeclaration buildProcess([Formatter formatter]) {
   switch (formatter) {
     case Formatter.dartStyle:
-      return ProcessDeclaration('pub', ['run', 'dart_style:format']);
+      return ProcessDeclaration('dart', ['run', 'dart_style:format']);
     case Formatter.dartFormat:
       return ProcessDeclaration('dart', ['format']);
     case Formatter.dartfmt:

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -62,11 +62,8 @@ class FormatTool extends DevTool {
   /// The formatter to run, one of:
   /// - `dartfmt` (provided by the SDK)
   /// - `dart run dart_style:format` (provided by the `dart_style` package)
+  /// - `dart format` (added in Dart SDK 2.10.0)
   Formatter formatter = Formatter.dartfmt;
-
-  /// The formatter to run:
-  /// - `dart format` (provided by the SDK >= 10)
-  Formatter dartFormatter = Formatter.dartFormat;
 
   /// The args to pass to the formatter process run by this command.
   ///
@@ -397,8 +394,8 @@ Iterable<String> buildArgsForDartFormat(
     // Combine all args that should be passed through to the dart format in this
     // order:
     // 1. Mode flag(s), if configured
-    if (mode == FormatMode.check) '--set-exit-if-changed',
-    if (mode == FormatMode.dryRun) ...['-o', 'none', '.'],
+    if (mode == FormatMode.check) ...['-o', 'none', '--set-exit-if-changed'],
+    if (mode == FormatMode.dryRun) ...['-o', 'none'],
 
     // 2. Statically configured args from [FormatTool.formatterArgs]
     ...?configuredFormatterArgs,

--- a/lib/src/tools/over_react_format_tool.dart
+++ b/lib/src/tools/over_react_format_tool.dart
@@ -31,9 +31,9 @@ class OverReactFormatTool extends DevTool {
       'over_react_format',
       if (lineLength != null) '--line-length=$lineLength'
     ];
-    final process = ProcessDeclaration('pub', [...args, ...paths],
+    final process = ProcessDeclaration('dart', [...args, ...paths],
         mode: ProcessStartMode.inheritStdio);
-    logCommand('pub', paths, args, verbose: context?.verbose);
+    logCommand('dart', paths, args, verbose: context?.verbose);
     return runProcessAndEnsureExit(process);
   }
 }

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -19,9 +19,9 @@ final _log = Logger('Test');
 
 /// A dart_dev tool that runs dart tests for the current project.
 ///
-/// Tests will be run via `pub run test` unless the current project depends on
+/// Tests will be run via `dart run test` unless the current project depends on
 /// `build_test`, in which case it will run tests via
-/// `pub run build_runner test`.
+/// `dart run build_runner test`.
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
@@ -32,7 +32,7 @@ final _log = Logger('Test');
 ///     };
 ///
 /// This will make it available via the `dart_dev` command-line app like so:
-///     pub run dart_dev test
+///     dart run dart_dev test
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
@@ -85,29 +85,29 @@ class TestTool extends DevTool {
         help: 'Write the test process stdout to this file path.')
     ..addOption('test-args',
         help: 'Args to pass to the test runner process.\n'
-            'Run "pub run test -h -v" to see all available options.')
+            'Run "dart run test -h" to see all available options.')
     ..addOption('build-args',
         help: 'Args to pass to the build runner process.\n'
-            'Run "pub run build_runner test -h -v" to see all available '
+            'Run "dart run build_runner test -h" to see all available '
             'options.\n'
             'Note: these args are only applicable if the current project '
             'depends on "build_test".');
 
-  /// The args to pass to the `pub run build_runner test` process that will be
+  /// The args to pass to the `dart run build_runner test` process that will be
   /// run by this command when the current project depends on `build_test`.
   ///
-  /// Run `pub run build_runner test -h` to see all available args.
+  /// Run `dart run build_runner test -h` to see all available args.
   List<String> buildArgs;
 
   @override
   String description = 'Run dart tests in this package.';
 
-  /// The args to pass to the `pub run test` process (either directly or
-  /// through the `pub run build_runner test` process if applicable).
+  /// The args to pass to the `dart run test` process (either directly or
+  /// through the `dart run build_runner test` process if applicable).
   ///
-  /// Run `pub run test -h` to see all available args.
+  /// Run `dart run test -h` to see all available args.
   ///
-  /// Note that most of the command-line options for the `pub run test` process
+  /// Note that most of the command-line options for the `dart run test` process
   /// also have `dart_test.yaml` configuration counterparts. Rather than
   /// configuring this field, it is preferred that the project be configured via
   /// `dart_test.yaml` so that the configuration is used even when running tests
@@ -163,12 +163,12 @@ class TestExecution {
 /// [TestTool] will start.
 ///
 /// If [useBuildRunner] is true, the returned args will run tests via
-/// `pub run build_runner test`. Additional args targeting the build process
+/// `dart run build_runner test`. Additional args targeting the build process
 /// will immediately follow and args targeting the test process will follow an
 /// arg separator (`--`).
 ///
 /// If [useBuildRunner] is false, the returned args will run tests via
-/// `pub run test` and additional args targeting the test process will follow
+/// `dart run test` and additional args targeting the test process will follow
 /// immediately. Build args will be ignored.
 ///
 /// When building the build args portion of the list, the [configuredBuildArgs]
@@ -233,7 +233,7 @@ List<String> buildArgs({
   }
 
   return [
-    // `pub run test` or `pub run build_runner test`
+    // `dart run test` or `dart run build_runner test`
     'run',
     if (useBuildRunner) 'build_runner',
     'test',
@@ -324,9 +324,9 @@ TestExecution buildExecution(
       configuredTestArgs: configuredTestArgs,
       useBuildRunner: useBuildRunner,
       verbose: context.verbose);
-  logSubprocessHeader(_log, 'pub ${args.join(' ')}'.trim());
+  logSubprocessHeader(_log, 'dart ${args.join(' ')}'.trim());
   return TestExecution.process(
-      ProcessDeclaration('pub', args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration('dart', args, mode: ProcessStartMode.inheritStdio));
 }
 
 // NOTE: This currently depends on https://github.com/dart-lang/build/pull/2445

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -233,8 +233,8 @@ List<String> buildArgs({
   }
 
   return [
-    // `dart run test` or `dart run build_runner test`
-    'run',
+    // `dart test` or `dart run build_runner test`
+    if (useBuildRunner) 'run',
     if (useBuildRunner) 'build_runner',
     'test',
 

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -19,7 +19,7 @@ final _log = Logger('Test');
 
 /// A dart_dev tool that runs dart tests for the current project.
 ///
-/// Tests will be run via `dart run test` unless the current project depends on
+/// Tests will be run via `dart test` unless the current project depends on
 /// `build_test`, in which case it will run tests via
 /// `dart run build_runner test`.
 ///
@@ -85,7 +85,7 @@ class TestTool extends DevTool {
         help: 'Write the test process stdout to this file path.')
     ..addOption('test-args',
         help: 'Args to pass to the test runner process.\n'
-            'Run "dart run test -h" to see all available options.')
+            'Run "dart test -h" to see all available options.')
     ..addOption('build-args',
         help: 'Args to pass to the build runner process.\n'
             'Run "dart run build_runner test -h" to see all available '
@@ -102,12 +102,12 @@ class TestTool extends DevTool {
   @override
   String description = 'Run dart tests in this package.';
 
-  /// The args to pass to the `dart run test` process (either directly or
+  /// The args to pass to the `dart test` process (either directly or
   /// through the `dart run build_runner test` process if applicable).
   ///
-  /// Run `dart run test -h` to see all available args.
+  /// Run `dart test -h` to see all available args.
   ///
-  /// Note that most of the command-line options for the `dart run test` process
+  /// Note that most of the command-line options for the `dart test` process
   /// also have `dart_test.yaml` configuration counterparts. Rather than
   /// configuring this field, it is preferred that the project be configured via
   /// `dart_test.yaml` so that the configuration is used even when running tests
@@ -168,7 +168,7 @@ class TestExecution {
 /// arg separator (`--`).
 ///
 /// If [useBuildRunner] is false, the returned args will run tests via
-/// `dart run test` and additional args targeting the test process will follow
+/// `dart test` and additional args targeting the test process will follow
 /// immediately. Build args will be ignored.
 ///
 /// When building the build args portion of the list, the [configuredBuildArgs]

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -27,7 +27,7 @@ final _log = Logger('TuneupCheck');
 ///     };
 ///
 /// This will make it available via the `dart_dev` command-line app like so:
-///     pub run dart_dev analyze
+///     dart run dart_dev analyze
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
@@ -150,7 +150,7 @@ TuneupExecution buildExecution(
       argResults: context.argResults,
       configuredIgnoreInfos: configuredIgnoreInfos,
       verbose: context.verbose);
-  logSubprocessHeader(_log, 'pub ${args.join(' ')}');
+  logSubprocessHeader(_log, 'dart ${args.join(' ')}');
   return TuneupExecution.process(
-      ProcessDeclaration('pub', args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration('dart', args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -29,7 +29,7 @@ final _log = Logger('WebdevServe');
 ///     };
 ///
 /// This will make it available via the `dart_dev` command-line app like so:
-///     pub run dart_dev serve
+///     dart run dart_dev serve
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
@@ -47,7 +47,7 @@ class WebdevServeTool extends DevTool {
   /// The args to pass to the `build_runner` process via the `webdev serve`
   /// process that will be run by this tool.
   ///
-  /// Run `pub run build_runner build -h` to see all available args.
+  /// Run `dart run build_runner build -h` to see all available args.
   List<String> buildArgs;
 
   /// The args to pass to the `webdev serve` process that will be run by this
@@ -70,7 +70,7 @@ class WebdevServeTool extends DevTool {
             'options.')
     ..addOption('build-args',
         help: 'Args to pass to the build runner process.\n'
-            'Run "pub run build_runner build -h -v" to see all available '
+            'Run "dart run build_runner build -h -v" to see all available '
             'options.');
 
   @override

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -53,7 +53,7 @@ class WebdevServeTool extends DevTool {
   /// The args to pass to the `webdev serve` process that will be run by this
   /// tool.
   ///
-  /// Run `pub global run webdev serve -h` to see all available args.
+  /// Run `dart pub global run webdev serve -h` to see all available args.
   List<String> webdevArgs;
 
   // ---------------------------------------------------------------------------
@@ -66,7 +66,7 @@ class WebdevServeTool extends DevTool {
     ..addSeparator('======== Other Options')
     ..addOption('webdev-args',
         help: 'Args to pass to the webdev serve process.\n'
-            'Run "pub global run webdev serve -h -v" to see all available '
+            'Run "dart pub global run webdev serve -h -v" to see all available '
             'options.')
     ..addOption('build-args',
         help: 'Args to pass to the build runner process.\n'
@@ -118,7 +118,7 @@ class WebdevServeExecution {
 ///
 /// Since the `webdev` tool wraps a `build_runner` process, the returned list of
 /// args will be two portions with an arg separator between them, e.g.:
-///     pub global run webdev serve <webdev args> -- <build args>
+///     dart pub global run webdev serve <webdev args> -- <build args>
 ///
 /// When building the webdev args portion of the list, the
 /// [configuredWebdevArgs] will be included first (if non-null) followed by the
@@ -165,6 +165,7 @@ List<String> buildArgs(
   }
 
   return [
+    'pub',
     'global',
     'run',
     'webdev',
@@ -216,7 +217,7 @@ WebdevServeExecution buildExecution(
     _log.severe(red.wrap(styleBold.wrap('webdev serve') +
             ' could not run for this project.\n') +
         yellow.wrap('You must have `webdev` globally activated:\n'
-            '  pub global activate webdev ^2.0.0'));
+            '  dart pub global activate webdev ^2.0.0'));
     return WebdevServeExecution.exitEarly(ExitCode.config.code);
   }
   final args = buildArgs(
@@ -224,7 +225,7 @@ WebdevServeExecution buildExecution(
       configuredBuildArgs: configuredBuildArgs,
       configuredWebdevArgs: configuredWebdevArgs,
       verbose: context.verbose);
-  logSubprocessHeader(_log, 'pub ${args.join(' ')}'.trim());
+  logSubprocessHeader(_log, 'dart ${args.join(' ')}'.trim());
   return WebdevServeExecution.process(
-      ProcessDeclaration('pub', args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration('dart', args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/utils/format_tool_builder.dart
+++ b/lib/src/utils/format_tool_builder.dart
@@ -148,6 +148,9 @@ Formatter detectFormatterForFormatTool(SimpleIdentifier formatterIdentifier) {
     case 'dartfmt':
       formatter = Formatter.dartfmt;
       break;
+    case 'dartFormat':
+      formatter = Formatter.dartFormat;
+      break;
     case 'dartStyle':
       formatter = Formatter.dartStyle;
       break;

--- a/lib/src/utils/global_package_is_active_and_compatible.dart
+++ b/lib/src/utils/global_package_is_active_and_compatible.dart
@@ -18,7 +18,7 @@ bool globalPackageIsActiveAndCompatible(
     {Map<String, String> environment}) {
   final executable = 'dart';
   final args = ['pub', 'global', 'list'];
-  final result = Process.runSync('dart', ['pub', 'global', 'list'],
+  final result = Process.runSync(executable, args,
       environment: environment, stderrEncoding: utf8, stdoutEncoding: utf8);
   if (result.exitCode != 0) {
     throw ProcessException(

--- a/lib/src/utils/global_package_is_active_and_compatible.dart
+++ b/lib/src/utils/global_package_is_active_and_compatible.dart
@@ -6,7 +6,7 @@ import 'package:pub_semver/pub_semver.dart';
 /// Returns `true` if [packageName] is globally activated at a version
 /// allowed by [constraint]. Returns `false` otherwise.
 ///
-/// This is determined by running a `pub global list` and looking for
+/// This is determined by running a `dart pub global list` and looking for
 /// [packageName] in the output and then testing its version against
 /// [constraint].
 ///
@@ -16,9 +16,9 @@ import 'package:pub_semver/pub_semver.dart';
 bool globalPackageIsActiveAndCompatible(
     String packageName, VersionConstraint constraint,
     {Map<String, String> environment}) {
-  final executable = 'pub';
-  final args = ['global', 'list'];
-  final result = Process.runSync('pub', ['global', 'list'],
+  final executable = 'dart';
+  final args = ['pub', 'global', 'list'];
+  final result = Process.runSync('dart', ['pub', 'global', 'list'],
       environment: environment, stderrEncoding: utf8, stdoutEncoding: utf8);
   if (result.exitCode != 0) {
     throw ProcessException(

--- a/lib/src/utils/run_process_and_ensure_exit.dart
+++ b/lib/src/utils/run_process_and_ensure_exit.dart
@@ -7,6 +7,7 @@ import 'ensure_process_exit.dart';
 
 Future<int> runProcessAndEnsureExit(ProcessDeclaration processDeclaration,
     {Logger log}) async {
+  print('ajw ${processDeclaration.args}');
   final process = await Process.start(
       processDeclaration.executable, processDeclaration.args,
       mode: processDeclaration.mode ?? ProcessStartMode.normal,

--- a/lib/src/utils/run_process_and_ensure_exit.dart
+++ b/lib/src/utils/run_process_and_ensure_exit.dart
@@ -7,7 +7,6 @@ import 'ensure_process_exit.dart';
 
 Future<int> runProcessAndEnsureExit(ProcessDeclaration processDeclaration,
     {Logger log}) async {
-  print('ajw ${processDeclaration.args}');
   final process = await Process.start(
       processDeclaration.executable, processDeclaration.args,
       mode: processDeclaration.mode ?? ProcessStartMode.normal,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   analyzer: ">=0.39.0 <0.42.0"

--- a/test/functional.dart
+++ b/test/functional.dart
@@ -44,17 +44,17 @@ Future<TestProcess> runDevToolFunctionalTest(
     });
     pubspec.writeAsStringSync(updated);
 
-    final result =
-        Process.runSync('pub', ['get'], workingDirectory: pubspec.parent.path);
+    final result = Process.runSync('dart', ['pub', 'get'],
+        workingDirectory: pubspec.parent.path);
     if (result.exitCode != 0) {
       final origPath = p.join(p.relative(templateDir.absolute.path),
           p.relative(pubspec.absolute.path, from: d.sandbox));
-      throw StateError('pub get failed on: $origPath\n'
+      throw StateError('dart pub get failed on: $origPath\n'
           'STDOUT:\n${result.stdout}\n'
           'STDERR:\n${result.stderr}\n');
     }
   }
 
   final allArgs = <String>['run', 'dart_dev', command, ...?args];
-  return TestProcess.start('pub', allArgs, workingDirectory: d.sandbox);
+  return TestProcess.start('dart', allArgs, workingDirectory: d.sandbox);
 }

--- a/test/functional/documentation_test.dart
+++ b/test/functional/documentation_test.dart
@@ -28,7 +28,7 @@ void main() {
         d.file('pubspec.yaml', pubspecSource),
       ]).create();
 
-      final pubGet = await TestProcess.start('pub', ['get'],
+      final pubGet = await TestProcess.start('dart', ['pub', 'get'],
           workingDirectory: '${d.sandbox}/project');
       printOnFailure('PUBSPEC:\n$pubspecSource\n');
       await pubGet.shouldExit(0);

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -212,21 +212,19 @@ void main() {
     test('with >5 entrypoints', () {
       expect(Logger.root.onRecord,
           emitsThrough(infoLogOf(contains('dartanalyzer -t <6 paths>'))));
-      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'],
-          useDartAnalyzer: false);
+      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f']);
     });
 
     test('with >5 entrypoints in verbose mode', () {
       expect(Logger.root.onRecord,
           emitsThrough(infoLogOf(contains('dartanalyzer -t a b c d e f'))));
-      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'],
-          verbose: true, useDartAnalyzer: false);
+      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'], verbose: true);
     });
 
     test('in useDartAnalyze mode', () {
-      expect(
-          Logger.root.onRecord, emitsThrough(infoLogOf(contains('dart -t a'))));
-      logCommand(['-t'], ['a'], useDartAnalyzer: true);
+      expect(Logger.root.onRecord,
+          emitsThrough(infoLogOf(contains('dart analyze -t a'))));
+      logCommand(['analyze', '-t'], ['a'], useDartAnalyzer: true);
     });
   });
 }

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -26,17 +26,14 @@ void main() {
 
   group('buildArgs', () {
     test('defaults to an empty list', () {
-      expect(buildArgs(useDartAnalyze: false), isEmpty);
+      expect(buildArgs(), isEmpty);
     });
 
     test('combines configured args and cli args (in that order)', () {
       final argParser = AnalyzeTool().toCommand('t').argParser;
       final argResults = argParser.parse(['--analyzer-args', 'c d']);
       expect(
-          buildArgs(
-              argResults: argResults,
-              configuredAnalyzerArgs: ['a', 'b'],
-              useDartAnalyze: false),
+          buildArgs(argResults: argResults, configuredAnalyzerArgs: ['a', 'b']),
           orderedEquals(['a', 'b', 'c', 'd']));
     });
 
@@ -60,26 +57,17 @@ void main() {
           buildArgs(
               argResults: argResults,
               configuredAnalyzerArgs: ['a', 'b'],
-              verbose: true,
-              useDartAnalyze: false),
+              verbose: true),
           orderedEquals(['a', 'b', 'c', 'd', '-v']));
     });
 
     test('does not insert a duplicate verbose flag (-v)', () {
-      expect(
-          buildArgs(
-              configuredAnalyzerArgs: ['-v'],
-              verbose: true,
-              useDartAnalyze: false),
+      expect(buildArgs(configuredAnalyzerArgs: ['-v'], verbose: true),
           orderedEquals(['-v']));
     });
 
     test('does not insert a duplicate verbose flag (--verbose)', () {
-      expect(
-          buildArgs(
-              configuredAnalyzerArgs: ['--verbose'],
-              verbose: true,
-              useDartAnalyze: false),
+      expect(buildArgs(configuredAnalyzerArgs: ['--verbose'], verbose: true),
           orderedEquals(['--verbose']));
     });
   });
@@ -109,7 +97,7 @@ void main() {
       final context = DevToolExecutionContext(
           argResults: argResults, commandName: 'test_analyze');
       expect(
-          () => buildProcess(context, useDartAnalyze: false),
+          () => buildProcess(context),
           throwsA(isA<UsageException>()
               .having(
                   (e) => e.message, 'command name', contains('test_analyze'))
@@ -122,7 +110,7 @@ void main() {
       final context = DevToolExecutionContext(
           argResults: argResults, commandName: 'test_analyze');
       expect(
-          () => buildProcess(context, useDartAnalyze: false),
+          () => buildProcess(context),
           throwsA(isA<UsageException>()
               .having(
                   (e) => e.message, 'command name', contains('test_analyze'))
@@ -132,7 +120,7 @@ void main() {
 
     test('returns a ProcessDeclaration (default)', () {
       final context = DevToolExecutionContext();
-      final process = buildProcess(context, useDartAnalyze: false);
+      final process = buildProcess(context);
       expect(process.executable, 'dartanalyzer');
       expect(process.args, orderedEquals(['.']));
     });
@@ -152,8 +140,7 @@ void main() {
       final process = buildProcess(context,
           configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
           include: [Glob('*.dart'), Glob('*.txt')],
-          path: globRoot,
-          useDartAnalyze: false);
+          path: globRoot);
       expect(process.executable, 'dartanalyzer');
       expect(
           process.args,
@@ -199,8 +186,7 @@ void main() {
       final process = buildProcess(context,
           configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
           include: [Glob('*.dart'), Glob('*.txt')],
-          path: globRoot,
-          useDartAnalyze: false);
+          path: globRoot);
       expect(process.executable, 'dartanalyzer');
       expect(
           process.args,

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -193,5 +193,11 @@ void main() {
       logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'],
           verbose: true, useDartAnalyzer: false);
     });
+
+    test('in useDartAnalyze mode', () {
+      expect(
+          Logger.root.onRecord, emitsThrough(infoLogOf(contains('dart -t a'))));
+      logCommand(['-t'], ['a'], useDartAnalyzer: true);
+    });
   });
 }

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -124,6 +124,13 @@ void main() {
       expect(process.args, orderedEquals(['.']));
     });
 
+    test('returns a ProcessDeclaration with useDartAnalyze (default)', () {
+      final context = DevToolExecutionContext();
+      final process = buildProcess(context, useDartAnalyze: true);
+      expect(process.executable, 'dart');
+      expect(process.args, orderedEquals(['analyze', '.']));
+    });
+
     test('returns a ProcessDeclaration (with args)', () {
       final argParser = AnalyzeTool().toCommand('t').argParser;
       final argResults =
@@ -144,6 +151,29 @@ void main() {
             '/sdk',
             '${globRoot}file.dart',
             '${globRoot}file.txt',
+          ]));
+    });
+
+    test('returns a ProcessDeclaration with useDartAnalyzer (with args)', () {
+      final argParser = AnalyzeTool().toCommand('t').argParser;
+      final argResults =
+          argParser.parse(['--analyzer-args', '--dart-sdk /sdk']);
+      final context = DevToolExecutionContext(argResults: argResults);
+      final process = buildProcess(context,
+          configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
+          include: [Glob('*.dart')],
+          path: globRoot,
+          useDartAnalyze: true);
+      expect(process.executable, 'dart');
+      expect(
+          process.args,
+          orderedEquals([
+            'analyze',
+            '--fatal-infos',
+            '--fatal-warnings',
+            '--dart-sdk',
+            '/sdk',
+            '${globRoot}file.dart',
           ]));
     });
 

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -26,14 +26,17 @@ void main() {
 
   group('buildArgs', () {
     test('defaults to an empty list', () {
-      expect(buildArgs(), isEmpty);
+      expect(buildArgs(useDartAnalyze: false), isEmpty);
     });
 
     test('combines configured args and cli args (in that order)', () {
       final argParser = AnalyzeTool().toCommand('t').argParser;
       final argResults = argParser.parse(['--analyzer-args', 'c d']);
       expect(
-          buildArgs(argResults: argResults, configuredAnalyzerArgs: ['a', 'b']),
+          buildArgs(
+              argResults: argResults,
+              configuredAnalyzerArgs: ['a', 'b'],
+              useDartAnalyze: false),
           orderedEquals(['a', 'b', 'c', 'd']));
     });
 
@@ -44,17 +47,26 @@ void main() {
           buildArgs(
               argResults: argResults,
               configuredAnalyzerArgs: ['a', 'b'],
-              verbose: true),
+              verbose: true,
+              useDartAnalyze: false),
           orderedEquals(['a', 'b', 'c', 'd', '-v']));
     });
 
     test('does not insert a duplicate verbose flag (-v)', () {
-      expect(buildArgs(configuredAnalyzerArgs: ['-v'], verbose: true),
+      expect(
+          buildArgs(
+              configuredAnalyzerArgs: ['-v'],
+              verbose: true,
+              useDartAnalyze: false),
           orderedEquals(['-v']));
     });
 
     test('does not insert a duplicate verbose flag (--verbose)', () {
-      expect(buildArgs(configuredAnalyzerArgs: ['--verbose'], verbose: true),
+      expect(
+          buildArgs(
+              configuredAnalyzerArgs: ['--verbose'],
+              verbose: true,
+              useDartAnalyze: false),
           orderedEquals(['--verbose']));
     });
   });
@@ -84,7 +96,7 @@ void main() {
       final context = DevToolExecutionContext(
           argResults: argResults, commandName: 'test_analyze');
       expect(
-          () => buildProcess(context),
+          () => buildProcess(context, useDartAnalyze: false),
           throwsA(isA<UsageException>()
               .having(
                   (e) => e.message, 'command name', contains('test_analyze'))
@@ -97,7 +109,7 @@ void main() {
       final context = DevToolExecutionContext(
           argResults: argResults, commandName: 'test_analyze');
       expect(
-          () => buildProcess(context),
+          () => buildProcess(context, useDartAnalyze: false),
           throwsA(isA<UsageException>()
               .having(
                   (e) => e.message, 'command name', contains('test_analyze'))
@@ -107,7 +119,7 @@ void main() {
 
     test('returns a ProcessDeclaration (default)', () {
       final context = DevToolExecutionContext();
-      final process = buildProcess(context);
+      final process = buildProcess(context, useDartAnalyze: false);
       expect(process.executable, 'dartanalyzer');
       expect(process.args, orderedEquals(['.']));
     });
@@ -120,7 +132,8 @@ void main() {
       final process = buildProcess(context,
           configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
           include: [Glob('*.dart'), Glob('*.txt')],
-          path: globRoot);
+          path: globRoot,
+          useDartAnalyze: false);
       expect(process.executable, 'dartanalyzer');
       expect(
           process.args,
@@ -143,7 +156,8 @@ void main() {
       final process = buildProcess(context,
           configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
           include: [Glob('*.dart'), Glob('*.txt')],
-          path: globRoot);
+          path: globRoot,
+          useDartAnalyze: false);
       expect(process.executable, 'dartanalyzer');
       expect(
           process.args,
@@ -163,19 +177,21 @@ void main() {
     test('with <=5 entrypoints', () {
       expect(Logger.root.onRecord,
           emitsThrough(infoLogOf(contains('dartanalyzer -t a b c d e'))));
-      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e']);
+      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e'], useDartAnalyzer: false);
     });
 
     test('with >5 entrypoints', () {
       expect(Logger.root.onRecord,
           emitsThrough(infoLogOf(contains('dartanalyzer -t <6 paths>'))));
-      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f']);
+      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'],
+          useDartAnalyzer: false);
     });
 
     test('with >5 entrypoints in verbose mode', () {
       expect(Logger.root.onRecord,
           emitsThrough(infoLogOf(contains('dartanalyzer -t a b c d e f'))));
-      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'], verbose: true);
+      logCommand(['-t'], ['a', 'b', 'c', 'd', 'e', 'f'],
+          verbose: true, useDartAnalyzer: false);
     });
   });
 }

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -40,6 +40,19 @@ void main() {
           orderedEquals(['a', 'b', 'c', 'd']));
     });
 
+    test(
+        'combines configured args and cli args (in that order) with useDartAnalyze',
+        () {
+      final argParser = AnalyzeTool().toCommand('t').argParser;
+      final argResults = argParser.parse(['--analyzer-args', 'c d']);
+      expect(
+          buildArgs(
+              argResults: argResults,
+              configuredAnalyzerArgs: ['a', 'b'],
+              useDartAnalyze: true),
+          orderedEquals(['analyze', 'a', 'b', 'c', 'd']));
+    });
+
     test('inserts a verbose flag if not already present', () {
       final argParser = AnalyzeTool().toCommand('t').argParser;
       final argResults = argParser.parse(['--analyzer-args', 'c d']);

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -373,7 +373,7 @@ void main() {
             formatter: Formatter.dartStyle,
             path: 'test/tools/fixtures/format/has_dart_style');
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'pub');
+        expect(execution.process.executable, 'dart');
         expect(execution.process.args,
             orderedEquals(['run', 'dart_style:format', '.']));
         expect(execution.process.mode, ProcessStartMode.inheritStdio);
@@ -444,7 +444,7 @@ void main() {
 
     test('dart_style', () {
       final process = buildProcess(Formatter.dartStyle);
-      expect(process.executable, 'pub');
+      expect(process.executable, 'dart');
       expect(process.args, orderedEquals(['run', 'dart_style:format']));
     });
 

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -323,6 +323,16 @@ void main() {
         expect(execution.process.mode, ProcessStartMode.inheritStdio);
       });
 
+      test('with dartFormat', () {
+        final context = DevToolExecutionContext();
+        final execution =
+            buildExecution(context, formatter: Formatter.dartFormat);
+        expect(execution.exitCode, isNull);
+        expect(execution.process.executable, 'dart');
+        expect(execution.process.args, orderedEquals(['format', '.']));
+        expect(execution.process.mode, ProcessStartMode.inheritStdio);
+      });
+
       test('with dart_style:format', () {
         final context = DevToolExecutionContext();
         final execution = buildExecution(context,
@@ -335,7 +345,7 @@ void main() {
         expect(execution.process.mode, ProcessStartMode.inheritStdio);
       });
 
-      test('with args', () {
+      test('dartfmt with args', () {
         final argParser = FormatTool().toCommand('t').argParser;
         final argResults =
             argParser.parse(['-w', '--formatter-args', '--indent 2']);
@@ -352,11 +362,35 @@ void main() {
         expect(execution.process.mode, ProcessStartMode.inheritStdio);
       });
 
-      test('and logs the test subprocess', () {
+      test('dartFormat with args', () {
+        final argParser = FormatTool().toCommand('t').argParser;
+        final argResults = argParser.parse(['--formatter-args', '--indent 2']);
+        final context = DevToolExecutionContext(argResults: argResults);
+        final execution = buildExecution(context,
+            configuredFormatterArgs: ['--fix', '--follow-links'],
+            formatter: Formatter.dartFormat);
+        expect(execution.exitCode, isNull);
+        expect(execution.process.executable, 'dart');
+        expect(
+            execution.process.args,
+            orderedEquals(
+                ['format', '--fix', '--follow-links', '--indent', '2', '.']));
+        expect(execution.process.mode, ProcessStartMode.inheritStdio);
+      });
+
+      test('and logs the test subprocess by default', () {
         expect(Logger.root.onRecord,
             emitsThrough(infoLogOf(contains('dartfmt .'))));
 
         buildExecution(DevToolExecutionContext());
+      });
+
+      test('and logs the test subprocess for dart format', () {
+        expect(Logger.root.onRecord,
+            emitsThrough(infoLogOf(contains('dart format .'))));
+
+        buildExecution(DevToolExecutionContext(),
+            formatter: Formatter.dartFormat);
       });
     });
   });
@@ -366,6 +400,12 @@ void main() {
       final process = buildProcess(Formatter.dartfmt);
       expect(process.executable, 'dartfmt');
       expect(process.args, isEmpty);
+    });
+
+    test('dart format', () {
+      final process = buildProcess(Formatter.dartFormat);
+      expect(process.executable, 'dart');
+      expect(process.args, orderedEquals(['format']));
     });
 
     test('dart_style', () {

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -178,6 +178,40 @@ void main() {
     });
   });
 
+  group('buildArgsForDartFormat', () {
+    test('no mode', () {
+      expect(
+          buildArgsForDartFormat(['a', 'b'], null), orderedEquals(['a', 'b']));
+    });
+
+    test('mode=dry-run', () {
+      expect(buildArgsForDartFormat(['a', 'b'], FormatMode.dryRun),
+          orderedEquals(['a', 'b', '-o', 'none', '.']));
+    });
+
+    test('mode=check', () {
+      expect(buildArgsForDartFormat(['a', 'b'], FormatMode.check),
+          orderedEquals(['a', 'b', '--set-exit-if-changed']));
+    });
+
+    test('combines configured args with cli args (in that order)', () {
+      final argParser = FormatTool().toCommand('t').argParser;
+      final argResults = argParser.parse(['--formatter-args', '--indent 2']);
+      expect(
+          buildArgsForDartFormat(['a', 'b'], FormatMode.overwrite,
+              argResults: argResults,
+              configuredFormatterArgs: ['--fix', '--follow-links']),
+          orderedEquals([
+            'a',
+            'b',
+            '--fix',
+            '--follow-links',
+            '--indent',
+            '2',
+          ]));
+    });
+  });
+
   group('buildExecution', () {
     test('throws UsageException if positional args are given', () {
       final argResults = ArgParser().parse(['a']);

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -186,12 +186,12 @@ void main() {
 
     test('mode=dry-run', () {
       expect(buildArgsForDartFormat(['a', 'b'], FormatMode.dryRun),
-          orderedEquals(['a', 'b', '-o', 'none', '.']));
+          orderedEquals(['a', 'b', '-o', 'none']));
     });
 
     test('mode=check', () {
       expect(buildArgsForDartFormat(['a', 'b'], FormatMode.check),
-          orderedEquals(['a', 'b', '--set-exit-if-changed']));
+          orderedEquals(['a', 'b', '-o', 'none', '--set-exit-if-changed']));
     });
 
     test('combines configured args with cli args (in that order)', () {

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -333,7 +333,7 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(execution.process.args, orderedEquals(['run', 'test']));
         });
 
@@ -344,7 +344,7 @@ dev_dependencies:
           final execution = buildExecution(context,
               configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(execution.process.args,
               orderedEquals(['run', 'test', '-P', 'unit', '-n', 'foo']));
         });
@@ -365,8 +365,10 @@ dev_dependencies:
                 }));
 
         test('and logs the test subprocess', () {
-          expect(Logger.root.onRecord,
-              emitsThrough(infoLogOf(contains('pub run test -P unit -n foo'))));
+          expect(
+              Logger.root.onRecord,
+              emitsThrough(
+                  infoLogOf(contains('dart run test -P unit -n foo'))));
 
           final argParser = TestTool().toCommand('t').argParser;
           final argResults = argParser.parse(['--test-args', '-n foo']);
@@ -393,7 +395,7 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(execution.process.args, orderedEquals(['run', 'test']));
         });
 
@@ -404,7 +406,7 @@ dev_dependencies:
           final execution = buildExecution(context,
               configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(execution.process.args,
               orderedEquals(['run', 'test', '-P', 'unit', '-n', 'foo']));
         });
@@ -425,8 +427,10 @@ dev_dependencies:
                 }));
 
         test('and logs the test subprocess', () {
-          expect(Logger.root.onRecord,
-              emitsThrough(infoLogOf(contains('pub run test -P unit -n foo'))));
+          expect(
+              Logger.root.onRecord,
+              emitsThrough(
+                  infoLogOf(contains('dart run test -P unit -n foo'))));
 
           final argParser = TestTool().toCommand('t').argParser;
           final argResults = argParser.parse(['--test-args', '-n foo']);
@@ -454,7 +458,7 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(execution.process.args,
               orderedEquals(['run', 'build_runner', 'test']));
         });
@@ -469,7 +473,7 @@ dev_dependencies:
               configuredTestArgs: ['-P', 'unit'],
               path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(
               execution.process.args,
               orderedEquals([
@@ -498,7 +502,7 @@ dev_dependencies:
               configuredTestArgs: ['-P', 'unit'],
               path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'pub');
+          expect(execution.process.executable, 'dart');
           expect(
               execution.process.args,
               orderedEquals([
@@ -521,7 +525,7 @@ dev_dependencies:
           expect(
               Logger.root.onRecord,
               emitsThrough(infoLogOf(contains(
-                  'pub run build_runner test foo -o test:build -- -P unit '
+                  'dart run build_runner test foo -o test:build -- -P unit '
                   '-n foo'))));
 
           final argParser = TestTool().toCommand('t').argParser;

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -52,37 +52,35 @@ void main() {
 
   group('buildArgs', () {
     test('(default)', () {
-      expect(buildArgs(), orderedEquals(['run', 'test']));
+      expect(buildArgs(), orderedEquals(['test']));
     });
 
     test('forwards the -n|--name options', () {
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['-n', 'foo', '-n', 'bar']);
       expect(buildArgs(argResults: argResults),
-          orderedEquals(['run', 'test', '--name=foo', '--name=bar']));
+          orderedEquals(['test', '--name=foo', '--name=bar']));
     });
 
     test('forwards the -N|--plain-name options', () {
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['-N', 'foo', '-N', 'bar']);
-      expect(
-          buildArgs(argResults: argResults),
-          orderedEquals(
-              ['run', 'test', '--plain-name=foo', '--plain-name=bar']));
+      expect(buildArgs(argResults: argResults),
+          orderedEquals(['test', '--plain-name=foo', '--plain-name=bar']));
     });
 
     test('forwards the -P|--preset options', () {
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['-P', 'foo', '-P', 'bar']);
       expect(buildArgs(argResults: argResults),
-          orderedEquals(['run', 'test', '--preset=foo', '--preset=bar']));
+          orderedEquals(['test', '--preset=foo', '--preset=bar']));
     });
 
     test('forwards the --reporter option', () {
       final argParser = TestTool().toCommand('t').argParser;
       final argResults = argParser.parse(['--reporter', 'expanded']);
       expect(buildArgs(argResults: argResults),
-          orderedEquals(['run', 'test', '--reporter=expanded']));
+          orderedEquals(['test', '--reporter=expanded']));
     });
 
     group('with useBuildTest=false', () {
@@ -92,7 +90,7 @@ void main() {
         expect(
             buildArgs(
                 argResults: argResults, configuredTestArgs: ['-P', 'unit']),
-            orderedEquals(['run', 'test', '-P', 'unit', '-N', 'foo']));
+            orderedEquals(['test', '-P', 'unit', '-N', 'foo']));
       });
 
       test('ignores build args if given', () {
@@ -103,7 +101,7 @@ void main() {
             buildArgs(
                 argResults: argResults,
                 configuredBuildArgs: ['-o', 'test:build']),
-            orderedEquals(['run', 'test']));
+            orderedEquals(['test']));
       });
     });
 
@@ -334,7 +332,7 @@ dev_dependencies:
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'dart');
-          expect(execution.process.args, orderedEquals(['run', 'test']));
+          expect(execution.process.args, orderedEquals(['test']));
         });
 
         test('with args', () {
@@ -346,7 +344,7 @@ dev_dependencies:
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'dart');
           expect(execution.process.args,
-              orderedEquals(['run', 'test', '-P', 'unit', '-n', 'foo']));
+              orderedEquals(['test', '-P', 'unit', '-n', 'foo']));
         });
 
         test(
@@ -365,10 +363,8 @@ dev_dependencies:
                 }));
 
         test('and logs the test subprocess', () {
-          expect(
-              Logger.root.onRecord,
-              emitsThrough(
-                  infoLogOf(contains('dart run test -P unit -n foo'))));
+          expect(Logger.root.onRecord,
+              emitsThrough(infoLogOf(contains('dart test -P unit -n foo'))));
 
           final argParser = TestTool().toCommand('t').argParser;
           final argResults = argParser.parse(['--test-args', '-n foo']);
@@ -396,7 +392,7 @@ dev_dependencies:
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'dart');
-          expect(execution.process.args, orderedEquals(['run', 'test']));
+          expect(execution.process.args, orderedEquals(['test']));
         });
 
         test('with args', () {
@@ -408,7 +404,7 @@ dev_dependencies:
           expect(execution.exitCode, isNull);
           expect(execution.process.executable, 'dart');
           expect(execution.process.args,
-              orderedEquals(['run', 'test', '-P', 'unit', '-n', 'foo']));
+              orderedEquals(['test', '-P', 'unit', '-n', 'foo']));
         });
 
         test(
@@ -427,10 +423,8 @@ dev_dependencies:
                 }));
 
         test('and logs the test subprocess', () {
-          expect(
-              Logger.root.onRecord,
-              emitsThrough(
-                  infoLogOf(contains('dart run test -P unit -n foo'))));
+          expect(Logger.root.onRecord,
+              emitsThrough(infoLogOf(contains('dart test -P unit -n foo'))));
 
           final argParser = TestTool().toCommand('t').argParser;
           final argResults = argParser.parse(['--test-args', '-n foo']);

--- a/test/tools/tuneup_check_tool_test.dart
+++ b/test/tools/tuneup_check_tool_test.dart
@@ -73,7 +73,7 @@ void main() {
       test('(default)', () {
         final execution = buildExecution(DevToolExecutionContext(), path: path);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'pub');
+        expect(execution.process.executable, 'dart');
         expect(
             execution.process.args, orderedEquals(['run', 'tuneup', 'check']));
         expect(execution.process.mode, ProcessStartMode.inheritStdio);
@@ -86,7 +86,7 @@ void main() {
             DevToolExecutionContext(argResults: argResults, verbose: true);
         final execution = buildExecution(context, path: path);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'pub');
+        expect(execution.process.executable, 'dart');
         expect(
             execution.process.args,
             orderedEquals(
@@ -96,7 +96,7 @@ void main() {
 
       test('and logs the subprocess header', () {
         expect(Logger.root.onRecord,
-            emitsThrough(infoLogOf(allOf(contains('pub run tuneup check')))));
+            emitsThrough(infoLogOf(allOf(contains('dart run tuneup check')))));
 
         buildExecution(DevToolExecutionContext(), path: path);
       });

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -33,14 +33,17 @@ void main() {
 
   group('buildArgs', () {
     test('(default)', () {
-      expect(buildArgs(), orderedEquals(['global', 'run', 'webdev', 'serve']));
+      expect(buildArgs(),
+          orderedEquals(['pub', 'global', 'run', 'webdev', 'serve']));
     });
 
     test('forwards the -r|--release flag', () {
       final argParser = WebdevServeTool().toCommand('t').argParser;
       final argResults = argParser.parse(['-r']);
-      expect(buildArgs(argResults: argResults),
-          orderedEquals(['global', 'run', 'webdev', 'serve', '--release']));
+      expect(
+          buildArgs(argResults: argResults),
+          orderedEquals(
+              ['pub', 'global', 'run', 'webdev', 'serve', '--release']));
     });
 
     test('combines configured args with cli args (in that order)', () {
@@ -53,6 +56,7 @@ void main() {
               configuredBuildArgs: ['-o', 'web:build'],
               configuredWebdevArgs: ['web:9000', 'example:9001']),
           orderedEquals([
+            'pub',
             'global',
             'run',
             'webdev',
@@ -80,6 +84,7 @@ void main() {
               configuredWebdevArgs: ['web:9000', 'example:9001'],
               verbose: true),
           orderedEquals([
+            'pub',
             'global',
             'run',
             'webdev',
@@ -105,7 +110,7 @@ void main() {
               configuredWebdevArgs: ['-v'],
               verbose: true),
           orderedEquals(
-              ['global', 'run', 'webdev', 'serve', '-v', '--', '-v']));
+              ['pub', 'global', 'run', 'webdev', 'serve', '-v', '--', '-v']));
     });
 
     test('does not insert a duplicate verbose flag (--verbose)', () {
@@ -115,6 +120,7 @@ void main() {
               configuredWebdevArgs: ['--verbose'],
               verbose: true),
           orderedEquals([
+            'pub',
             'global',
             'run',
             'webdev',
@@ -174,7 +180,7 @@ void main() {
             Logger.root.onRecord,
             emitsThrough(severeLogOf(allOf(
                 contains('webdev serve could not run'),
-                contains('pub global activate webdev ^2.0.0')))));
+                contains('dart pub global activate webdev ^2.0.0')))));
 
         expect(
             buildExecution(DevToolExecutionContext(),
@@ -189,9 +195,9 @@ void main() {
         final execution = buildExecution(DevToolExecutionContext(),
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'pub');
+        expect(execution.process.executable, 'dart');
         expect(execution.process.args,
-            orderedEquals(['global', 'run', 'webdev', 'serve']));
+            orderedEquals(['pub', 'global', 'run', 'webdev', 'serve']));
       });
 
       test('with args', () {
@@ -204,10 +210,11 @@ void main() {
             configuredWebdevArgs: ['web:9000', 'example:9001'],
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'pub');
+        expect(execution.process.executable, 'dart');
         expect(
             execution.process.args,
             orderedEquals([
+              'pub',
               'global',
               'run',
               'webdev',
@@ -235,10 +242,11 @@ void main() {
             configuredWebdevArgs: ['web:9000', 'example:9001'],
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'pub');
+        expect(execution.process.executable, 'dart');
         expect(
             execution.process.args,
             orderedEquals([
+              'pub',
               'global',
               'run',
               'webdev',
@@ -261,9 +269,9 @@ void main() {
         overrideAnsiOutput(false, () {
           expect(
               Logger.root.onRecord,
-              emitsThrough(infoLogOf(
-                  contains('pub global run webdev serve web --auto restart -- '
-                      '--delete-conflicting-outputs -o test:build'))));
+              emitsThrough(infoLogOf(contains(
+                  'dart pub global run webdev serve web --auto restart -- '
+                  '--delete-conflicting-outputs -o test:build'))));
 
           final argParser = WebdevServeTool().toCommand('t').argParser;
           final argResults = argParser.parse([

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -19,8 +19,8 @@ class TempPubCache {
 void globalActivate(String packageName, String constraint,
     {Map<String, String> environment}) {
   final result = Process.runSync(
-    'pub',
-    ['global', 'activate', packageName, constraint],
+    'dart',
+    ['pub', 'global', 'activate', packageName, constraint],
     environment: environment,
     stderrEncoding: utf8,
     stdoutEncoding: utf8,

--- a/test/utils/format_tool_builder_test.dart
+++ b/test/utils/format_tool_builder_test.dart
@@ -56,7 +56,7 @@ void main() {
                 Formatter.dartfmt);
           });
 
-          test('darFormat', () {
+          test('dartFormat', () {
             final visitor = FormatToolBuilder();
 
             parseString(content: formatTool_cascadeSrc(formatter: 'dartFormat'))

--- a/test/utils/format_tool_builder_test.dart
+++ b/test/utils/format_tool_builder_test.dart
@@ -56,6 +56,19 @@ void main() {
                 Formatter.dartfmt);
           });
 
+          test('darFormat', () {
+            final visitor = FormatToolBuilder();
+
+            parseString(content: formatTool_cascadeSrc(formatter: 'dartFormat'))
+                .unit
+                .accept(visitor);
+
+            expect(visitor.formatDevTool, isNotNull);
+            expect(visitor.formatDevTool, isA<FormatTool>());
+            expect((visitor.formatDevTool as FormatTool).formatter,
+                Formatter.dartFormat);
+          });
+
           test('dartStyle', () {
             final visitor = FormatToolBuilder();
 

--- a/tool/dart_dev/config.dart
+++ b/tool/dart_dev/config.dart
@@ -3,5 +3,8 @@ import 'package:glob/glob.dart';
 
 final config = {
   ...coreConfig,
-  'format': FormatTool()..exclude = [Glob('test/**/fixtures/**.dart')],
+  'analyze': AnalyzeTool()..useDartAnalyze = true,
+  'format': FormatTool()
+    ..exclude = [Glob('test/**/fixtures/**.dart')]
+    ..formatter = Formatter.dartFormat,
 };


### PR DESCRIPTION
Purpose:

ddev analyze runs dartanalyzer, which does not leverage the analysis server
ddev format may run dartfmt (unless the package depends on dart_style)
in several places, ddev will run other dart executables via pub run
As of Dart 2.10 (https://medium.com/dartlang/announcing-dart-2-10-350823952bd5), there exists a new unified dart CLI with improved options for analysis, formatting, and running packages. The primary benefit to this new CLI is dart analyze which (like tuneup) uses the analysis server, which is important because the now-outdated dartanalyzer suffers from several deficiences and bugs because it doesn't use the analysis server.

Note: dart_dev also provides a tuneup-based option for analysis. There does still seem to be some functionality in tuneup that doesn't exist in dart analyze, but its future is unclear. We can probably leave the tuneup tool in place, but recommend that the default AnalyzeTool be used once it is updated to use dart analyze.

Acceptance Criteria
- Update AnalyzeTool to have the option to run dart analyze instead of dartanalyzer
- Update FormatTool to have the option run dart format instead of dartfmt (this shouldn't change the scenario when dart_style is used)
- Update any usage of pub run to dart run/ except dart test
- Update any usage of pub global to dart pub global
- Update any usage of pub <get|upgrade> to dart pub <get|upgrade>
- Update any applicable references to outdated CLI commands in the README and documentation guides