### PR TITLE
Auto-switch analyze and format commands when on certain Dart SDKs

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, 2.18.7, stable, beta, dev ]
+        sdk: [ 2.13.4, 2.18.7, stable, beta ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.3

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, stable, beta, dev ]
+        sdk: [ 2.13.4, 2.18.7, stable, beta, dev ]
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.3

--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,11 @@
+Dockerfile
+skynet.yaml
+.dart_tool/
+.idea/
+.packages
+.pub/
+build/
+/doc/api/
+/pubspec.lock
+test/
+tool/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [3.9.2](https://github.com/Workiva/dart_dev/compare/3.9.1...3.9.2)
+
+- Automatically use `dart analyze` instead of `dartanalyzer` when on Dart SDK
+v2.18 or higher (`dartanalyzer` was removed in this version).
+- Automatically use `dart format` instead of `dartfmt` when on Dart SDK v2.15 or
+higher (`dartfmt` was removed in this version).
+
 ## [3.9.1](https://github.com/Workiva/dart_dev/compare/3.9.0...3.9.1)
 
 - Fixes to be compatible with Windows.

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -9,6 +9,7 @@ import 'package:logging/logging.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/dart_semver_version.dart';
 import '../utils/executables.dart' as exe;
 import '../utils/logging.dart';
 import '../utils/process_declaration.dart';
@@ -75,6 +76,9 @@ class AnalyzeTool extends DevTool {
   @override
   FutureOr<int> run([DevToolExecutionContext context]) {
     useDartAnalyze ??= false;
+    if (!dartVersionHasDartanalyzer) {
+      useDartAnalyze = true;
+    }
     return runProcessAndEnsureExit(
         buildProcess(context ?? DevToolExecutionContext(),
             configuredAnalyzerArgs: analyzerArgs,

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -13,6 +13,7 @@ import '../../utils.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/dart_semver_version.dart';
 import '../utils/executables.dart' as exe;
 import '../utils/logging.dart';
 import '../utils/organize_directives/organize_directives_in_paths.dart';
@@ -108,6 +109,9 @@ class FormatTool extends DevTool {
   @override
   FutureOr<int> run([DevToolExecutionContext context]) async {
     context ??= DevToolExecutionContext();
+    if (formatter == Formatter.dartfmt && !dartVersionHasDartfmt) {
+      formatter = Formatter.dartFormat;
+    }
     final formatExecution = buildExecution(
       context,
       configuredFormatterArgs: formatterArgs,

--- a/lib/src/utils/dart_semver_version.dart
+++ b/lib/src/utils/dart_semver_version.dart
@@ -1,0 +1,13 @@
+import 'dart:io';
+
+import 'package:pub_semver/pub_semver.dart';
+
+final versionPattern = RegExp(r'(\d+.\d+.\d+)');
+
+Version get dartSemverVersion =>
+    Version.parse(versionPattern.firstMatch(Platform.version).group(1));
+
+bool get dartVersionHasDartanalyzer =>
+    dartSemverVersion < Version.parse('2.18.0');
+
+bool get dartVersionHasDartfmt => dartSemverVersion < Version.parse('2.15.0');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
  sdk: ">=2.11.0 <3.0.0"
 
 dependencies:
-  analyzer: '>=1.0.0 <3.0.0'
+  analyzer: '>=1.0.0 <6.0.0'
   args: ^2.0.0
   async: ^2.3.0
   build_runner: '>=1.0.0 <3.0.0'

--- a/test/functional.dart
+++ b/test/functional.dart
@@ -34,14 +34,19 @@ Future<TestProcess> runDevToolFunctionalTest(
       .where((f) => p.basename(f.path) == 'pubspec.yaml')
       .map((f) => f.absolute);
   final pathDepPattern = RegExp(r'path: (.*)');
-  final posix = p.Context(style: p.Style.posix);
+
   for (final pubspec in pubspecs) {
     final updated =
         pubspec.readAsStringSync().replaceAllMapped(pathDepPattern, (match) {
       final relDepPath = match.group(1);
-      final relPubspecPath = posix.relative(pubspec.path, from: d.sandbox);
-      final absPath = posix.absolute(posix.normalize(
-          posix.join(templateDir.path, relPubspecPath, relDepPath, '..')));
+      final relPubspecPath = p.relative(pubspec.path, from: d.sandbox);
+      var absPath = p.absolute(p.normalize(
+          p.join(templateDir.path, relPubspecPath, relDepPath, '..')));
+      // Since pubspec paths should always be posix style or dart analyze
+      // complains, switch to forward slashes on windows
+      if (Platform.isWindows) {
+        absPath = absPath.replaceAll('\\', '/');
+      }
       return 'path: $absPath';
     });
     pubspec.writeAsStringSync(updated);

--- a/test/functional.dart
+++ b/test/functional.dart
@@ -34,13 +34,14 @@ Future<TestProcess> runDevToolFunctionalTest(
       .where((f) => p.basename(f.path) == 'pubspec.yaml')
       .map((f) => f.absolute);
   final pathDepPattern = RegExp(r'path: (.*)');
+  final posix = p.Context(style: p.Style.posix);
   for (final pubspec in pubspecs) {
     final updated =
         pubspec.readAsStringSync().replaceAllMapped(pathDepPattern, (match) {
       final relDepPath = match.group(1);
-      final relPubspecPath = p.relative(pubspec.path, from: d.sandbox);
-      final absPath = p.absolute(p.normalize(
-          p.join(templateDir.path, relPubspecPath, relDepPath, '..')));
+      final relPubspecPath = posix.relative(pubspec.path, from: d.sandbox);
+      final absPath = posix.absolute(posix.normalize(
+          posix.join(templateDir.path, relPubspecPath, relDepPath, '..')));
       return 'path: $absPath';
     });
     pubspec.writeAsStringSync(updated);


### PR DESCRIPTION
- Automatically use `dart analyze` instead of `dartanalyzer` when on Dart SDK v2.18 or higher (`dartanalyzer` was removed in this version).
- Automatically use `dart format` instead of `dartfmt` when on Dart SDK v2.15 or higher (`dartfmt` was removed in this version).