### PR TITLE
Compile the dart_dev run script for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [3.9.0](https://github.com/Workiva/dart_dev/compare/3.9.0...3.8.0)
+
+- Add a `clean` command by default that removes temporary files used by
+dart_dev, like the compiled version of the run script.
+- Use `dart compile exe` to compile the `.dart_tool/dart_dev/run.dart` script
+for better startup performance on subsequent runs. This compilation step will be
+cached until `tool/dart_dev/config.dart`, the installed packages, or the current
+Dart SDK is changed.
+
 ## [3.8.0](https://github.com/Workiva/dart_dev/compare/3.8.0...3.7.0)
 
 - Upgrade to analyzer ^1.0.0 and build_runner to ^2.0.0. This also brings along

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -5,6 +5,7 @@ import 'package:args/command_runner.dart';
 
 import 'dart_dev_tool.dart';
 import 'events.dart' as events;
+import 'tools/clean_tool.dart';
 import 'utils/version.dart';
 
 // import 'package:completion/completion.dart' as completion;
@@ -12,6 +13,10 @@ import 'utils/version.dart';
 class DartDevRunner extends CommandRunner<int> {
   DartDevRunner(Map<String, DevTool> commands)
       : super('dart_dev', 'Dart tool runner.') {
+    // For backwards-compatibility, only add the `clean` command if it doesn't
+    // conflict with any configured command.
+    commands.putIfAbsent('clean', () => CleanTool());
+
     commands.forEach((name, builder) {
       final command = builder.toCommand(name);
       if (command.name != name) {
@@ -19,6 +24,7 @@ class DartDevRunner extends CommandRunner<int> {
       }
       addCommand(command);
     });
+
     argParser
       ..addFlag('verbose',
           abbr: 'v', negatable: false, help: 'Enables verbose logging.')

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -1,16 +1,21 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:args/command_runner.dart';
+import 'package:crypto/crypto.dart';
 import 'package:dart_dev/dart_dev.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:dart_dev/src/utils/format_tool_builder.dart';
 import 'package:dart_dev/src/utils/parse_flag_from_args.dart';
+import 'package:glob/glob.dart';
+import 'package:glob/list_local_fs.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart' show ExitCode;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
+import 'package:pubspec_parse/pubspec_parse.dart';
 
 import '../utils.dart';
 import 'dart_dev_runner.dart';
@@ -22,13 +27,18 @@ import 'utils/logging.dart';
 
 typedef _ConfigGetter = Map<String, DevTool> Function();
 
+const _packageConfigPath = '.dart_tool/package_config.json';
+final _packageConfig = File(_packageConfigPath);
+final _runExecutablePath = p.join(cacheDirPath, 'run');
+final _runExecutable = File(_runExecutablePath);
+final _runExecutableDigestPath = p.setExtension(_runExecutablePath, '.digest');
+final _runExecutableDigest = File(_runExecutableDigestPath);
 final _runScriptPath = p.join(cacheDirPath, 'run.dart');
-
 final _runScript = File(_runScriptPath);
-
 const _configPath = 'tool/dart_dev/config.dart';
-
+final _config = File(_configPath);
 const _oldDevDartPath = 'tool/dev.dart';
+final _oldDevDart = File(_oldDevDartPath);
 
 final _relativeDevDartPath = p.relative(
   p.absolute(_configPath),
@@ -37,29 +47,30 @@ final _relativeDevDartPath = p.relative(
 
 Future<void> run(List<String> args) async {
   attachLoggerToStdio(args);
-  final configExists = File(_configPath).existsSync();
-  final oldDevDartExists = File(_oldDevDartPath).existsSync();
 
-  if (!configExists) {
+  if (!_config.existsSync()) {
     log.fine('No custom `tool/dart_dev/config.dart` file found; '
         'using default config.');
   }
-  if (oldDevDartExists) {
+  if (_oldDevDart.existsSync()) {
     log.warning(yellow.wrap(
         'dart_dev v3 now expects configuration to be at `$_configPath`,\n'
         'but `$_oldDevDartPath` still exists. View the guide to see how to upgrade:\n'
         'https://github.com/Workiva/dart_dev/blob/master/doc/v3-upgrade-guide.md'));
   }
 
-  if (args.contains('hackFastFormat') && !oldDevDartExists) {
+  if (args.contains('hackFastFormat') && !_oldDevDart.existsSync()) {
     await handleFastFormat(args);
-
     return;
   }
 
-  generateRunScript();
+  final processArgs = generateRunScript();
   final process = await Process.start(
-      Platform.executable, [_runScriptPath, ...args],
+      processArgs.first,
+      [
+        if (processArgs.length > 1) ...processArgs.sublist(1),
+        ...args,
+      ],
       mode: ProcessStartMode.inheritStdio);
   ensureProcessExit(process);
   exitCode = await process.exitCode;
@@ -101,21 +112,103 @@ Future<void> handleFastFormat(List<String> args) async {
   }
 }
 
-void generateRunScript() {
-  if (shouldWriteRunScript) {
+List<String> generateRunScript() {
+  // Generate the run script if it doesn't yet exist or regenerate it if the
+  // existing script is outdated.
+  final runScriptContents = buildDartDevRunScriptContents();
+  if (!_runScript.existsSync() ||
+      _runScript.readAsStringSync() != runScriptContents) {
     logTimedSync(log, 'Generating run script', () {
       createCacheDir();
       _runScript.writeAsStringSync(buildDartDevRunScriptContents());
     }, level: Level.INFO);
   }
+
+  // Generate a digest of inputs to the run script. We use this to determine
+  // whether we need to recompile the executable.
+  String encodedDigest;
+  logTimedSync(log, 'Computing run script digest', () {
+    var configHasRelativeImports = false;
+    var configHasSamePackageImports = false;
+    if (_config.existsSync()) {
+      final contents = _config.readAsStringSync();
+      configHasRelativeImports =
+          RegExp(r'''^import ['"][^:]+''').hasMatch(contents);
+      final currentPackageName =
+          Pubspec.parse(File('pubspec.yaml').readAsStringSync()).name;
+      configHasSamePackageImports =
+          RegExp('''import ['"]package:$currentPackageName''')
+              .hasMatch(contents);
+    }
+
+    if (configHasSamePackageImports) {
+      log.fine(
+          'Skipping compilation because $_configPath imports from its own package.');
+      // If the config imports from its own source files, we don't have a way of
+      // efficiently tracking changes that would require recompilation of this
+      // executable, so we skip the compilation altogether.
+      if (_runExecutable.existsSync()) {
+        _runExecutable.deleteSync();
+      }
+      if (_runExecutableDigest.existsSync()) {
+        _runExecutableDigest.deleteSync();
+      }
+      return;
+    }
+
+    final digest = md5.convert([
+      ..._packageConfig.readAsBytesSync(),
+      if (_config.existsSync()) ..._config.readAsBytesSync(),
+      if (configHasRelativeImports)
+        for (final file in Glob('tool/**.dart', recursive: true)
+            .listSync()
+            .whereType<File>()
+            .where((f) => f.path != _configPath))
+          ...file.readAsBytesSync(),
+    ]);
+    encodedDigest = base64.encode(digest.bytes);
+  }, level: Level.FINE);
+
+  if (encodedDigest != null &&
+      (!_runExecutableDigest.existsSync() ||
+          _runExecutableDigest.readAsStringSync() != encodedDigest)) {
+    // Digest either didn't exist or is outdated, so we (re-)compile.
+    logTimedSync(log, 'Compiling run script', () {
+      // Delete the previous exectuable and digest so that if we hit a failure
+      // trying to compile, we don't leave the outdated one in place.
+      if (_runExecutable.existsSync()) {
+        _runExecutable.deleteSync();
+      }
+      if (_runExecutableDigest.existsSync()) {
+        _runExecutableDigest.deleteSync();
+      }
+
+      final args = ['compile', 'exe', _runScriptPath, '-o', _runExecutablePath];
+      final result = Process.runSync(Platform.executable, args);
+      if (result.exitCode == 0) {
+        // Compilation succeeded. Write the new digest, as well.
+        _runExecutableDigest.writeAsStringSync(encodedDigest);
+      } else {
+        // Compilation failed. Dump some logs for debugging, but note to the
+        // user that dart_dev should still work.
+        log.warning(
+            'Could not compile run script; dart_dev will continue without precompilation.');
+        log.fine('CMD: ${Platform.executable} ${args.join(" ")}');
+        log.fine('STDOUT:\n${result.stdout}');
+        log.fine('STDERR:\n${result.stderr}');
+      }
+    });
+  }
+
+  if (_runExecutable.existsSync()) {
+    return [_runExecutablePath];
+  } else {
+    return [Platform.executable, 'run', _runScriptPath];
+  }
 }
 
-bool get shouldWriteRunScript =>
-    !_runScript.existsSync() ||
-    _runScript.readAsStringSync() != buildDartDevRunScriptContents();
-
 String buildDartDevRunScriptContents() {
-  final hasCustomToolDevDart = File(_configPath).existsSync();
+  final hasCustomToolDevDart = _config.existsSync();
   return '''
 import 'dart:io';
 

--- a/lib/src/tools/clean_tool.dart
+++ b/lib/src/tools/clean_tool.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:io/io.dart';
+
+import '../dart_dev_tool.dart';
+import '../utils/dart_tool_cache.dart';
+
+class CleanTool extends DevTool {
+  @override
+  String description = 'Cleans up temporary files used by dart_dev.';
+
+  @override
+  FutureOr<int> run([DevToolExecutionContext context]) {
+    final cache = Directory(cacheDirPath);
+    if (cache.existsSync()) {
+      cache.deleteSync(recursive: true);
+    }
+    return ExitCode.success.code;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   async: ^2.3.0
   build_runner: ^2.0.0
   completion: ^1.0.0
+  crypto: ^3.0.1
   glob: ^2.0.0
   io: ^1.0.0
   logging: ^1.0.0


### PR DESCRIPTION
Running a `dart_dev` command involves several subprocesses. The main reason for this is because we wanted to support rich package configuration via a `.dart` file that can do whatever is necessary and possible, rather than just a static config file in something like yaml. To make this work with `dart run dart_dev`, however, requires generating another Dart program that imports this config file from the current package and uses it when running `dart_dev`, which we then run via a subprocess.

The execution flow looks like this:

<img width="368" alt="Screen Shot 2021-11-20 at 11 04 23 AM" src="https://user-images.githubusercontent.com/1738457/142736734-b2f22613-dd55-4fef-bdf0-838fd7a40b7e.png">

With the exception that currently we don't perform the second precompilation step, meaning that every time you run `dart_dev`, you have to pay the cost of Dart compiling that generated run script. In some informal benchmarking, that step takes about **5 seconds**.

This PR introduces logic that will compile this run script and store the result in `.dart_tool/dart_dev/` so that subsequent runs can use it directly. Running precompiled Dart executables is very fast (~0.5s for kernel snapshots and ~0.02s for native executables), so once the compilation step is done, subsequent runs save almost all of the aforementioned 5 seconds.

The compiled result is cached along with a digest of its inputs. If any of these inputs change, the script will be recompiled:
- `.dart_tool/package_config.json` (pub get resolution + the current Dart SDK)
- `tool/dart_dev/config.dart`
- `tool/**.dart` (if the above config file has any relative imports)

Additionally, this compilation step will be skipped if:
- `tool/dart_dev/config.dart` imports from any package that is considered mutable

## Benchmarking

Here's some more informal benchmarking to demonstrate how this impacts first runs and subsequent (cached) runs:

### `dart run dart_dev` (first run)
| SDK                | Before | After  | Delta |
| ------------------ | ------ | ------ | ----- |
| 2.13.4             | ~15.6s | ~21s   | +5.4s |
| 2.14.4             | ~12.6s | ~18s   | +5.4s |
| 2.15.0-268.18.beta | ~11.7s | ~15.5s | +3.8s |

### `dart run dart_dev` (cached run)

| SDK                | Before | After | Delta |
| ------------------ | ------ | ----- | ----- |
| 2.13.4             | ~6.7s  | ~1.5s | -5.2s |
| 2.14.4             | ~7s    | ~2s   | -5s   |
| 2.15.0-268.18.beta | ~6.5s  | ~1.3s | -5.2s |

To summarize, the first run takes a perf hit of about 5 seconds, but as a result, subsequent runs have very little overhead and save that same 5 seconds every time.

---

This PR also adds a `clean` subcommand to `dart run dart_dev` that will remove the files in `.dart_tool/dart_dev/`, in case a bug is found in our compilation caching logic.