### PR TITLE
FEA-427: Widen analyzer range to allow v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [3.8.7](https://github.com/Workiva/dart_dev/compare/3.8.6...3.8.7)
+
+- Allow analyzer v2.
+
+## [3.8.6](https://github.com/Workiva/dart_dev/compare/3.8.5...3.8.6)
+
+- Widen dependency ranges.
+
 ## [3.8.5](https://github.com/Workiva/dart_dev/compare/3.8.4...3.8.5)
 
 - Fix errors when running in mixed-version packages that have opted into null safety via pubspec.yaml.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  analyzer: ^1.0.0
+  analyzer: '>=1.0.0 <3.0.0'
   args: ^2.0.0
   async: ^2.3.0
   build_runner: '>=1.0.0 <3.0.0'


### PR DESCRIPTION
Widen analyzer range to allow v2. Compatibility with V2 is tested here: https://github.com/Workiva/dart_dev/pull/376