### PR TITLE
FW-144 Add skynet config that verifies that github workflow passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.8.8](https://github.com/Workiva/dart_dev/compare/3.8.7...3.8.8)
+
+- CI tweaks.
+
 ## [3.8.7](https://github.com/Workiva/dart_dev/compare/3.8.6...3.8.7)
 
 - Allow analyzer v2.

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,7 +1,7 @@
 name: verify-github-actions
 description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
 contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
-image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+image: drydock.workiva.net/workiva/skynet-images:3708893 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
 size: small
 timeout: 600
 

--- a/skynet.yaml
+++ b/skynet.yaml
@@ -1,0 +1,13 @@
+name: verify-github-actions
+description: Verify that the github actions run passed, this is needed to make pipelines pass without manual intervention
+contact: 'Frontend Frameworks Architecture / #support-frontend-architecture'
+image: drydock.workiva.net/workiva/skynet-images:3693290 # Uses the image from this branch: https://github.com/Workiva/skynet-images/pull/127
+size: small
+timeout: 600
+
+env:
+# encrypted github token used for requests to api.github.com
+ - secure: PBYV1M83AKj5+NlaDsDv8ey/mw9+0HOx15Y5/ot6LCespcHXnj7s+nVqKCotoPjyC2rQEaeXh98KzSriMhLou6dYJHk=
+
+scripts:
+  - python3 /actions/verify_github_actions.py


### PR DESCRIPTION
## Motivation
Currently release pipelines are failing because they require a skynet run in order to pass the testing phase of the pipeline. We would like to not have to manually check that the github workflow passed and override the pipeline so we need a way to automatically check that the workflow passed and tell the pipeline that all is good.
  <!-- High-level overview of what you are trying to fix or improve, and why.
         Include any relevant background information that reviewers should know. -->

## Changes
Add a skynet.yaml that checks the github workflow run and passes or fails the skynet run depending on the results.
  <!-- What this PR changes to fix the problem. -->

#### Release Notes
Add skynet run to check that the github workflow run passes  
<!-- A concise description of your changes, written in the imperative.
         ("Fix bug" and not "Fixed bug" or "Fixes bug.") -->