### PR TITLE
FEDX-13: Dart 2.18 lints & formatting

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -17,52 +17,32 @@ jobs:
       matrix:
         sdk: [ 2.13.4, 2.18.7, stable, beta ]
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
         with:
           sdk: ${{ matrix.sdk }}
-
-      - id: install
-        name: Install dependencies
-        run: dart pub get
-
-      - name: Validate dependencies
-        run: dart run dependency_validator
-        if: always() && steps.install.outcome == 'success'
-
-      - name: Analyze project source
-        run: dart run dart_dev analyze
-        if: always() && steps.install.outcome == 'success'
-
-      - name: Run tests
-        run: dart run dart_dev test
-        if: always() && steps.install.outcome == 'success'
+      - run: dart pub get
+      - run: dart run dependency_validator
+      - run: dart run dart_dev analyze
+      - run: dart run dart_dev test
 
   format_and_publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
         with:
-          sdk: 2.13.4
-
-      - id: install
-        name: Install dependencies
-        run: dart pub get
-
-      - name: Verify formatting
-        run: dart run dart_dev format --check
-        if: always() && steps.install.outcome == 'success'
-
-      - name: Publish dry run
-        run: dart pub publish --dry-run
-        if: always() && steps.install.outcome == 'success'
+          sdk: 2.18.7
+      - run: dart pub get
+      - run: dart run dart_dev format --check
+      # TODO: uncomment once https://github.com/dart-lang/sdk/issues/51398 is fixed
+      # - run: dart pub publish --dry-run
 
   windows:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.3
+      - uses: actions/checkout@v3
+      - uses: dart-lang/setup-dart@v1
         with:
           sdk: stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.9.3-dev
+
+- Fixes lints on Dart 2.18
+- Formatting changes on Dart 2.18
+- Replace deprecated pedantic package with lints package
+
 ## [3.9.2](https://github.com/Workiva/dart_dev/compare/3.9.1...3.9.2)
 
 - Automatically use `dart analyze` instead of `dartanalyzer` when on Dart SDK

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.8.0.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude:
@@ -12,6 +12,9 @@ analyzer:
 
 linter:
   rules:
-    - avoid_types_on_closure_parameters
-    - prefer_void_to_null
-    - void_checks
+    include:
+      - avoid_types_on_closure_parameters
+      - prefer_void_to_null
+      - void_checks
+    exclude:
+      - overridden_fields

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -5,7 +5,8 @@ Future<void> commandComplete(CommandResult result) async {
       _commandCompleteListeners.map((listener) => listener(result)));
 }
 
