### PR TITLE
Fixes for Windows compatibility

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -18,7 +18,7 @@ jobs:
         sdk: [ 2.13.4, stable, beta, dev ]
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.2
+      - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: ${{ matrix.sdk }}
 
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.2
+      - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: 2.13.4
 
@@ -56,4 +56,20 @@ jobs:
 
       - name: Publish dry run
         run: dart pub publish --dry-run
+        if: always() && steps.install.outcome == 'success'
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1.3
+        with:
+          sdk: stable
+
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+
+      - name: Run tests
+        run: dart run dart_dev test
         if: always() && steps.install.outcome == 'success'

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -16,6 +16,7 @@ import 'utils/cached_pubspec.dart';
 import 'utils/dart_dev_paths.dart';
 import 'utils/dart_tool_cache.dart';
 import 'utils/ensure_process_exit.dart';
+import 'utils/executables.dart' as exe;
 import 'utils/format_tool_builder.dart';
 import 'utils/get_dart_version_comment.dart';
 import 'utils/logging.dart';
@@ -51,8 +52,7 @@ Future<void> run(List<String> args) async {
   }
 
   generateRunScript();
-  final process = await Process.start(
-      Platform.executable, [paths.runScript, ...args],
+  final process = await Process.start(exe.dart, [paths.runScript, ...args],
       mode: ProcessStartMode.inheritStdio);
   ensureProcessExit(process);
   exitCode = await process.exitCode;

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -27,9 +27,9 @@ final _runScriptPath = p.join(cacheDirPath, 'run.dart');
 
 final _runScript = File(_runScriptPath);
 
-const _configPath = 'tool/dart_dev/config.dart';
+final _configPath = p.join('tool', 'dart_dev', 'config.dart');
 
-const _oldDevDartPath = 'tool/dev.dart';
+final _oldDevDartPath = p.join('tool', 'dev.dart');
 
 final _relativeDevDartPath = p.relative(
   p.absolute(_configPath),
@@ -42,7 +42,7 @@ Future<void> run(List<String> args) async {
   final oldDevDartExists = File(_oldDevDartPath).existsSync();
 
   if (!configExists) {
-    log.fine('No custom `tool/dart_dev/config.dart` file found; '
+    log.fine('No custom `$_configPath` file found; '
         'using default config.');
   }
   if (oldDevDartExists) {
@@ -162,8 +162,7 @@ Future<void> runWithConfig(
     config = configGetter();
   } catch (error) {
     stderr
-      ..writeln(
-          'Invalid "tool/dart_dev/config.dart" in ${p.absolute(p.current)}')
+      ..writeln('Invalid "$_configPath" in ${p.absolute(p.current)}')
       ..writeln()
       ..writeln('It should provide a `Map<String, DevTool> config;` getter,'
           ' but it either does not exist or threw unexpectedly:')

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -4,51 +4,43 @@ import 'dart:io';
 import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/dart_dev.dart';
-import 'package:dart_dev/src/dart_dev_tool.dart';
-import 'package:dart_dev/src/utils/format_tool_builder.dart';
-import 'package:dart_dev/src/utils/get_dart_version_comment.dart';
-import 'package:dart_dev/src/utils/parse_flag_from_args.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart' show ExitCode;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
-import '../utils.dart';
 import 'dart_dev_runner.dart';
 import 'tools/over_react_format_tool.dart';
 import 'utils/assert_dir_is_dart_package.dart';
+import 'utils/cached_pubspec.dart';
+import 'utils/dart_dev_paths.dart';
 import 'utils/dart_tool_cache.dart';
 import 'utils/ensure_process_exit.dart';
+import 'utils/format_tool_builder.dart';
+import 'utils/get_dart_version_comment.dart';
 import 'utils/logging.dart';
+import 'utils/parse_flag_from_args.dart';
 
 typedef _ConfigGetter = Map<String, DevTool> Function();
 
-final _runScriptPath = p.join(cacheDirPath, 'run.dart');
+final paths = DartDevPaths();
 
-final _runScript = File(_runScriptPath);
-
-final _configPath = p.join('tool', 'dart_dev', 'config.dart');
-
-final _oldDevDartPath = p.join('tool', 'dev.dart');
-
-final _relativeDevDartPath = p.relative(
-  p.absolute(_configPath),
-  from: p.absolute(p.dirname(_runScriptPath)),
-);
+final _runScript = File(paths.runScript);
 
 Future<void> run(List<String> args) async {
   attachLoggerToStdio(args);
-  final configExists = File(_configPath).existsSync();
-  final oldDevDartExists = File(_oldDevDartPath).existsSync();
+
+  final configExists = File(paths.config).existsSync();
+  final oldDevDartExists = File(paths.legacyConfig).existsSync();
 
   if (!configExists) {
-    log.fine('No custom `$_configPath` file found; '
+    log.fine('No custom `${paths.config}` file found; '
         'using default config.');
   }
   if (oldDevDartExists) {
     log.warning(yellow.wrap(
-        'dart_dev v3 now expects configuration to be at `$_configPath`,\n'
-        'but `$_oldDevDartPath` still exists. View the guide to see how to upgrade:\n'
+        'dart_dev v3 now expects configuration to be at `${paths.config}`,\n'
+        'but `${paths.legacyConfig}` still exists. View the guide to see how to upgrade:\n'
         'https://github.com/Workiva/dart_dev/blob/master/doc/v3-upgrade-guide.md'));
   }
 
@@ -60,7 +52,7 @@ Future<void> run(List<String> args) async {
 
   generateRunScript();
   final process = await Process.start(
-      Platform.executable, [_runScriptPath, ...args],
+      Platform.executable, [paths.runScript, ...args],
       mode: ProcessStartMode.inheritStdio);
   ensureProcessExit(process);
   exitCode = await process.exitCode;
@@ -70,7 +62,7 @@ Future<void> handleFastFormat(List<String> args) async {
   assertDirIsDartPackage();
 
   DevTool formatTool;
-  final configFile = File(_configPath);
+  final configFile = File(paths.config);
   if (configFile.existsSync()) {
     final toolBuilder = FormatToolBuilder();
     parseString(content: configFile.readAsStringSync())
@@ -119,11 +111,11 @@ bool get shouldWriteRunScript =>
 const _isDartDevNullSafe = false;
 
 String buildDartDevRunScriptContents() {
-  final hasCustomToolDevDart = File(_configPath).existsSync();
+  final hasCustomToolDevDart = File(paths.config).existsSync();
   // If the config has a dart version comment (e.g., if it opts out of null safety),
   // copy it over to the entrypoint so the program is run in that language version.
   var dartVersionComment = hasCustomToolDevDart
-      ? getDartVersionComment(File(_configPath).readAsStringSync())
+      ? getDartVersionComment(File(paths.config).readAsStringSync())
       : null;
   // If dart_dev itself is not null-safe, opt the entrypoint out of null-safety
   // so the entrypoint doesn't fail to run in packages that have opted into null-safety.
@@ -137,7 +129,7 @@ import 'dart:io';
 
 import 'package:dart_dev/src/core_config.dart';
 import 'package:dart_dev/src/executable.dart' as executable;
-${hasCustomToolDevDart ? "import '$_relativeDevDartPath' as custom_dev;" : ""}
+${hasCustomToolDevDart ? "import '${paths.configFromRunScriptForDart}' as custom_dev;" : ""}
 
 void main(List<String> args) async {
   await executable.runWithConfig(args,
@@ -162,7 +154,7 @@ Future<void> runWithConfig(
     config = configGetter();
   } catch (error) {
     stderr
-      ..writeln('Invalid "$_configPath" in ${p.absolute(p.current)}')
+      ..writeln('Invalid "${paths.config}" in ${p.absolute(p.current)}')
       ..writeln()
       ..writeln('It should provide a `Map<String, DevTool> config;` getter,'
           ' but it either does not exist or threw unexpectedly:')

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/executables.dart' as exe;
 import '../utils/logging.dart';
 import '../utils/process_declaration.dart';
 import '../utils/run_process_and_ensure_exit.dart';
@@ -176,7 +177,7 @@ ProcessDeclaration buildProcess(
             'Arguments can be passed to the "${analyzerUsed}" process via '
             'the --analyzer-args option.');
   }
-  final executable = useDartAnalyze ? 'dart' : 'dartanalyzer';
+  var executable = useDartAnalyze ? exe.dart : exe.dartanalyzer;
   final args = buildArgs(
       argResults: context.argResults,
       configuredAnalyzerArgs: configuredAnalyzerArgs,

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -13,6 +13,7 @@ import '../../utils.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/executables.dart' as exe;
 import '../utils/logging.dart';
 import '../utils/organize_directives/organize_directives_in_paths.dart';
 import '../utils/package_is_immediate_dependency.dart';
@@ -586,12 +587,12 @@ FormatExecution buildExecution(
 ProcessDeclaration buildFormatProcess([Formatter formatter]) {
   switch (formatter) {
     case Formatter.dartStyle:
-      return ProcessDeclaration('dart', ['run', 'dart_style:format']);
+      return ProcessDeclaration(exe.dart, ['run', 'dart_style:format']);
     case Formatter.dartFormat:
-      return ProcessDeclaration('dart', ['format']);
+      return ProcessDeclaration(exe.dart, ['format']);
     case Formatter.dartfmt:
     default:
-      return ProcessDeclaration('dartfmt', []);
+      return ProcessDeclaration(exe.dartfmt, []);
   }
 }
 

--- a/lib/src/tools/over_react_format_tool.dart
+++ b/lib/src/tools/over_react_format_tool.dart
@@ -4,7 +4,8 @@ import 'dart:io';
 import 'package:dart_dev/dart_dev.dart';
 import 'package:dart_dev/utils.dart';
 
-import '../tools/format_tool.dart';
+import '../utils/executables.dart' as exe;
+import 'format_tool.dart';
 
 class OverReactFormatTool extends DevTool {
   /// Wrap lines longer than this.
@@ -31,7 +32,7 @@ class OverReactFormatTool extends DevTool {
       'over_react_format',
       if (lineLength != null) '--line-length=$lineLength'
     ];
-    final process = ProcessDeclaration('dart', [...args, ...paths],
+    final process = ProcessDeclaration(exe.dart, [...args, ...paths],
         mode: ProcessStartMode.inheritStdio);
     logCommand('dart', paths, args, verbose: context?.verbose);
     return runProcessAndEnsureExit(process);

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
+import '../utils/executables.dart' as exe;
 import '../utils/logging.dart';
 import '../utils/package_is_immediate_dependency.dart';
 import '../utils/process_declaration.dart';
@@ -315,7 +316,7 @@ TestExecution buildExecution(
       verbose: context.verbose);
   logSubprocessHeader(_log, 'dart ${args.join(' ')}'.trim());
   return TestExecution.process(
-      ProcessDeclaration('dart', args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration(exe.dart, args, mode: ProcessStartMode.inheritStdio));
 }
 
 // NOTE: This currently depends on https://github.com/dart-lang/build/pull/2445

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/executables.dart' as exe;
 import '../utils/logging.dart';
 import '../utils/package_is_immediate_dependency.dart';
 import '../utils/process_declaration.dart';
@@ -152,5 +153,5 @@ TuneupExecution buildExecution(
       verbose: context.verbose);
   logSubprocessHeader(_log, 'dart ${args.join(' ')}');
   return TuneupExecution.process(
-      ProcessDeclaration('dart', args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration(exe.dart, args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -10,6 +10,7 @@ import 'package:pub_semver/pub_semver.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/executables.dart' as exe;
 import '../utils/global_package_is_active_and_compatible.dart';
 import '../utils/logging.dart';
 import '../utils/process_declaration.dart';
@@ -227,5 +228,5 @@ WebdevServeExecution buildExecution(
       verbose: context.verbose);
   logSubprocessHeader(_log, 'dart ${args.join(' ')}'.trim());
   return WebdevServeExecution.process(
-      ProcessDeclaration('dart', args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration(exe.dart, args, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/utils/dart_dev_paths.dart
+++ b/lib/src/utils/dart_dev_paths.dart
@@ -1,0 +1,31 @@
+import 'package:path/path.dart' as p;
+
+/// A collection of paths to files and directories constructed to be compatible
+/// with a given [p.Context].
+class DartDevPaths {
+  final p.Context _context;
+
+  DartDevPaths({p.Context context}) : _context = context ?? p.context;
+
+  String cache([String subPath]) => _context.normalize(
+      _context.joinAll([..._cacheParts, if (subPath != null) subPath]));
+
+  String get _cacheForDart => p.url.joinAll(_cacheParts);
+
+  final List<String> _cacheParts = ['.dart_tool', 'dart_dev'];
+
+  String get config => _context.joinAll(_configParts);
+
+  String get configForDart => p.url.joinAll(_configParts);
+
+  final List<String> _configParts = ['tool', 'dart_dev', 'config.dart'];
+
+  String get configFromRunScriptForDart => p.url.relative(
+        p.url.absolute(configForDart),
+        from: p.url.absolute(_cacheForDart),
+      );
+
+  String get legacyConfig => _context.join('tool', 'dev.dart');
+
+  String get runScript => cache('run.dart');
+}

--- a/lib/src/utils/dart_tool_cache.dart
+++ b/lib/src/utils/dart_tool_cache.dart
@@ -1,15 +1,9 @@
 import 'dart:io';
 
-import 'package:path/path.dart' as p;
-
-const cacheDirPath = '.dart_tool/dart_dev';
+import 'package:dart_dev/src/utils/dart_dev_paths.dart';
 
 void createCacheDir({String subPath}) {
-  var path = cacheDirPath;
-  if (subPath != null) {
-    path = p.join(path, subPath);
-  }
-  final dir = Directory(path);
+  final dir = Directory(DartDevPaths().cache(subPath));
   if (!dir.existsSync()) {
     dir.createSync(recursive: true);
   }

--- a/lib/src/utils/executables.dart
+++ b/lib/src/utils/executables.dart
@@ -1,0 +1,7 @@
+import 'dart:io';
+
+final dart = 'dart';
+
+final dartanalyzer = Platform.isWindows ? 'dartanalyzer.bat' : 'dartanalyzer';
+
+final dartfmt = Platform.isWindows ? 'dartfmt.bat' : 'dartfmt';

--- a/lib/src/utils/global_package_is_active_and_compatible.dart
+++ b/lib/src/utils/global_package_is_active_and_compatible.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 
 import 'package:pub_semver/pub_semver.dart';
 
+import 'executables.dart' as exe;
+
 /// Returns `true` if [packageName] is globally activated at a version
 /// allowed by [constraint]. Returns `false` otherwise.
 ///
@@ -16,13 +18,12 @@ import 'package:pub_semver/pub_semver.dart';
 bool globalPackageIsActiveAndCompatible(
     String packageName, VersionConstraint constraint,
     {Map<String, String> environment}) {
-  final executable = 'dart';
   final args = ['pub', 'global', 'list'];
-  final result = Process.runSync(executable, args,
+  final result = Process.runSync(exe.dart, args,
       environment: environment, stderrEncoding: utf8, stdoutEncoding: utf8);
   if (result.exitCode != 0) {
     throw ProcessException(
-        executable,
+        exe.dart,
         args,
         'Could not list global pub packages:\n${result.stderr}',
         result.exitCode);

--- a/test/functional.dart
+++ b/test/functional.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:path/path.dart' as p;
 import 'package:test_descriptor/test_descriptor.dart' as d;
 import 'package:test_process/test_process.dart';
@@ -44,7 +45,7 @@ Future<TestProcess> runDevToolFunctionalTest(
     });
     pubspec.writeAsStringSync(updated);
 
-    final result = Process.runSync('dart', ['pub', 'get'],
+    final result = Process.runSync(exe.dart, ['pub', 'get'],
         workingDirectory: pubspec.parent.path);
     if (result.exitCode != 0) {
       final origPath = p.join(p.relative(templateDir.absolute.path),
@@ -56,5 +57,5 @@ Future<TestProcess> runDevToolFunctionalTest(
   }
 
   final allArgs = <String>['run', 'dart_dev', command, ...?args];
-  return TestProcess.start('dart', allArgs, workingDirectory: d.sandbox);
+  return TestProcess.start(exe.dart, allArgs, workingDirectory: d.sandbox);
 }

--- a/test/functional/documentation_test.dart
+++ b/test/functional/documentation_test.dart
@@ -12,6 +12,7 @@ library test.functional.documentation_test;
 
 import 'dart:io';
 
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:glob/glob.dart';
 import 'package:glob/list_local_fs.dart';
 import 'package:path/path.dart' as p;
@@ -28,13 +29,13 @@ void main() {
         d.file('pubspec.yaml', pubspecSource),
       ]).create();
 
-      final pubGet = await TestProcess.start('dart', ['pub', 'get'],
+      final pubGet = await TestProcess.start(exe.dart, ['pub', 'get'],
           workingDirectory: '${d.sandbox}/project');
       printOnFailure('PUBSPEC:\n$pubspecSource\n');
       await pubGet.shouldExit(0);
 
       final analysis = await TestProcess.start(
-          'dart', ['analyze', '--fatal-infos'],
+          exe.dart, ['analyze', '--fatal-infos'],
           workingDirectory: '${d.sandbox}/project');
       printOnFailure('SOURCE:\n${dartBlock.source}\n');
       await analysis.shouldExit(0);

--- a/test/functional/documentation_test.dart
+++ b/test/functional/documentation_test.dart
@@ -45,7 +45,7 @@ void main() {
 
 Iterable<DartBlock> getDartBlocks() sync* {
   final dartBlockPattern =
-      RegExp(r'^```dart *([^\n]*)([^`]*)^```', multiLine: true);
+      RegExp(r'^```dart *([^\r\n]*)([^`]*)^```', multiLine: true);
   for (final file in Glob('**.md').listSync().whereType<File>()) {
     final source = file.readAsStringSync();
     var i = 1;

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -1,8 +1,11 @@
 @TestOn('vm')
+import 'dart:io';
+
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:dart_dev/src/tools/analyze_tool.dart';
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:glob/glob.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
@@ -120,14 +123,14 @@ void main() {
     test('returns a ProcessDeclaration (default)', () {
       final context = DevToolExecutionContext();
       final process = buildProcess(context);
-      expect(process.executable, 'dartanalyzer');
+      expect(process.executable, exe.dartanalyzer);
       expect(process.args, orderedEquals(['.']));
     });
 
     test('returns a ProcessDeclaration with useDartAnalyze (default)', () {
       final context = DevToolExecutionContext();
       final process = buildProcess(context, useDartAnalyze: true);
-      expect(process.executable, 'dart');
+      expect(process.executable, exe.dart);
       expect(process.args, orderedEquals(['analyze', '.']));
     });
 
@@ -140,7 +143,7 @@ void main() {
           configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
           include: [Glob('*.dart'), Glob('*.txt')],
           path: globRoot);
-      expect(process.executable, 'dartanalyzer');
+      expect(process.executable, exe.dartanalyzer);
       expect(
           process.args,
           orderedEquals([
@@ -163,7 +166,7 @@ void main() {
           include: [Glob('*.dart')],
           path: globRoot,
           useDartAnalyze: true);
-      expect(process.executable, 'dart');
+      expect(process.executable, exe.dart);
       expect(
           process.args,
           orderedEquals([
@@ -186,7 +189,7 @@ void main() {
           configuredAnalyzerArgs: ['--fatal-infos', '--fatal-warnings'],
           include: [Glob('*.dart'), Glob('*.txt')],
           path: globRoot);
-      expect(process.executable, 'dartanalyzer');
+      expect(process.executable, exe.dartanalyzer);
       expect(
           process.args,
           orderedEquals([

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:dart_dev/src/tools/format_tool.dart';
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:glob/glob.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
@@ -230,7 +231,7 @@ void main() {
           argResults: argResults, commandName: 'hackFastFormat');
       final execution = buildExecution(context);
       expect(execution.exitCode, isNull);
-      expect(execution.formatProcess.executable, 'dartfmt');
+      expect(execution.formatProcess.executable, exe.dartfmt);
       expect(execution.formatProcess.args, orderedEquals(['a/random/path']));
       expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
       expect(execution.directiveOrganization, isNull);
@@ -333,7 +334,7 @@ void main() {
         final context = DevToolExecutionContext();
         final execution = buildExecution(context);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dartfmt');
+        expect(execution.formatProcess.executable, exe.dartfmt);
         expect(execution.formatProcess.args, orderedEquals(['.']));
         expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
@@ -344,7 +345,7 @@ void main() {
         final execution =
             buildExecution(context, defaultMode: FormatMode.dryRun);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dartfmt');
+        expect(execution.formatProcess.executable, exe.dartfmt);
         expect(execution.formatProcess.args, orderedEquals(['-n', '.']));
         expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
@@ -354,7 +355,7 @@ void main() {
         final context = DevToolExecutionContext();
         final execution = buildExecution(context, formatter: Formatter.dartfmt);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dartfmt');
+        expect(execution.formatProcess.executable, exe.dartfmt);
         expect(execution.formatProcess.args, orderedEquals(['.']));
         expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
@@ -365,7 +366,7 @@ void main() {
         final execution =
             buildExecution(context, formatter: Formatter.dartFormat);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dart');
+        expect(execution.formatProcess.executable, exe.dart);
         expect(execution.formatProcess.args, orderedEquals(['format', '.']));
         expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
       });
@@ -376,7 +377,7 @@ void main() {
             formatter: Formatter.dartStyle,
             path: 'test/tools/fixtures/format/has_dart_style');
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dart');
+        expect(execution.formatProcess.executable, exe.dart);
         expect(execution.formatProcess.args,
             orderedEquals(['run', 'dart_style:format', '.']));
         expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
@@ -392,7 +393,7 @@ void main() {
             configuredFormatterArgs: ['--fix', '--follow-links'],
             formatter: Formatter.dartfmt);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dartfmt');
+        expect(execution.formatProcess.executable, exe.dartfmt);
         expect(
             execution.formatProcess.args,
             orderedEquals(
@@ -409,7 +410,7 @@ void main() {
             configuredFormatterArgs: ['--fix', '--follow-links'],
             formatter: Formatter.dartFormat);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, 'dart');
+        expect(execution.formatProcess.executable, exe.dart);
         expect(
             execution.formatProcess.args,
             orderedEquals(
@@ -461,25 +462,25 @@ void main() {
   group('buildFormatProcess', () {
     test('dartfmt', () {
       final process = buildFormatProcess(Formatter.dartfmt);
-      expect(process.executable, 'dartfmt');
+      expect(process.executable, exe.dartfmt);
       expect(process.args, isEmpty);
     });
 
     test('dart format', () {
       final process = buildFormatProcess(Formatter.dartFormat);
-      expect(process.executable, 'dart');
+      expect(process.executable, exe.dart);
       expect(process.args, orderedEquals(['format']));
     });
 
     test('dart_style', () {
       final process = buildFormatProcess(Formatter.dartStyle);
-      expect(process.executable, 'dart');
+      expect(process.executable, exe.dart);
       expect(process.args, orderedEquals(['run', 'dart_style:format']));
     });
 
     test('default', () {
       final process = buildFormatProcess(Formatter.dartfmt);
-      expect(process.executable, 'dartfmt');
+      expect(process.executable, exe.dartfmt);
       expect(process.args, isEmpty);
     });
   });

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -58,18 +58,20 @@ void main() {
             formatterInputs.includedFiles,
             unorderedEquals({
               'file.dart',
-              'links/not_link.dart',
-              'lib/sub/file.dart',
+              p.join('links', 'not_link.dart'),
+              p.join('lib', 'sub', 'file.dart'),
               'linked.dart',
-              'other/file.dart',
+              p.join('other', 'file.dart'),
             }));
 
         expect(formatterInputs.excludedFiles,
             unorderedEquals({'should_exclude.dart'}));
         expect(formatterInputs.hiddenDirectories,
             unorderedEquals({'.dart_tool_test'}));
-        expect(formatterInputs.skippedLinks,
-            unorderedEquals({'links/lib-link', 'links/link.dart'}));
+        expect(
+            formatterInputs.skippedLinks,
+            unorderedEquals(
+                {p.join('links', 'lib-link'), p.join('links', 'link.dart')}));
       });
 
       test('custom excludes with collapseDirectories', () {
@@ -115,10 +117,10 @@ void main() {
             formatterInputs.includedFiles,
             unorderedEquals({
               'file.dart',
-              'links/not_link.dart',
-              'lib/sub/file.dart',
+              p.join('links', 'not_link.dart'),
+              p.join('lib', 'sub', 'file.dart'),
               'linked.dart',
-              'other/file.dart',
+              p.join('other', 'file.dart'),
               'should_exclude.dart',
             }));
         expect(formatterInputs.excludedFiles, isEmpty);
@@ -130,7 +132,7 @@ void main() {
         expect(
             formatterInputs.includedFiles,
             unorderedEquals({
-              'lib-link/sub/file.dart',
+              p.join('lib-link', 'sub', 'file.dart'),
               'not_link.dart',
               'link.dart',
             }));
@@ -420,14 +422,14 @@ void main() {
 
       test('and logs the test subprocess by default', () {
         expect(Logger.root.onRecord,
-            emitsThrough(infoLogOf(contains('dartfmt .'))));
+            emitsThrough(infoLogOf(contains('${exe.dartfmt} .'))));
 
         buildExecution(DevToolExecutionContext());
       });
 
       test('and logs the test subprocess for dart format', () {
         expect(Logger.root.onRecord,
-            emitsThrough(infoLogOf(contains('dart format .'))));
+            emitsThrough(infoLogOf(contains('${exe.dart} format .'))));
 
         buildExecution(DevToolExecutionContext(),
             formatter: Formatter.dartFormat);

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -3,6 +3,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:dart_dev/src/tools/test_tool.dart';
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
@@ -356,7 +357,7 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args, orderedEquals(['test']));
         });
 
@@ -367,7 +368,7 @@ dev_dependencies:
           final execution = buildExecution(context,
               configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args,
               orderedEquals(['test', '-P', 'unit', '-n', 'foo']));
         });
@@ -378,7 +379,7 @@ dev_dependencies:
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args, orderedEquals(['test', '-j1']));
         });
 
@@ -426,7 +427,7 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args, orderedEquals(['test']));
         });
 
@@ -437,7 +438,7 @@ dev_dependencies:
           final execution = buildExecution(context,
               configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args,
               orderedEquals(['test', '-P', 'unit', '-n', 'foo']));
         });
@@ -448,7 +449,7 @@ dev_dependencies:
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args, orderedEquals(['test', '-j1']));
         });
 
@@ -497,7 +498,7 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(execution.process.args,
               orderedEquals(['run', 'build_runner', 'test']));
         });
@@ -512,7 +513,7 @@ dev_dependencies:
               configuredTestArgs: ['-P', 'unit'],
               path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(
               execution.process.args,
               orderedEquals([
@@ -536,7 +537,7 @@ dev_dependencies:
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(
               execution.process.args,
               orderedEquals([
@@ -559,7 +560,7 @@ dev_dependencies:
               configuredTestArgs: ['-P', 'unit'],
               path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, 'dart');
+          expect(execution.process.executable, exe.dart);
           expect(
               execution.process.args,
               orderedEquals([

--- a/test/tools/tuneup_check_tool_test.dart
+++ b/test/tools/tuneup_check_tool_test.dart
@@ -5,6 +5,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/dart_dev.dart';
 import 'package:dart_dev/src/tools/tuneup_check_tool.dart';
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
@@ -73,7 +74,7 @@ void main() {
       test('(default)', () {
         final execution = buildExecution(DevToolExecutionContext(), path: path);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'dart');
+        expect(execution.process.executable, exe.dart);
         expect(
             execution.process.args, orderedEquals(['run', 'tuneup', 'check']));
         expect(execution.process.mode, ProcessStartMode.inheritStdio);
@@ -86,7 +87,7 @@ void main() {
             DevToolExecutionContext(argResults: argResults, verbose: true);
         final execution = buildExecution(context, path: path);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'dart');
+        expect(execution.process.executable, exe.dart);
         expect(
             execution.process.args,
             orderedEquals(

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -3,6 +3,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:dart_dev/src/tools/webdev_serve_tool.dart';
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
@@ -194,7 +195,7 @@ void main() {
         final execution = buildExecution(DevToolExecutionContext(),
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'dart');
+        expect(execution.process.executable, exe.dart);
         expect(execution.process.args,
             orderedEquals(['pub', 'global', 'run', 'webdev', 'serve']));
       });
@@ -209,7 +210,7 @@ void main() {
             configuredWebdevArgs: ['web:9000', 'example:9001'],
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'dart');
+        expect(execution.process.executable, exe.dart);
         expect(
             execution.process.args,
             orderedEquals([
@@ -241,7 +242,7 @@ void main() {
             configuredWebdevArgs: ['web:9000', 'example:9001'],
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, 'dart');
+        expect(execution.process.executable, exe.dart);
         expect(
             execution.process.args,
             orderedEquals([

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:dart_dev/utils.dart';
 import 'package:pub_semver/pub_semver.dart';
 import 'package:test/test.dart';
@@ -19,7 +20,7 @@ class TempPubCache {
 void globalActivate(String packageName, String constraint,
     {Map<String, String> environment}) {
   final result = Process.runSync(
-    'dart',
+    exe.dart,
     ['pub', 'global', 'activate', packageName, constraint],
     environment: environment,
     stderrEncoding: utf8,

--- a/test/utils/dart_dev_paths_test.dart
+++ b/test/utils/dart_dev_paths_test.dart
@@ -1,0 +1,73 @@
+import 'package:dart_dev/src/utils/dart_dev_paths.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('DartDevPaths', () {
+    group('posix', () {
+      DartDevPaths paths;
+
+      setUp(() {
+        paths = DartDevPaths(context: p.posix);
+      });
+
+      test('cache', () {
+        expect(paths.cache(), '.dart_tool/dart_dev');
+      });
+
+      test('cache with subpath', () {
+        expect(paths.cache('sub/path'), '.dart_tool/dart_dev/sub/path');
+      });
+
+      test('config', () {
+        expect(paths.config, 'tool/dart_dev/config.dart');
+      });
+
+      test('configFromRunScriptForDart', () {
+        expect(paths.configFromRunScriptForDart,
+            '../../tool/dart_dev/config.dart');
+      });
+
+      test('legacyConfig', () {
+        expect(paths.legacyConfig, 'tool/dev.dart');
+      });
+
+      test('runScript', () {
+        expect(paths.runScript, '.dart_tool/dart_dev/run.dart');
+      });
+    });
+
+    group('windows', () {
+      DartDevPaths paths;
+
+      setUp(() {
+        paths = DartDevPaths(context: p.windows);
+      });
+
+      test('cache', () {
+        expect(paths.cache(), r'.dart_tool\dart_dev');
+      });
+
+      test('cache with subpath', () {
+        expect(paths.cache('sub/path'), r'.dart_tool\dart_dev\sub\path');
+      });
+
+      test('config', () {
+        expect(paths.config, r'tool\dart_dev\config.dart');
+      });
+
+      test('configFromRunScriptForDart', () {
+        expect(paths.configFromRunScriptForDart,
+            r'../../tool/dart_dev/config.dart');
+      });
+
+      test('legacyConfig', () {
+        expect(paths.legacyConfig, r'tool\dev.dart');
+      });
+
+      test('runScript', () {
+        expect(paths.runScript, r'.dart_tool\dart_dev\run.dart');
+      });
+    });
+  });
+}


### PR DESCRIPTION
There are several paths that we're using in our executable and in the run script that we generate and we need to construct them with the appropriate APIs from `package:path` to ensure they work when running on Windows. This PR does that.