### PR TITLE
Widen build_runner, io, and pubspec_parse ranges

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,15 +10,15 @@ dependencies:
   analyzer: ^1.0.0
   args: ^2.0.0
   async: ^2.3.0
-  build_runner: ^2.0.0
+  build_runner: '>=1.0.0 <3.0.0'
   completion: ^1.0.0
   glob: ^2.0.0
-  io: ^1.0.0
+  io: '>=0.3.5 <2.0.0'
   logging: ^1.0.0
   path: ^1.6.2
   pedantic: ^1.7.0
   pub_semver: ^2.0.0
-  pubspec_parse: ^1.0.0
+  pubspec_parse: '>=0.1.8 <2.0.0'
   stack_trace: ^1.9.3
   yaml: ^3.0.0
 


### PR DESCRIPTION
## Motivation
When we previously upgraded some dependencies, we raised the minimum just a bit too far for build_runner, io, and pubspec_parse. By lowering these slightly (which is safe to do given our usage), it allows us to resolve to analyzer v1 in wdesk_sdk sooner.