-void onCommandComplete(FutureOr<dynamic> callback(CommandResult result)) {
+void onCommandComplete(
+    FutureOr<dynamic> Function(CommandResult result) callback) {
   _commandCompleteListeners.add(callback);
 }
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -139,7 +139,9 @@ void main(List<String> args) async {
 }
 
 Future<void> runWithConfig(
-    List<String> args, _ConfigGetter configGetter) async {
+    // ignore: library_private_types_in_public_api
+    List<String> args,
+    _ConfigGetter configGetter) async {
   attachLoggerToStdio(args);
 
   try {

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -178,7 +178,7 @@ ProcessDeclaration buildProcess(
         context.argResults, context.usageException,
         commandName: context.commandName,
         usageFooter:
-            'Arguments can be passed to the "${analyzerUsed}" process via '
+            'Arguments can be passed to the "$analyzerUsed" process via '
             'the --analyzer-args option.');
   }
   var executable = useDartAnalyze ? exe.dart : exe.dartanalyzer;

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -60,6 +60,7 @@ mixin CompoundToolMixin on DevTool {
   String get description => _description ??= _specs
       .map((s) => s.tool.description)
       .firstWhere((desc) => desc != null, orElse: () => null);
+  @override
   set description(String value) => _description = value;
   String _description;
 

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -9,7 +9,6 @@ import 'package:io/io.dart' show ExitCode;
 import 'package:logging/logging.dart';
 import 'package:path/path.dart' as p;
 
-import '../../utils.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -178,7 +178,7 @@ class FormatTool extends DevTool {
     final dir = Directory(root ?? '.');
 
     // Use Glob.listSync to get all directories which might include a matching file.
-    var directoriesWithExcludes = Set<String>();
+    var directoriesWithExcludes = <String>{};
 
     if (collapseDirectories) {
       for (var g in exclude) {

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 
 import '../dart_dev_tool.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
+import 'package:pedantic/pedantic.dart';
 
 import '../dart_dev_tool.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -214,7 +214,7 @@ List<String> buildArgs({
     ...?configuredTestArgs,
     // 2. The --reporter option.
     if (argResults?.wasParsed('reporter') ?? false)
-      '--reporter=' + singleOptionValue(argResults, 'reporter'),
+      '--reporter=${singleOptionValue(argResults, 'reporter')}',
     // 3. The -n|--name, -N|--plain-name, and -P|--preset options
     ...?multiOptionValue(argResults, 'name')?.map((v) => '--name=$v'),
     ...?multiOptionValue(argResults, 'plain-name')

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -328,7 +328,9 @@ Iterable<String> buildFiltersForTestArgs(List<String> testArgs) {
   final filters = <String>[];
   for (final input in testInputs) {
     if (input.endsWith('.dart')) {
-      filters..add('$input.*_test.dart.js*')..add(dartExtToHtml(input));
+      filters
+        ..add('$input.*_test.dart.js*')
+        ..add(dartExtToHtml(input));
     } else {
       filters.add('$input**');
     }

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -61,6 +61,7 @@ class WebdevServeTool extends DevTool {
   // DevTool Overrides
   // ---------------------------------------------------------------------------
 
+  @override
   final ArgParser argParser = ArgParser()
     ..addFlag('release',
         abbr: 'r', help: 'Build with release mode defaults for builders.')
@@ -215,8 +216,8 @@ WebdevServeExecution buildExecution(
   if (!globalPackageIsActiveAndCompatible(
       'webdev', VersionConstraint.parse('^2.0.0'),
       environment: environment)) {
-    _log.severe(red.wrap(styleBold.wrap('webdev serve') +
-            ' could not run for this project.\n') +
+    _log.severe(red.wrap(
+            '${styleBold.wrap('webdev serve')} could not run for this project.\n') +
         yellow.wrap('You must have `webdev` globally activated:\n'
             '  dart pub global activate webdev ^2.0.0'));
     return WebdevServeExecution.exitEarly(ExitCode.config.code);

--- a/lib/src/utils/assert_no_positional_args_before_separator.dart
+++ b/lib/src/utils/assert_no_positional_args_before_separator.dart
@@ -5,7 +5,7 @@ import 'has_any_positional_args_before_separator.dart';
 void assertNoPositionalArgs(
   String name,
   ArgResults argResults,
-  void usageException(String message), {
+  void Function(String message) usageException, {
   bool beforeSeparator,
 }) {
   beforeSeparator ??= false;

--- a/lib/src/utils/logging.dart
+++ b/lib/src/utils/logging.dart
@@ -104,13 +104,9 @@ String humanReadable(Duration duration) {
 
 void logSubprocessHeader(Logger logger, String command, {Level level}) {
   level ??= Level.INFO;
-  logger.log(
-      level,
-      'Running subprocess:\n' +
-          magenta.wrap(command) +
-          '\n' +
-          '-' * (io.stdout.hasTerminal ? io.stdout.terminalColumns : 79) +
-          '\n');
+  final numColumns = io.stdout.hasTerminal ? io.stdout.terminalColumns : 79;
+  logger.log(level,
+      'Running subprocess:\n${magenta.wrap(command)}\n${'-' * numColumns}\n');
 }
 
 /// Logs an asynchronous [action] with [description] before and after.
@@ -119,7 +115,7 @@ void logSubprocessHeader(Logger logger, String command, {Level level}) {
 Future<T> logTimedAsync<T>(
   Logger logger,
   String description,
-  Future<T> action(), {
+  Future<T> Function() action, {
   Level level,
 }) async {
   level ??= Level.INFO;
@@ -138,7 +134,7 @@ Future<T> logTimedAsync<T>(
 T logTimedSync<T>(
   Logger logger,
   String description,
-  T action(), {
+  T Function() action, {
   Level level = Level.INFO,
 }) {
   final watch = Stopwatch()..start();

--- a/lib/src/utils/organize_directives/namespace_collector.dart
+++ b/lib/src/utils/organize_directives/namespace_collector.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/ast/visitor.dart';
 /// Imports and exports are returned in the order they appear in a file when
 /// passed to `CompilationUnit.accept`.
 class NamespaceCollector extends SimpleAstVisitor<List<NamespaceDirective>> {
-  List<NamespaceDirective> _namespaces = [];
+  final List<NamespaceDirective> _namespaces = [];
 
   @override
   List<NamespaceDirective> visitExportDirective(ExportDirective node) {

--- a/lib/src/utils/organize_directives/organize_directives.dart
+++ b/lib/src/utils/organize_directives/organize_directives.dart
@@ -180,7 +180,9 @@ String _getSortedNamespaceString(
           namespaceWithQuotesReplaced,
         )
         .substring(namespace.start(), namespace.end());
-    sortedReplacement..write(source)..write('\n');
+    sortedReplacement
+      ..write(source)
+      ..write('\n');
   }
   return sortedReplacement.toString();
 }

--- a/lib/src/utils/organize_directives/organize_directives_in_paths.dart
+++ b/lib/src/utils/organize_directives/organize_directives_in_paths.dart
@@ -16,7 +16,7 @@ int organizeDirectivesInPaths(
 
 /// Returns all file paths from a given set of files and directories.
 Iterable<String> _getAllFiles(Iterable<String> paths) {
-  final allFiles = Set<String>();
+  final allFiles = <String>{};
 
   for (final path in paths) {
     switch (FileSystemEntity.typeSync(path)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   glob: ^2.0.0
   io: '>=0.3.5 <2.0.0'
+  lints: ^1.0.1
   logging: ^1.0.0
   path: ^1.6.2
-  pedantic: ^1.7.0
   pub_semver: ^2.0.0
   pubspec_parse: '>=0.1.8 <2.0.0'
   stack_trace: ^1.9.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   build_runner: '>=1.0.0 <3.0.0'
   glob: ^2.0.0
   io: '>=0.3.5 <2.0.0'
-  lints: ^1.0.1
   logging: ^1.0.0
   path: ^1.6.2
   pub_semver: ^2.0.0
@@ -23,6 +22,7 @@ dependencies:
 
 dev_dependencies:
   dependency_validator: ^3.0.0
+  lints: ^1.0.1
   matcher: ^0.12.5
   test: ^1.15.7
   test_descriptor: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   io: '>=0.3.5 <2.0.0'
   logging: ^1.0.0
   path: ^1.6.2
+  pedantic: ^1.7.0
   pub_semver: ^2.0.0
   pubspec_parse: '>=0.1.8 <2.0.0'
   stack_trace: ^1.9.3

--- a/test/functional/format_tool_functional_test.dart
+++ b/test/functional/format_tool_functional_test.dart
@@ -9,7 +9,7 @@ import '../functional.dart';
 
 void main() {
   group('Format Tool', () {
-    Future<_SourceFile> _format(String projectPath) async {
+    Future<_SourceFile> format(String projectPath) async {
       const filePath = 'lib/main.dart';
 
       final process = await runDevToolFunctionalTest('format', projectPath);
@@ -23,7 +23,7 @@ void main() {
     test('organize directives off', () async {
       const projectPath =
           'test/functional/fixtures/format/unsorted_imports/organize_directives_off/';
-      final sourceFile = await _format(projectPath);
+      final sourceFile = await format(projectPath);
       expect(
         sourceFile.contentsBefore,
         equals(sourceFile.contentsAfter),
@@ -33,7 +33,7 @@ void main() {
     test('organize directives on', () async {
       const projectPath =
           'test/functional/fixtures/format/unsorted_imports/organize_directives_on/';
-      final sourceFile = await _format(projectPath);
+      final sourceFile = await format(projectPath);
       expect(
         sourceFile.contentsBefore,
         isNot(equals(sourceFile.contentsAfter)),

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -1,6 +1,4 @@
 @TestOn('vm')
-import 'dart:io';
-
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';

--- a/test/tools/compound_tool_test.dart
+++ b/test/tools/compound_tool_test.dart
@@ -45,7 +45,9 @@ void main() {
     });
 
     test('runs tools in order', () async {
-      final ct = CompoundTool()..addTool(tool())..addTool(tool());
+      final ct = CompoundTool()
+        ..addTool(tool())
+        ..addTool(tool());
       expect(await ct.run(), 0);
       expect(toolsRan, orderedEquals([0, 1]));
     });
@@ -73,7 +75,9 @@ void main() {
         return 0;
       }, argParser: ArgParser()..addFlag('bar'));
 
-      final ct = CompoundTool()..addTool(tool1)..addTool(tool2);
+      final ct = CompoundTool()
+        ..addTool(tool1)
+        ..addTool(tool2);
       await ct.run(DevToolExecutionContext(
           argResults: ct.argParser.parse(['--foo', '--bar', 'baz'])));
     });
@@ -130,7 +134,9 @@ void main() {
     test('parses all options', () {
       final parser1 = ArgParser()..addFlag('flag');
       final parser2 = ArgParser()..addOption('option');
-      final cap = CompoundArgParser()..addParser(parser1)..addParser(parser2);
+      final cap = CompoundArgParser()
+        ..addParser(parser1)
+        ..addParser(parser2);
       final args = ['--flag', '--option=foo', 'bar'];
       final argResults = cap.parse(args);
       expect(argResults['flag'], isTrue);
@@ -141,7 +147,9 @@ void main() {
     test('provides a combined usage output', () {
       final parser1 = ArgParser()..addFlag('flag');
       final parser2 = ArgParser()..addOption('option');
-      final cap = CompoundArgParser()..addParser(parser1)..addParser(parser2);
+      final cap = CompoundArgParser()
+        ..addParser(parser1)
+        ..addParser(parser2);
       expect(
           cap.usage, allOf(contains(parser1.usage), contains(parser2.usage)));
     });
@@ -178,7 +186,9 @@ void main() {
       final barParser = ArgParser()..addFlag('bar');
       final barTool = DevTool.fromFunction((_) => 0, argParser: barParser);
 
-      final compoundTool = CompoundTool()..addTool(fooTool)..addTool(barTool);
+      final compoundTool = CompoundTool()
+        ..addTool(fooTool)
+        ..addTool(barTool);
       final baseContext = DevToolExecutionContext(
           argResults: compoundTool.argParser.parse(['--foo', '--bar']));
 

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -525,40 +525,32 @@ void main() {
           argParser.parse(['--check', '--dry-run', '--overwrite']);
       expect(
           () => validateAndParseMode(argResults, usageException),
-          throwsA(isA<UsageException>()
-              .having((e) => e.message, 'command name', 'test_format')
-              .having((e) => e.message, 'usage footer',
-                  contains('--check and --dry-run and --overwrite'))));
+          throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
+              contains('--check and --dry-run and --overwrite'))));
     });
 
     test('--check and --dry-run throws UsageException', () {
       final argResults = argParser.parse(['--check', '--dry-run']);
       expect(
           () => validateAndParseMode(argResults, usageException),
-          throwsA(isA<UsageException>()
-              .having((e) => e.message, 'command name', 'test_format')
-              .having((e) => e.message, 'usage footer',
-                  contains('--check and --dry-run'))));
+          throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
+              contains('--check and --dry-run'))));
     });
 
     test('--check and --overwrite throws UsageException', () {
       final argResults = argParser.parse(['--check', '--overwrite']);
       expect(
           () => validateAndParseMode(argResults, usageException),
-          throwsA(isA<UsageException>()
-              .having((e) => e.message, 'command name', 'test_format')
-              .having((e) => e.message, 'usage footer',
-                  contains('--check and --overwrite'))));
+          throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
+              contains('--check and --overwrite'))));
     });
 
     test('--dry-run and --overwrite throws UsageException', () {
       final argResults = argParser.parse(['--dry-run', '--overwrite']);
       expect(
           () => validateAndParseMode(argResults, usageException),
-          throwsA(isA<UsageException>()
-              .having((e) => e.message, 'command name', 'test_format')
-              .having((e) => e.message, 'usage footer',
-                  contains('--dry-run and --overwrite'))));
+          throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
+              contains('--dry-run and --overwrite'))));
     });
 
     test('--check', () {

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -222,8 +222,9 @@ void main() {
       expect(
           () => buildExecution(context),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', contains('test_format'))
-            ..having((e) => e.message, 'usage', contains('--formatter-args'))));
+              .having((e) => e.message, 'command name', contains('test_format'))
+              .having(
+                  (e) => e.message, 'usage', contains('--formatter-args'))));
     });
 
     test('allows positional arguments when the command is hackFastFormat', () {
@@ -248,10 +249,10 @@ void main() {
       expect(
           () => buildExecution(context),
           throwsA(isA<UsageException>()
-            ..having(
-                (e) => e.message, 'command name', contains('hackFastFormat'))
-            ..having(
-                (e) => e.message, 'usage', contains('must specify targets'))));
+              .having(
+                  (e) => e.message, 'command name', contains('hackFastFormat'))
+              .having((e) => e.message, 'usage',
+                  contains('must specify targets'))));
     });
 
     test('throws UsageException if args are given after a separator', () {
@@ -261,8 +262,9 @@ void main() {
       expect(
           () => buildExecution(context),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', contains('test_format'))
-            ..having((e) => e.message, 'usage', contains('--formatter-args'))));
+              .having((e) => e.message, 'command name', contains('test_format'))
+              .having(
+                  (e) => e.message, 'usage', contains('--formatter-args'))));
     });
 
     test(
@@ -524,9 +526,9 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', 'test_format')
-            ..having((e) => e.message, 'usage footer',
-                contains('--check and --dry-run and --overwrite'))));
+              .having((e) => e.message, 'command name', 'test_format')
+              .having((e) => e.message, 'usage footer',
+                  contains('--check and --dry-run and --overwrite'))));
     });
 
     test('--check and --dry-run throws UsageException', () {
@@ -534,9 +536,9 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', 'test_format')
-            ..having((e) => e.message, 'usage footer',
-                contains('--check and --dry-run'))));
+              .having((e) => e.message, 'command name', 'test_format')
+              .having((e) => e.message, 'usage footer',
+                  contains('--check and --dry-run'))));
     });
 
     test('--check and --overwrite throws UsageException', () {
@@ -544,9 +546,9 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', 'test_format')
-            ..having((e) => e.message, 'usage footer',
-                contains('--check and --overwrite'))));
+              .having((e) => e.message, 'command name', 'test_format')
+              .having((e) => e.message, 'usage footer',
+                  contains('--check and --overwrite'))));
     });
 
     test('--dry-run and --overwrite throws UsageException', () {
@@ -554,9 +556,9 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', 'test_format')
-            ..having((e) => e.message, 'usage footer',
-                contains('--dry-run and --overwrite'))));
+              .having((e) => e.message, 'command name', 'test_format')
+              .having((e) => e.message, 'usage footer',
+                  contains('--dry-run and --overwrite'))));
     });
 
     test('--check', () {

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -1,11 +1,11 @@
 @TestOn('vm')
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/dart_dev.dart';
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import '../log_matchers.dart';

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -1,11 +1,11 @@
 @TestOn('vm')
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/dart_dev.dart';
 import 'package:logging/logging.dart';
+import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import '../log_matchers.dart';

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -1,6 +1,6 @@
+@TestOn('vm')
 import 'dart:convert';
 
-@TestOn('vm')
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/dart_dev.dart';

--- a/test/tools/shared_tool_tests.dart
+++ b/test/tools/shared_tool_tests.dart
@@ -1,7 +1,7 @@
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:test/test.dart';
 
-void sharedDevToolTests(DevTool factory()) {
+void sharedDevToolTests(DevTool Function() factory) {
   group('toCommand', () {
     test('should return a command with the given name', () {
       expect(factory().toCommand('custom_command').name, 'custom_command');

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -242,8 +242,8 @@ dev_dependencies:
       expect(
           () => buildExecution(context, path: d.sandbox),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'help', contains('--build-args'))
-            ..having((e) => e.message, 'help', contains('build_runner'))));
+              .having((e) => e.message, 'help', contains('--build-args'))
+              .having((e) => e.message, 'help', contains('build_runner'))));
     });
 
     test(
@@ -264,8 +264,8 @@ dev_dependencies:
       expect(
           () => buildExecution(context, path: d.sandbox),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'help', contains('--build-args'))
-            ..having((e) => e.message, 'help', contains('build_test'))));
+              .having((e) => e.message, 'help', contains('--build-args'))
+              .having((e) => e.message, 'help', contains('build_test'))));
     });
 
     test('returns config exit code and logs if test is not a direct dependency',

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -156,9 +156,9 @@ void main() {
       expect(
           () => buildExecution(context),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', contains('test_serve'))
-            ..having((e) => e.message, 'usage', contains('--webdev-args'))
-            ..having((e) => e.message, 'usage', contains('--build-args'))));
+              .having((e) => e.message, 'command name', contains('test_serve'))
+              .having((e) => e.message, 'usage', contains('--webdev-args'))
+              .having((e) => e.message, 'usage', contains('--build-args'))));
     });
 
     test('throws UsageException if args are given after a separator', () {
@@ -168,9 +168,9 @@ void main() {
       expect(
           () => buildExecution(context),
           throwsA(isA<UsageException>()
-            ..having((e) => e.message, 'command name', contains('test_serve'))
-            ..having((e) => e.message, 'usage', contains('--webdev-args'))
-            ..having((e) => e.message, 'usage', contains('--build-args'))));
+              .having((e) => e.message, 'command name', contains('test_serve'))
+              .having((e) => e.message, 'usage', contains('--webdev-args'))
+              .having((e) => e.message, 'usage', contains('--build-args'))));
     });
 
     test('returns config exit code and logs if webdev is not globally activate',

--- a/test/utils/format_tool_builder_test.dart
+++ b/test/utils/format_tool_builder_test.dart
@@ -12,7 +12,7 @@ void main() {
       test('when the tool is a MethodInvocation', () {
         final visitor = FormatToolBuilder();
 
-        parseString(content: orf_noCascadeSrc).unit.accept(visitor);
+        parseString(content: orfNoCascadeSrc).unit.accept(visitor);
 
         expect(visitor.formatDevTool, isNotNull);
         expect(visitor.formatDevTool, isA<OverReactFormatTool>());
@@ -22,7 +22,7 @@ void main() {
         test('detects line-length', () {
           final visitor = FormatToolBuilder();
 
-          parseString(content: orf_cascadeSrc).unit.accept(visitor);
+          parseString(content: orfCascadeSrc).unit.accept(visitor);
 
           expect(visitor.formatDevTool, isNotNull);
           expect(visitor.formatDevTool, isA<OverReactFormatTool>());
@@ -36,7 +36,7 @@ void main() {
       test('when the tool is a MethodInvocation', () {
         final visitor = FormatToolBuilder();
 
-        parseString(content: formatTool_noCascadeSrc).unit.accept(visitor);
+        parseString(content: formatToolNoCascadeSrc).unit.accept(visitor);
 
         expect(visitor.formatDevTool, isNotNull);
         expect(visitor.formatDevTool, isA<FormatTool>());
@@ -47,7 +47,7 @@ void main() {
           test('darfmt', () {
             final visitor = FormatToolBuilder();
 
-            parseString(content: formatTool_cascadeSrc()).unit.accept(visitor);
+            parseString(content: formatToolCascadeSrc()).unit.accept(visitor);
 
             expect(visitor.formatDevTool, isNotNull);
             expect(visitor.formatDevTool, isA<FormatTool>());
@@ -58,7 +58,7 @@ void main() {
           test('dartFormat', () {
             final visitor = FormatToolBuilder();
 
-            parseString(content: formatTool_cascadeSrc(formatter: 'dartFormat'))
+            parseString(content: formatToolCascadeSrc(formatter: 'dartFormat'))
                 .unit
                 .accept(visitor);
 
@@ -71,7 +71,7 @@ void main() {
           test('dartStyle', () {
             final visitor = FormatToolBuilder();
 
-            parseString(content: formatTool_cascadeSrc(formatter: 'dartStyle'))
+            parseString(content: formatToolCascadeSrc(formatter: 'dartStyle'))
                 .unit
                 .accept(visitor);
 
@@ -85,7 +85,7 @@ void main() {
         test('detects formatterArgs', () {
           final visitor = FormatToolBuilder();
 
-          parseString(content: formatTool_cascadeSrc()).unit.accept(visitor);
+          parseString(content: formatToolCascadeSrc()).unit.accept(visitor);
 
           expect(visitor.formatDevTool, isNotNull);
           expect(visitor.formatDevTool, isA<FormatTool>());
@@ -108,7 +108,7 @@ void main() {
   });
 }
 
-const orf_noCascadeSrc = '''import 'package:dart_dev/dart_dev.dart';
+const orfNoCascadeSrc = '''import 'package:dart_dev/dart_dev.dart';
 import 'package:glob/glob.dart';
 
 final config = {
@@ -117,7 +117,7 @@ final config = {
 };
 ''';
 
-const orf_cascadeSrc = '''import 'package:dart_dev/dart_dev.dart';
+const orfCascadeSrc = '''import 'package:dart_dev/dart_dev.dart';
 import 'package:glob/glob.dart';
 
 final config = {
@@ -127,7 +127,7 @@ final config = {
 };
 ''';
 
-const formatTool_noCascadeSrc = '''import 'package:dart_dev/dart_dev.dart';
+const formatToolNoCascadeSrc = '''import 'package:dart_dev/dart_dev.dart';
 import 'package:glob/glob.dart';
 
 final config = {
@@ -136,7 +136,7 @@ final config = {
 };
 ''';
 
-String formatTool_cascadeSrc({String formatter = 'dartfmt'}) =>
+String formatToolCascadeSrc({String formatter = 'dartfmt'}) =>
     '''import 'package:dart_dev/dart_dev.dart';
 import 'package:glob/glob.dart';
 


### PR DESCRIPTION
# [FEDX-13](https://jira.atl.workiva.net/browse/FEDX-13)
![Issue Status](https://h.inf-dev.workiva.org/s/wk-backend/jira/status/FEDX-13)

- Address new lints on 2.18
- Run formatter on 2.18
- Replace deprecated pedantic package with lints package
- Tweaks to CI