### PR TITLE
Migrate to null safety

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.13.4, 2.18.7, stable, beta ]
+        sdk: [ 2.14.4, 2.18.7, stable, beta ]
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7, stable, beta ]
+        sdk: [ 2.18.7, stable ]
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.14.4, 2.18.7, stable, beta ]
+        sdk: [ 2.18.7, stable, beta ]
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 3.9.3-dev
+## 4.0.0
 
+- Migrated to null safety. The new SDK minimum is 2.18
 - Fixes lints on Dart 2.18
 - Formatting changes on Dart 2.18
 - Replace deprecated pedantic package with lints package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.18.7
+FROM dart:2.18.7
 WORKDIR /build
 ADD pubspec.yaml /build
 RUN dart pub get

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/dart:2.13.4
+FROM google/dart:2.18.7
 WORKDIR /build
 ADD pubspec.yaml /build
 RUN dart pub get

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -46,7 +46,7 @@ class DartDevRunner extends CommandRunner<int> {
     final exitCode = (await super.run(args)) ?? 0;
     stopwatch.stop();
     await events.commandComplete(
-        events.CommandResult(args, exitCode, stopwatch.elapsed));
+        events.CommandResult(args as List<String>, exitCode, stopwatch.elapsed));
     return exitCode;
   }
 }

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -45,8 +45,8 @@ class DartDevRunner extends CommandRunner<int> {
     final stopwatch = Stopwatch()..start();
     final exitCode = (await super.run(args)) ?? 0;
     stopwatch.stop();
-    await events.commandComplete(
-        events.CommandResult(args as List<String>, exitCode, stopwatch.elapsed));
+    await events.commandComplete(events.CommandResult(
+        args as List<String>, exitCode, stopwatch.elapsed));
     return exitCode;
   }
 }

--- a/lib/src/dart_dev_tool.dart
+++ b/lib/src/dart_dev_tool.dart
@@ -12,12 +12,12 @@ abstract class DevTool {
   DevTool();
 
   factory DevTool.fromFunction(
-          FutureOr<int> Function(DevToolExecutionContext context) function,
-          {ArgParser argParser}) =>
+          FutureOr<int>? Function(DevToolExecutionContext context) function,
+          {ArgParser? argParser}) =>
       FunctionTool(function, argParser: argParser);
 
   factory DevTool.fromProcess(String executable, List<String> args,
-          {ProcessStartMode mode, String workingDirectory}) =>
+          {ProcessStartMode? mode, String? workingDirectory}) =>
       ProcessTool(executable, args,
           mode: mode, workingDirectory: workingDirectory);
 
@@ -26,11 +26,11 @@ abstract class DevTool {
   /// When this tool is run from the command-line, this will be used to parse
   /// the arguments. The results will be available via the
   /// [DevToolExecutionContext] provided when calling [run].
-  ArgParser get argParser => null;
+  ArgParser? get argParser => null;
 
   /// This tool's description (which is included in the help/usage output) can
   /// be overridden by setting this field to a non-null value.
-  String description;
+  String? description;
 
   /// This field determines whether or not this tool is hidden from the
   /// help/usage output when running as a part of a command-line app.
@@ -47,7 +47,7 @@ abstract class DevTool {
   /// will provide a fully-populated [DevToolExecutionContext] here.
   ///
   /// This is the one API member that subclasses need to implement.
-  FutureOr<int> run([DevToolExecutionContext context]);
+  FutureOr<int?> run([DevToolExecutionContext? context]);
 
   /// Converts this tool to a [Command] that can be added directly to a
   /// [CommandRunner], therefore making it executable from the command-line.
@@ -82,24 +82,24 @@ class DevToolExecutionContext {
   DevToolExecutionContext(
       {this.argResults,
       this.commandName,
-      void Function(String message) usageException,
-      bool verbose})
+      void Function(String message)? usageException,
+      bool? verbose})
       : _usageException = usageException,
         verbose = verbose ?? false;
 
-  final void Function(String message) _usageException;
+  final void Function(String message)? _usageException;
 
   /// The results from parsing the arguments passed to a [Command] if this tool
   /// was executed via a command-line app.
   ///
   /// This may be null.
-  final ArgResults argResults;
+  final ArgResults? argResults;
 
   /// The name of the [Command] that executed this tool if it was executed via a
   /// command-line app.
   ///
   /// This may be null.
-  final String commandName;
+  final String? commandName;
 
   /// Whether the `-v|--verbose` flag was enabled when running the [Command]
   /// that executed this tool if it was executed via a command-line app.
@@ -110,10 +110,10 @@ class DevToolExecutionContext {
   /// Return a copy of this instance with optional updates; any field that does
   /// not have an updated value will remain the same.
   DevToolExecutionContext update({
-    ArgResults argResults,
-    String commandName,
-    void Function(String message) usageException,
-    bool verbose,
+    ArgResults? argResults,
+    String? commandName,
+    void Function(String message)? usageException,
+    bool? verbose,
   }) =>
       DevToolExecutionContext(
         argResults: argResults ?? this.argResults,
@@ -127,7 +127,7 @@ class DevToolExecutionContext {
   /// print out usage information.
   void usageException(String message) {
     if (_usageException != null) {
-      _usageException(message);
+      _usageException!(message);
     }
     throw UsageException(message, '');
   }
@@ -145,7 +145,7 @@ class DevToolCommand extends Command<int> {
   final DevTool devTool;
 
   @override
-  bool get hidden => devTool.hidden ?? '';
+  bool get hidden => devTool.hidden;
 
   @override
   final String name;
@@ -155,5 +155,5 @@ class DevToolCommand extends Command<int> {
       argResults: argResults,
       commandName: name,
       usageException: usageException,
-      verbose: verboseEnabled(this)));
+      verbose: verboseEnabled(this))) as FutureOr<int>;
 }

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 Future<void> commandComplete(CommandResult result) async {
   await Future.wait(
-      _commandCompleteListeners.map((listener) => listener(result)));
+      _commandCompleteListeners.map((listener) => listener(result) as Future<void>));
 }
 
 void onCommandComplete(FutureOr<dynamic> callback(CommandResult result)) {

--- a/lib/src/events.dart
+++ b/lib/src/events.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 
 Future<void> commandComplete(CommandResult result) async {
-  await Future.wait(
-      _commandCompleteListeners.map((listener) => listener(result) as Future<void>));
+  await Future.wait(_commandCompleteListeners
+      .map((listener) => listener(result) as Future<void>));
 }
 
 void onCommandComplete(

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -61,7 +61,7 @@ Future<void> run(List<String> args) async {
 Future<void> handleFastFormat(List<String> args) async {
   assertDirIsDartPackage();
 
-  DevTool formatTool;
+  DevTool? formatTool;
   final configFile = File(paths.config);
   if (configFile.existsSync()) {
     final toolBuilder = FormatToolBuilder();
@@ -146,7 +146,8 @@ Future<void> runWithConfig(
     assertDirIsDartPackage();
   } on DirectoryIsNotPubPackage catch (error) {
     log.severe(error);
-    return ExitCode.usage.code;
+    exitCode = ExitCode.usage.code;
+    return;
   }
 
   Map<String, DevTool> config;
@@ -161,7 +162,8 @@ Future<void> runWithConfig(
       ..writeln('  $error')
       ..writeln()
       ..writeln('For more info: http://github.com/Workiva/dart_dev#TODO');
-    return ExitCode.config.code;
+    exitCode = ExitCode.config.code;
+    return;
   }
 
   try {
@@ -181,8 +183,8 @@ Future<void> runWithConfig(
 
 /// Returns [OverReactFormatTool] if `over_react_format` is a direct dependency,
 /// and the default [FormatTool] otherwise.
-DevTool chooseDefaultFormatTool({String path}) {
-  final pubspec = cachedPubspec(path: path);
+DevTool chooseDefaultFormatTool({String? path}) {
+  final pubspec = cachedPubspec(path: path)!;
   const orf = 'over_react_format';
   final hasOverReactFormat = pubspec.dependencies.containsKey(orf) ||
       pubspec.devDependencies.containsKey(orf) ||

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -47,17 +47,17 @@ class AnalyzeTool extends DevTool {
   /// The args to pass to the `dartanalyzer`  or `dart analyze` process run by this tool.
   ///
   /// Run `dartanalyzer -h -v` or `dart analyze -h -v` to see all available args.
-  List<String> analyzerArgs;
+  List<String>? analyzerArgs;
 
   /// The globs to include as entry points to run static analysis on.
   ///
   /// The default is `.` (e.g. `dartanalyzer .`) which runs analysis on all Dart
   /// files in the current working directory.
-  List<Glob> include;
+  List<Glob>? include;
 
   /// The default tool for analysis will be `dartanalyzer` unless opted in here
   /// to utilize `dart analyze`.
-  bool useDartAnalyze;
+  bool? useDartAnalyze;
 
   // ---------------------------------------------------------------------------
   // DevTool Overrides
@@ -70,10 +70,10 @@ class AnalyzeTool extends DevTool {
             'Run "dartanalyzer -h -v" or `dart analyze -h -v" to see all available options.');
 
   @override
-  String description = 'Run static analysis on dart files in this package.';
+  String? description = 'Run static analysis on dart files in this package.';
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) {
+  FutureOr<int> run([DevToolExecutionContext? context]) {
     useDartAnalyze ??= false;
     return runProcessAndEnsureExit(
         buildProcess(context ?? DevToolExecutionContext(),
@@ -95,10 +95,10 @@ class AnalyzeTool extends DevTool {
 /// If [verbose] is true and the verbose flag (`-v`) is not already included, it
 /// will be added.
 Iterable<String> buildArgs(
-    {ArgResults argResults,
-    List<String> configuredAnalyzerArgs,
-    bool useDartAnalyze,
-    bool verbose}) {
+    {ArgResults? argResults,
+    List<String>? configuredAnalyzerArgs,
+    bool? useDartAnalyze,
+    bool? verbose}) {
   useDartAnalyze ??= false;
   verbose ??= false;
   final args = <String>[
@@ -122,7 +122,7 @@ Iterable<String> buildArgs(
 ///
 /// By default these globs are assumed to be relative to the current working
 /// directory, but that can be overridden via [root] for testing purposes.
-Iterable<String> buildEntrypoints({List<Glob> include, String root}) {
+Iterable<String> buildEntrypoints({List<Glob>? include, String? root}) {
   include ??= <Glob>[];
   final entrypoints = <String>{
     for (final glob in include)
@@ -162,16 +162,16 @@ Iterable<String> buildEntrypoints({List<Glob> include, String root}) {
 /// on the declarative output.
 ProcessDeclaration buildProcess(
   DevToolExecutionContext context, {
-  List<String> configuredAnalyzerArgs,
-  List<Glob> include,
-  String path,
-  bool useDartAnalyze,
+  List<String>? configuredAnalyzerArgs,
+  List<Glob>? include,
+  String? path,
+  bool? useDartAnalyze,
 }) {
   useDartAnalyze ??= false;
   if (context.argResults != null) {
     final analyzerUsed = useDartAnalyze ? 'dart analyze' : 'dartanalyzer';
     assertNoPositionalArgsNorArgsAfterSeparator(
-        context.argResults, context.usageException,
+        context.argResults!, context.usageException,
         commandName: context.commandName,
         usageFooter:
             'Arguments can be passed to the "${analyzerUsed}" process via '
@@ -198,8 +198,8 @@ ProcessDeclaration buildProcess(
 void logCommand(
   Iterable<String> args,
   Iterable<String> entrypoints, {
-  bool useDartAnalyzer,
-  bool verbose,
+  bool? useDartAnalyzer,
+  bool? verbose,
 }) {
   useDartAnalyzer ??= false;
   verbose ??= false;

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -126,8 +126,6 @@ bool shouldRunTool(RunWhen runWhen, int? currentExitCode) {
       return true;
     case RunWhen.passing:
       return currentExitCode == 0;
-    default:
-      throw FallThroughError();
   }
 }
 

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -10,7 +10,7 @@ import '../utils/rest_args_with_separator.dart';
 
 final _log = Logger('CompoundTool');
 
-typedef ArgMapper = ArgResults Function(ArgParser parser, ArgResults results);
+typedef ArgMapper = ArgResults Function(ArgParser parser, ArgResults? results);
 
 /// Return a parsed [ArgResults] that only includes the option args (flags,
 /// single options, and multi options) supported by [parser].
@@ -42,8 +42,8 @@ ArgResults takeOptionArgs(ArgParser parser, ArgResults results) =>
 ///         // any positional args given to `ddev test`.
 ///         ..addTool(TestTool(), argMapper: takeAllArgs)
 ///     };
-ArgResults takeAllArgs(ArgParser parser, ArgResults results) => parser.parse([
-      ...optionArgsOnly(results, allowedOptions: parser.options.keys),
+ArgResults takeAllArgs(ArgParser parser, ArgResults? results) => parser.parse([
+      ...optionArgsOnly(results!, allowedOptions: parser.options.keys),
       ...restArgsWithSeparator(results),
     ]);
 
@@ -57,25 +57,25 @@ mixin CompoundToolMixin on DevTool {
   final _specs = <DevToolSpec>[];
 
   @override
-  String get description => _description ??= _specs
+  String? get description => _description ??= _specs
       .map((s) => s.tool.description)
       .firstWhere((desc) => desc != null, orElse: () => null);
-  set description(String value) => _description = value;
-  String _description;
+  set description(String? value) => _description = value;
+  String? _description;
 
-  void addTool(DevTool tool, {bool alwaysRun, ArgMapper argMapper}) {
+  void addTool(DevTool tool, {bool? alwaysRun, ArgMapper? argMapper}) {
     final runWhen = alwaysRun ?? false ? RunWhen.always : RunWhen.passing;
     _specs.add(DevToolSpec(runWhen, tool, argMapper: argMapper));
     if (tool.argParser != null) {
-      _argParser.addParser(tool.argParser);
+      _argParser.addParser(tool.argParser!);
     }
   }
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) async {
+  FutureOr<int?> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
 
-    int code = 0;
+    int? code = 0;
     for (var i = 0; i < _specs.length; i++) {
       if (!shouldRunTool(_specs[i].when, code)) continue;
       final newCode =
@@ -91,7 +91,7 @@ mixin CompoundToolMixin on DevTool {
 }
 
 List<String> optionArgsOnly(ArgResults results,
-    {Iterable<String> allowedOptions}) {
+    {Iterable<String>? allowedOptions}) {
   final args = <String>[];
   for (final option in results.options) {
     if (!results.wasParsed(option)) continue;
@@ -109,16 +109,16 @@ List<String> optionArgsOnly(ArgResults results,
 }
 
 DevToolExecutionContext contextForTool(
-    DevToolExecutionContext baseContext, DevToolSpec spec) {
+    DevToolExecutionContext baseContext, DevToolSpec? spec) {
   if (baseContext.argResults == null) return baseContext;
 
-  final parser = spec.tool.argParser ?? ArgParser();
-  final argMapper = spec.argMapper ?? takeOptionArgs;
+  final parser = spec!.tool.argParser ?? ArgParser();
+  final argMapper = spec.argMapper ?? takeOptionArgs as ArgResults Function(ArgParser, ArgResults?);
   return baseContext.update(
       argResults: argMapper(parser, baseContext.argResults));
 }
 
-bool shouldRunTool(RunWhen runWhen, int currentExitCode) {
+bool shouldRunTool(RunWhen runWhen, int? currentExitCode) {
   switch (runWhen) {
     case RunWhen.always:
       return true;
@@ -130,7 +130,7 @@ bool shouldRunTool(RunWhen runWhen, int currentExitCode) {
 }
 
 class DevToolSpec {
-  final ArgMapper argMapper;
+  final ArgMapper? argMapper;
 
   final DevTool tool;
 
@@ -156,8 +156,8 @@ class CompoundArgParser implements ArgParser {
             abbr: option.abbr,
             help: option.help,
             defaultsTo: option.defaultsTo,
-            negatable: option.negatable,
-            callback: option.callback,
+            negatable: option.negatable!,
+            callback: option.callback as void Function(bool)?,
             hide: option.hide);
       } else if (option.isMultiple) {
         _compoundParser.addMultiOption(option.name,
@@ -167,7 +167,7 @@ class CompoundArgParser implements ArgParser {
             allowed: option.allowed,
             allowedHelp: option.allowedHelp,
             defaultsTo: option.defaultsTo,
-            callback: option.callback,
+            callback: option.callback as void Function(List<String>)?,
             splitCommas: option.splitCommas,
             hide: option.hide);
       } else if (option.isSingle) {
@@ -178,7 +178,7 @@ class CompoundArgParser implements ArgParser {
             allowed: option.allowed,
             allowedHelp: option.allowedHelp,
             defaultsTo: option.defaultsTo,
-            callback: option.callback,
+            callback: option.callback as void Function(String?)?,
             hide: option.hide);
       }
     }
@@ -205,11 +205,11 @@ class CompoundArgParser implements ArgParser {
   defaultFor(String option) => _compoundParser.defaultFor(option);
 
   @override
-  Option findByAbbreviation(String abbr) =>
+  Option? findByAbbreviation(String abbr) =>
       _compoundParser.findByAbbreviation(abbr);
 
   @override
-  Option findByNameOrAlias(String name) =>
+  Option? findByNameOrAlias(String name) =>
       _compoundParser.findByNameOrAlias(name);
 
   @override
@@ -241,13 +241,13 @@ class CompoundArgParser implements ArgParser {
   }
 
   @override
-  int get usageLineLength {
+  int? get usageLineLength {
     if (_subParsers.isEmpty) return null;
-    int max;
+    int? max;
     for (final parser in _subParsers) {
       if (max != null &&
           parser.usageLineLength != null &&
-          parser.usageLineLength > max) {
+          parser.usageLineLength! > max) {
         max = parser.usageLineLength;
       }
     }
@@ -255,16 +255,16 @@ class CompoundArgParser implements ArgParser {
   }
 
   @override
-  ArgParser addCommand(String name, [ArgParser parser]) =>
+  ArgParser addCommand(String name, [ArgParser? parser]) =>
       _compoundParser.addCommand(name, parser);
 
   @override
   void addFlag(String name,
-          {String abbr,
-          String help,
-          bool defaultsTo = false,
+          {String? abbr,
+          String? help,
+          bool? defaultsTo = false,
           bool negatable = true,
-          void Function(bool value) callback,
+          void Function(bool value)? callback,
           bool hide = false,
           List<String> aliases = const []}) =>
       _compoundParser.addFlag(name,
@@ -278,13 +278,13 @@ class CompoundArgParser implements ArgParser {
 
   @override
   void addMultiOption(String name,
-          {String abbr,
-          String help,
-          String valueHelp,
-          Iterable<String> allowed,
-          Map<String, String> allowedHelp,
-          Iterable<String> defaultsTo,
-          void Function(List<String> values) callback,
+          {String? abbr,
+          String? help,
+          String? valueHelp,
+          Iterable<String>? allowed,
+          Map<String, String>? allowedHelp,
+          Iterable<String>? defaultsTo,
+          void Function(List<String> values)? callback,
           bool splitCommas = true,
           bool hide = false,
           List<String> aliases = const []}) =>
@@ -302,13 +302,13 @@ class CompoundArgParser implements ArgParser {
 
   @override
   void addOption(String name,
-          {String abbr,
-          String help,
-          String valueHelp,
-          Iterable<String> allowed,
-          Map<String, String> allowedHelp,
-          String defaultsTo,
-          Function callback,
+          {String? abbr,
+          String? help,
+          String? valueHelp,
+          Iterable<String>? allowed,
+          Map<String, String>? allowedHelp,
+          String? defaultsTo,
+          Function? callback,
           bool mandatory = false,
           bool hide = false,
           List<String> aliases = const []}) =>
@@ -319,7 +319,7 @@ class CompoundArgParser implements ArgParser {
           allowed: allowed,
           allowedHelp: allowedHelp,
           defaultsTo: defaultsTo,
-          callback: callback,
+          callback: callback as void Function(String?)?,
           mandatory: mandatory,
           hide: hide,
           aliases: aliases);

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -115,8 +115,7 @@ DevToolExecutionContext contextForTool(
   if (baseContext.argResults == null) return baseContext;
 
   final parser = spec!.tool.argParser ?? ArgParser();
-  final argMapper = spec.argMapper ??
-      takeOptionArgs;
+  final argMapper = spec.argMapper ?? takeOptionArgs;
   return baseContext.update(
       argResults: argMapper(parser, baseContext.argResults!));
 }

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -42,8 +42,8 @@ ArgResults takeOptionArgs(ArgParser parser, ArgResults results) =>
 ///         // any positional args given to `ddev test`.
 ///         ..addTool(TestTool(), argMapper: takeAllArgs)
 ///     };
-ArgResults takeAllArgs(ArgParser parser, ArgResults? results) => parser.parse([
-      ...optionArgsOnly(results!, allowedOptions: parser.options.keys),
+ArgResults takeAllArgs(ArgParser parser, ArgResults results) => parser.parse([
+      ...optionArgsOnly(results, allowedOptions: parser.options.keys),
       ...restArgsWithSeparator(results),
     ]);
 

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -115,9 +115,10 @@ DevToolExecutionContext contextForTool(
   if (baseContext.argResults == null) return baseContext;
 
   final parser = spec!.tool.argParser ?? ArgParser();
-  final argMapper = spec.argMapper ?? takeOptionArgs as ArgResults Function(ArgParser, ArgResults?);
+  final argMapper = spec.argMapper ??
+      takeOptionArgs;
   return baseContext.update(
-      argResults: argMapper(parser, baseContext.argResults));
+      argResults: argMapper(parser, baseContext.argResults!));
 }
 
 bool shouldRunTool(RunWhen runWhen, int? currentExitCode) {

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -59,18 +59,18 @@ class FormatTool extends DevTool {
   /// The globs to exclude from the inputs to the dart formatter.
   ///
   /// By default, nothing is excluded.
-  List<Glob> exclude;
+  List<Glob>? exclude;
 
   /// The formatter to run, one of:
   /// - `dartfmt` (provided by the SDK)
   /// - `dart run dart_style:format` (provided by the `dart_style` package)
   /// - `dart format` (added in Dart SDK 2.10.0)
-  Formatter formatter = Formatter.dartfmt;
+  Formatter? formatter = Formatter.dartfmt;
 
   /// The args to pass to the formatter process run by this command.
   ///
   /// Run `dartfmt -h -v` or `dart format -h -v` to see all available args.
-  List<String> formatterArgs;
+  List<String?>? formatterArgs;
 
   /// If the formatter should also organize imports and exports.
   ///
@@ -103,10 +103,10 @@ class FormatTool extends DevTool {
             'Run "dartfmt -h -v" or "dart format -h -v" to see all available options.');
 
   @override
-  String description = 'Format dart files in this package.';
+  String? description = 'Format dart files in this package.';
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) async {
+  FutureOr<int?> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     final formatExecution = buildExecution(
       context,
@@ -120,7 +120,7 @@ class FormatTool extends DevTool {
       return formatExecution.exitCode;
     }
     var exitCode = await runProcessAndEnsureExit(
-      formatExecution.formatProcess,
+      formatExecution.formatProcess!,
       log: _log,
     );
     if (exitCode != 0) {
@@ -128,8 +128,8 @@ class FormatTool extends DevTool {
     }
     if (formatExecution.directiveOrganization != null) {
       exitCode = organizeDirectivesInPaths(
-        formatExecution.directiveOrganization.inputs,
-        check: formatExecution.directiveOrganization.check,
+        formatExecution.directiveOrganization!.inputs,
+        check: formatExecution.directiveOrganization!.check,
         verbose: context.verbose,
       );
     }
@@ -151,11 +151,11 @@ class FormatTool extends DevTool {
   /// If collapseDirectories is true, directories that contain no exclusions will wind up in the [FormatterInputs],
   /// rather than each file in that tree.  You may get unexpected results if this and followLinks are both true.
   static FormatterInputs getInputs({
-    List<Glob> exclude,
-    bool expandCwd,
-    bool followLinks,
-    String root,
-    bool collapseDirectories,
+    List<Glob>? exclude,
+    bool? expandCwd,
+    bool? followLinks,
+    String? root,
+    bool? collapseDirectories,
   }) {
     expandCwd ??= false;
     followLinks ??= false;
@@ -179,7 +179,7 @@ class FormatTool extends DevTool {
 
     if (collapseDirectories) {
       for (var g in exclude) {
-        List<FileSystemEntity> matchingPaths;
+        List<FileSystemEntity>? matchingPaths;
         try {
           matchingPaths = g.listSync(followLinks: followLinks);
         } on FileSystemException catch (_) {
@@ -235,7 +235,7 @@ class FormatTool extends DevTool {
 
       // If the path is in a subdirectory starting with ".", ignore it.
       final parts = p.split(relative);
-      int hiddenIndex;
+      int? hiddenIndex;
       for (var i = 0; i < parts.length; i++) {
         if (parts[i].startsWith(".")) {
           hiddenIndex = i;
@@ -297,13 +297,13 @@ class FormatterInputs {
   FormatterInputs(this.includedFiles,
       {this.excludedFiles, this.hiddenDirectories, this.skippedLinks});
 
-  final Set<String> excludedFiles;
+  final Set<String>? excludedFiles;
 
-  final Set<String> hiddenDirectories;
+  final Set<String>? hiddenDirectories;
 
   final Set<String> includedFiles;
 
-  final Set<String> skippedLinks;
+  final Set<String>? skippedLinks;
 }
 
 /// A declarative representation of an execution of the [FormatTool].
@@ -325,23 +325,23 @@ class FormatExecution {
   /// exit with this code.
   ///
   /// If null, there is more work to do.
-  final int exitCode;
+  final int? exitCode;
 
   /// A declarative representation of the formatter process that should be run.
   ///
   /// If this process results in a non-zero exit code, [FormatTool] should return it.
-  final ProcessDeclaration formatProcess;
+  final ProcessDeclaration? formatProcess;
 
   /// A declarative representation of the directive organization work to be done
   /// (if enabled) after running the formatter.
-  final DirectiveOrganization directiveOrganization;
+  final DirectiveOrganization? directiveOrganization;
 }
 
 /// A declarative representation of the directive organization work.
 class DirectiveOrganization {
   DirectiveOrganization(this.inputs, {this.check});
 
-  final bool check;
+  final bool? check;
   final Set<String> inputs;
 }
 
@@ -381,13 +381,13 @@ enum Formatter {
 ///
 /// Finally, if [verbose] is true and the verbose flag (`-v`) is not already
 /// included, it will be added.
-Iterable<String> buildArgs(
-  Iterable<String> executableArgs,
-  FormatMode mode, {
-  ArgResults argResults,
-  List<String> configuredFormatterArgs,
+Iterable<String?> buildArgs(
+  Iterable<String?> executableArgs,
+  FormatMode? mode, {
+  ArgResults? argResults,
+  List<String?>? configuredFormatterArgs,
 }) {
-  final args = <String>[
+  final args = <String?>[
     ...executableArgs,
 
     // Combine all args that should be passed through to the dartfmt in this
@@ -424,10 +424,10 @@ Iterable<String> buildArgs(
 ///
 /// Finally, if [verbose] is true and the verbose flag (`-v`) is not already
 /// included, it will be added.
-Iterable<String> buildArgsForDartFormat(
-    Iterable<String> executableArgs, FormatMode mode,
-    {ArgResults argResults, List<String> configuredFormatterArgs}) {
-  final args = <String>[
+Iterable<String?> buildArgsForDartFormat(
+    Iterable<String?> executableArgs, FormatMode? mode,
+    {ArgResults? argResults, List<String?>? configuredFormatterArgs}) {
+  final args = <String?>[
     ...executableArgs,
 
     // Combine all args that should be passed through to the dart format in this
@@ -474,38 +474,38 @@ Iterable<String> buildArgsForDartFormat(
 /// on the declarative output.
 FormatExecution buildExecution(
   DevToolExecutionContext context, {
-  List<String> configuredFormatterArgs,
-  FormatMode defaultMode,
-  List<Glob> exclude,
-  Formatter formatter,
+  List<String?>? configuredFormatterArgs,
+  FormatMode? defaultMode,
+  List<Glob>? exclude,
+  Formatter? formatter,
   bool organizeDirectives = false,
-  String path,
+  String? path,
 }) {
-  FormatMode mode;
+  FormatMode? mode;
 
-  final useRestForInputs = (context?.argResults?.rest?.isNotEmpty ?? false) &&
+  final useRestForInputs = (context.argResults?.rest.isNotEmpty ?? false) &&
       context.commandName == 'hackFastFormat';
 
   if (context.argResults != null) {
     assertNoPositionalArgsNorArgsAfterSeparator(
-        context.argResults, context.usageException,
+        context.argResults!, context.usageException,
         allowRest: useRestForInputs,
         commandName: context.commandName,
         usageFooter:
             'Arguments can be passed to the "dartfmt" or "dart format" process via the '
             '--formatter-args option.');
-    mode = validateAndParseMode(context.argResults, context.usageException);
+    mode = validateAndParseMode(context.argResults!, context.usageException);
   }
   mode ??= defaultMode;
 
   if (formatter == Formatter.dartStyle &&
       !packageIsImmediateDependency('dart_style', path: path)) {
-    _log.severe(red.wrap('Cannot run "dart_style:format".\n') +
+    _log.severe(red.wrap('Cannot run "dart_style:format".\n')! +
         yellow.wrap('You must either have a dependency on "dart_style" in '
             'pubspec.yaml or configure the format tool to use "dartfmt" '
             'instead.\n'
             'Either add "dart_style" to your pubspec.yaml or configure the '
-            'format tool to use "dartfmt" instead.'));
+            'format tool to use "dartfmt" instead.')!);
     return FormatExecution.exitEarly(ExitCode.config.code);
   }
 
@@ -517,7 +517,7 @@ FormatExecution buildExecution(
   }
 
   final inputs = useRestForInputs
-      ? FormatterInputs({...context.argResults.rest})
+      ? FormatterInputs({...context.argResults!.rest})
       : FormatTool.getInputs(
           exclude: exclude,
           root: path,
@@ -533,21 +533,21 @@ FormatExecution buildExecution(
 
   if (inputs.excludedFiles?.isNotEmpty ?? false) {
     _log.fine('Excluding these paths from formatting:\n  '
-        '${inputs.excludedFiles.join('\n  ')}');
+        '${inputs.excludedFiles!.join('\n  ')}');
   }
 
   if (inputs.skippedLinks?.isNotEmpty ?? false) {
     _log.fine('Excluding these links from formatting:\n  '
-        '${inputs.skippedLinks.join('\n  ')}');
+        '${inputs.skippedLinks!.join('\n  ')}');
   }
 
   if (inputs.hiddenDirectories?.isNotEmpty ?? false) {
     _log.fine('Excluding these hidden directories from formatting:\n  '
-        '${inputs.hiddenDirectories.join('\n  ')}');
+        '${inputs.hiddenDirectories!.join('\n  ')}');
   }
 
   final dartFormatter = buildFormatProcess(formatter);
-  Iterable<String> args;
+  Iterable<String?> args;
   if (formatter == Formatter.dartFormat) {
     args = buildArgsForDartFormat(dartFormatter.args, mode,
         argResults: context.argResults,
@@ -565,7 +565,7 @@ FormatExecution buildExecution(
     [...args, ...inputs.includedFiles],
     mode: ProcessStartMode.inheritStdio,
   );
-  DirectiveOrganization directiveOrganization;
+  DirectiveOrganization? directiveOrganization;
   if (organizeDirectives) {
     directiveOrganization = DirectiveOrganization(
       inputs.includedFiles,
@@ -584,7 +584,7 @@ FormatExecution buildExecution(
 /// - [Formatter.dartfmt] -> `dartfmt`
 /// - [Formatter.dartFormat] -> `dart format`
 /// - [Formatter.dartStyle] -> `dart run dart_style:format`
-ProcessDeclaration buildFormatProcess([Formatter formatter]) {
+ProcessDeclaration buildFormatProcess([Formatter? formatter]) {
   switch (formatter) {
     case Formatter.dartStyle:
       return ProcessDeclaration(exe.dart, ['run', 'dart_style:format']);
@@ -602,8 +602,8 @@ ProcessDeclaration buildFormatProcess([Formatter formatter]) {
 /// Unless [verbose] is true, the list of inputs will be abbreviated to avoid an
 /// unnecessarily long log.
 void logCommand(
-    String executable, Iterable<String> inputs, Iterable<String> args,
-    {bool verbose}) {
+    String executable, Iterable<String> inputs, Iterable<String?> args,
+    {bool? verbose}) {
   verbose ??= false;
   final exeAndArgs = '$executable ${args.join(' ')}'.trim();
   if (inputs.length <= 5 || verbose) {
@@ -621,7 +621,7 @@ void logCommand(
 /// will be called with a message explaining that only one mode can be used.
 ///
 /// If none of the mode flags were enabled, this returns `null`.
-FormatMode validateAndParseMode(
+FormatMode? validateAndParseMode(
     ArgResults argResults, void Function(String message) usageException) {
   final check = argResults['check'] ?? false;
   final dryRun = argResults['dry-run'] ?? false;

--- a/lib/src/tools/function_tool.dart
+++ b/lib/src/tools/function_tool.dart
@@ -12,32 +12,32 @@ import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
 ///
 /// Use [DevTool.fromFunction] to create [FunctionTool] instances.
 class FunctionTool extends DevTool {
-  FunctionTool(FutureOr<int> Function(DevToolExecutionContext context) function,
-      {ArgParser argParser})
+  FunctionTool(FutureOr<int>? Function(DevToolExecutionContext context) function,
+      {ArgParser? argParser})
       : _argParser = argParser,
         _function = function;
 
-  final FutureOr<int> Function(DevToolExecutionContext context) _function;
+  final FutureOr<int>? Function(DevToolExecutionContext context) _function;
 
   // ---------------------------------------------------------------------------
   // DevTool Overrides
   // ---------------------------------------------------------------------------
 
   @override
-  ArgParser get argParser => _argParser;
-  final ArgParser _argParser;
+  ArgParser? get argParser => _argParser;
+  final ArgParser? _argParser;
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     if (context.argResults != null) {
       if (argParser == null) {
         assertNoPositionalArgsNorArgsAfterSeparator(
-            context.argResults, context.usageException,
+            context.argResults!, context.usageException,
             commandName: context.commandName);
       }
     }
-    final exitCode = await _function(context);
+    final exitCode = await _function(context)!;
     if (exitCode != null) {
       return exitCode;
     }

--- a/lib/src/tools/function_tool.dart
+++ b/lib/src/tools/function_tool.dart
@@ -12,7 +12,8 @@ import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
 ///
 /// Use [DevTool.fromFunction] to create [FunctionTool] instances.
 class FunctionTool extends DevTool {
-  FunctionTool(FutureOr<int>? Function(DevToolExecutionContext context) function,
+  FunctionTool(
+      FutureOr<int>? Function(DevToolExecutionContext context) function,
       {ArgParser? argParser})
       : _argParser = argParser,
         _function = function;
@@ -37,7 +38,7 @@ class FunctionTool extends DevTool {
             commandName: context.commandName);
       }
     }
-    final exitCode = await _function(context)!;
+    final exitCode = await _function(context);
     if (exitCode != null) {
       return exitCode;
     }

--- a/lib/src/tools/over_react_format_tool.dart
+++ b/lib/src/tools/over_react_format_tool.dart
@@ -11,16 +11,16 @@ class OverReactFormatTool extends DevTool {
   /// Wrap lines longer than this.
   ///
   /// Default is 80.
-  int lineLength;
+  int? lineLength;
 
   @override
-  String description =
+  String? description =
       'Format dart files in this package with over_react_format.';
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) async {
-    Iterable<String> paths = context?.argResults?.rest;
-    if (paths?.isEmpty ?? true) {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
+    Iterable<String> paths = context?.argResults?.rest ?? [];
+    if (paths.isEmpty) {
       context?.usageException(
           '"hackFastFormat" must specify targets to format.\n'
           'hackFastFormat should only be used to format specific files. '

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 
 import '../dart_dev_tool.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -29,7 +29,7 @@ final _log = Logger('Process');
 ///     ProcessTool(exe, args).run();
 class ProcessTool extends DevTool {
   ProcessTool(String executable, List<String> args,
-      {ProcessStartMode mode, String workingDirectory})
+      {ProcessStartMode? mode, String? workingDirectory})
       : _args = args,
         _executable = executable,
         _mode = mode,
@@ -37,18 +37,18 @@ class ProcessTool extends DevTool {
 
   final List<String> _args;
   final String _executable;
-  final ProcessStartMode _mode;
-  final String _workingDirectory;
+  final ProcessStartMode? _mode;
+  final String? _workingDirectory;
 
-  Process get process => _process;
-  Process _process;
+  Process? get process => _process;
+  Process? _process;
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     if (context.argResults != null) {
       assertNoPositionalArgsNorArgsAfterSeparator(
-          context.argResults, context.usageException,
+          context.argResults!, context.usageException,
           commandName: context.commandName);
     }
     logSubprocessHeader(_log, '$_executable ${_args.join(' ')}');
@@ -56,29 +56,29 @@ class ProcessTool extends DevTool {
         ProcessDeclaration(_executable, _args,
             mode: _mode, workingDirectory: _workingDirectory),
         log: _log);
-    return _process.exitCode;
+    return _process!.exitCode;
   }
 }
 
 class BackgroundProcessTool {
   final List<String> _args;
   final String _executable;
-  final ProcessStartMode _mode;
-  final Duration _delayAfterStart;
-  final String _workingDirectory;
+  final ProcessStartMode? _mode;
+  final Duration? _delayAfterStart;
+  final String? _workingDirectory;
 
   BackgroundProcessTool(String executable, List<String> args,
-      {ProcessStartMode mode,
-      Duration delayAfterStart,
-      String workingDirectory})
+      {ProcessStartMode? mode,
+      Duration? delayAfterStart,
+      String? workingDirectory})
       : _args = args,
         _executable = executable,
         _mode = mode,
         _delayAfterStart = delayAfterStart,
         _workingDirectory = workingDirectory;
 
-  Process get process => _process;
-  Process _process;
+  Process? get process => _process;
+  Process? _process;
 
   DevTool get starter => DevTool.fromFunction(_start);
 
@@ -89,7 +89,7 @@ class BackgroundProcessTool {
   Future<int> _start(DevToolExecutionContext context) async {
     if (context.argResults != null) {
       assertNoPositionalArgsNorArgsAfterSeparator(
-          context.argResults, context.usageException,
+          context.argResults!, context.usageException,
           commandName: context.commandName);
     }
     logSubprocessHeader(_log, '$_executable ${_args.join(' ')}');
@@ -100,17 +100,17 @@ class BackgroundProcessTool {
             : ProcessStartMode.normal);
     _process = await Process.start(_executable, _args,
         mode: mode, workingDirectory: _workingDirectory);
-    ensureProcessExit(_process);
-    unawaited(_process.exitCode.then((_) => _processHasExited = true));
+    ensureProcessExit(_process!);
+    unawaited(_process!.exitCode.then((_) => _processHasExited = true));
 
     if (_delayAfterStart != null) {
-      await Future<void>.delayed(_delayAfterStart);
+      await Future<void>.delayed(_delayAfterStart!);
     }
 
     if (_processHasExited) {
       // If the background process exits immediately or before the start delay,
       // something is probably wrong, so return that exit code.
-      return _process.exitCode;
+      return _process!.exitCode;
     }
 
     return ExitCode.success.code;
@@ -119,12 +119,12 @@ class BackgroundProcessTool {
   Future<int> _stop(DevToolExecutionContext context) async {
     if (context.argResults != null) {
       assertNoPositionalArgsNorArgsAfterSeparator(
-          context.argResults, context.usageException,
+          context.argResults!, context.usageException,
           commandName: context.commandName);
     }
     _log.info('Stopping: $_executable ${_args.join(' ')}');
     _process?.kill();
-    await _process.exitCode;
+    await _process!.exitCode;
     return ExitCode.success.code;
   }
 }

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -97,10 +97,10 @@ class TestTool extends DevTool {
   /// run by this command when the current project depends on `build_test`.
   ///
   /// Run `dart run build_runner test -h` to see all available args.
-  List<String> buildArgs;
+  List<String>? buildArgs;
 
   @override
-  String description = 'Run dart tests in this package.';
+  String? description = 'Run dart tests in this package.';
 
   /// The args to pass to the `dart test` process (either directly or
   /// through the `dart run build_runner test` process if applicable).
@@ -112,15 +112,15 @@ class TestTool extends DevTool {
   /// configuring this field, it is preferred that the project be configured via
   /// `dart_test.yaml` so that the configuration is used even when running tests
   /// through some means other than `ddev`.
-  List<String> testArgs;
+  List<String>? testArgs;
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) {
+  FutureOr<int> run([DevToolExecutionContext? context]) {
     context ??= DevToolExecutionContext();
     final execution = buildExecution(context,
         configuredBuildArgs: buildArgs, configuredTestArgs: testArgs);
-    return execution.exitCode ??
-        runProcessAndEnsureExit(execution.process, log: _log);
+    return (execution.exitCode ??
+        runProcessAndEnsureExit(execution.process!, log: _log)) as FutureOr<int>;
   }
 
   @override
@@ -151,12 +151,12 @@ class TestExecution {
   /// exit with this code.
   ///
   /// If null, there is more work to do.
-  final int exitCode;
+  final int? exitCode;
 
   /// A declarative representation of the test process that should be run.
   ///
   /// This process' result should become the final result of the [TestTool].
-  final ProcessDeclaration process;
+  final ProcessDeclaration? process;
 }
 
 /// Builds and returns the full list of args for the test process that
@@ -183,11 +183,11 @@ class TestExecution {
 /// If [verbose] is true, both the build args and the test args portions of the
 /// returned list will include the `-v` verbose flag.
 List<String> buildArgs({
-  ArgResults argResults,
-  List<String> configuredBuildArgs,
-  List<String> configuredTestArgs,
-  bool useBuildRunner,
-  bool verbose,
+  ArgResults? argResults,
+  List<String>? configuredBuildArgs,
+  List<String>? configuredTestArgs,
+  bool? useBuildRunner,
+  bool? verbose,
 }) {
   useBuildRunner ??= false;
   verbose ??= false;
@@ -214,7 +214,7 @@ List<String> buildArgs({
     ...?configuredTestArgs,
     // 2. The --reporter option.
     if (argResults?.wasParsed('reporter') ?? false)
-      '--reporter=' + singleOptionValue(argResults, 'reporter'),
+      '--reporter=' + singleOptionValue(argResults, 'reporter')!,
     // 3. The -n|--name, -N|--plain-name, and -P|--preset options
     ...?multiOptionValue(argResults, 'name')?.map((v) => '--name=$v'),
     ...?multiOptionValue(argResults, 'plain-name')
@@ -269,9 +269,9 @@ List<String> buildArgs({
 /// on the declarative output.
 TestExecution buildExecution(
   DevToolExecutionContext context, {
-  List<String> configuredBuildArgs,
-  List<String> configuredTestArgs,
-  String path,
+  List<String>? configuredBuildArgs,
+  List<String>? configuredTestArgs,
+  String? path,
 }) {
   final hasBuildRunner =
       packageIsImmediateDependency('build_runner', path: path);
@@ -279,7 +279,7 @@ TestExecution buildExecution(
   final useBuildRunner = hasBuildRunner && hasBuildTest;
   if (!useBuildRunner &&
       context.argResults != null &&
-      context.argResults['build-args'] != null) {
+      context.argResults!['build-args'] != null) {
     context.usageException('Can only use --build-args in a project that has a '
         'direct dependency on both "build_runner" and "build_test" in the '
         'pubspec.yaml.');
@@ -292,8 +292,8 @@ TestExecution buildExecution(
   }
 
   if (!packageIsImmediateDependency('test', path: path)) {
-    _log.severe(red.wrap('Cannot run tests.\n') +
-        yellow.wrap('You must have a dependency on "test" in pubspec.yaml.\n'));
+    _log.severe(red.wrap('Cannot run tests.\n')! +
+        yellow.wrap('You must have a dependency on "test" in pubspec.yaml.\n')!);
     return TestExecution.exitEarly(ExitCode.config.code);
   }
 
@@ -323,7 +323,7 @@ TestExecution buildExecution(
 // Additionally, consumers need to depend on build_web_compilers AND build_vm_compilers
 // We should add some guard-rails (don't use filters if either of those deps are
 // missing, and ensure adequate version of build_runner).
-Iterable<String> buildFiltersForTestArgs(List<String> testArgs) {
+Iterable<String> buildFiltersForTestArgs(List<String>? testArgs) {
   final testInputs = (testArgs ?? []).where((arg) => arg.startsWith('test'));
   final filters = <String>[];
   for (final input in testInputs) {

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -120,7 +120,8 @@ class TestTool extends DevTool {
     final execution = buildExecution(context,
         configuredBuildArgs: buildArgs, configuredTestArgs: testArgs);
     return (execution.exitCode ??
-        runProcessAndEnsureExit(execution.process!, log: _log)) as FutureOr<int>;
+            runProcessAndEnsureExit(execution.process!, log: _log))
+        as FutureOr<int>;
   }
 
   @override
@@ -293,7 +294,8 @@ TestExecution buildExecution(
 
   if (!packageIsImmediateDependency('test', path: path)) {
     _log.severe(red.wrap('Cannot run tests.\n')! +
-        yellow.wrap('You must have a dependency on "test" in pubspec.yaml.\n')!);
+        yellow
+            .wrap('You must have a dependency on "test" in pubspec.yaml.\n')!);
     return TestExecution.exitEarly(ExitCode.config.code);
   }
 

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -62,7 +62,8 @@ class TuneupCheckTool extends DevTool {
     final execution = buildExecution(context ?? DevToolExecutionContext(),
         configuredIgnoreInfos: ignoreInfos);
     return (execution.exitCode ??
-        runProcessAndEnsureExit(execution.process!, log: _log)) as FutureOr<int>;
+            runProcessAndEnsureExit(execution.process!, log: _log))
+        as FutureOr<int>;
   }
 }
 
@@ -142,8 +143,8 @@ TuneupExecution buildExecution(
 
   if (!packageIsImmediateDependency('tuneup', path: path)) {
     _log.severe(red.wrap('Cannot run "tuneup check".\n')! +
-        yellow
-            .wrap('You must have a dependency on "tuneup" in pubspec.yaml.\n')!);
+        yellow.wrap(
+            'You must have a dependency on "tuneup" in pubspec.yaml.\n')!);
     return TuneupExecution.exitEarly(ExitCode.config.code);
   }
 
@@ -152,6 +153,7 @@ TuneupExecution buildExecution(
       configuredIgnoreInfos: configuredIgnoreInfos,
       verbose: context.verbose);
   logSubprocessHeader(_log, 'dart ${args.join(' ')}');
-  return TuneupExecution.process(
-      ProcessDeclaration(exe.dart, args as List<String?>, mode: ProcessStartMode.inheritStdio));
+  return TuneupExecution.process(ProcessDeclaration(
+      exe.dart, args as List<String?>,
+      mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -43,7 +43,7 @@ final _log = Logger('TuneupCheck');
 ///     TuneupCheckTool().run();
 class TuneupCheckTool extends DevTool {
   /// Whether `--ignore-infos` should be passed to `tuneup check`.
-  bool ignoreInfos;
+  bool? ignoreInfos;
 
   // ---------------------------------------------------------------------------
   // DevTool Overrides
@@ -54,15 +54,15 @@ class TuneupCheckTool extends DevTool {
     ..addFlag('ignore-infos', help: 'Ignore any info level issues.');
 
   @override
-  String description = 'Run static analysis on dart files in this package '
+  String? description = 'Run static analysis on dart files in this package '
       'using the tuneup tool.';
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) {
+  FutureOr<int> run([DevToolExecutionContext? context]) {
     final execution = buildExecution(context ?? DevToolExecutionContext(),
         configuredIgnoreInfos: ignoreInfos);
-    return execution.exitCode ??
-        runProcessAndEnsureExit(execution.process, log: _log);
+    return (execution.exitCode ??
+        runProcessAndEnsureExit(execution.process!, log: _log)) as FutureOr<int>;
   }
 }
 
@@ -83,13 +83,13 @@ class TuneupExecution {
   /// [TuneupCheckTool] should exit with this code.
   ///
   /// If null, there is more work to do.
-  final int exitCode;
+  final int? exitCode;
 
   /// A declarative representation of the test process that should be run.
   ///
   /// This process' result should become the final result of the
   /// [TuneupCheckTool].
-  final ProcessDeclaration process;
+  final ProcessDeclaration? process;
 }
 
 /// Returns a combined list of args for the `tuneup` process.
@@ -97,9 +97,9 @@ class TuneupExecution {
 /// If [verbose] is true and the verbose flag (`-v`) is not already included, it
 /// will be added.
 Iterable<String> buildArgs({
-  ArgResults argResults,
-  bool configuredIgnoreInfos,
-  bool verbose,
+  ArgResults? argResults,
+  bool? configuredIgnoreInfos,
+  bool? verbose,
 }) {
   verbose ??= false;
   var ignoreInfos = (configuredIgnoreInfos ?? false) ||
@@ -109,7 +109,7 @@ Iterable<String> buildArgs({
     'tuneup',
     'check',
     if (ignoreInfos) '--ignore-infos',
-    if (verbose ?? false) '--verbose',
+    if (verbose) '--verbose',
   ];
 }
 
@@ -131,19 +131,19 @@ Iterable<String> buildArgs({
 /// assertions on the declarative output.
 TuneupExecution buildExecution(
   DevToolExecutionContext context, {
-  bool configuredIgnoreInfos,
-  String path,
+  bool? configuredIgnoreInfos,
+  String? path,
 }) {
   if (context.argResults != null) {
     assertNoPositionalArgsNorArgsAfterSeparator(
-        context.argResults, context.usageException,
+        context.argResults!, context.usageException,
         commandName: context.commandName);
   }
 
   if (!packageIsImmediateDependency('tuneup', path: path)) {
-    _log.severe(red.wrap('Cannot run "tuneup check".\n') +
+    _log.severe(red.wrap('Cannot run "tuneup check".\n')! +
         yellow
-            .wrap('You must have a dependency on "tuneup" in pubspec.yaml.\n'));
+            .wrap('You must have a dependency on "tuneup" in pubspec.yaml.\n')!);
     return TuneupExecution.exitEarly(ExitCode.config.code);
   }
 
@@ -153,5 +153,5 @@ TuneupExecution buildExecution(
       verbose: context.verbose);
   logSubprocessHeader(_log, 'dart ${args.join(' ')}');
   return TuneupExecution.process(
-      ProcessDeclaration(exe.dart, args, mode: ProcessStartMode.inheritStdio));
+      ProcessDeclaration(exe.dart, args as List<String?>, mode: ProcessStartMode.inheritStdio));
 }

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -85,7 +85,8 @@ class WebdevServeTool extends DevTool {
     final execution = buildExecution(context,
         configuredBuildArgs: buildArgs, configuredWebdevArgs: webdevArgs);
     return (execution.exitCode ??
-        runProcessAndEnsureExit(execution.process!, log: _log)) as FutureOr<int>;
+            runProcessAndEnsureExit(execution.process!, log: _log))
+        as FutureOr<int>;
   }
 }
 

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -49,13 +49,13 @@ class WebdevServeTool extends DevTool {
   /// process that will be run by this tool.
   ///
   /// Run `dart run build_runner build -h` to see all available args.
-  List<String> buildArgs;
+  List<String>? buildArgs;
 
   /// The args to pass to the `webdev serve` process that will be run by this
   /// tool.
   ///
   /// Run `dart pub global run webdev serve -h` to see all available args.
-  List<String> webdevArgs;
+  List<String>? webdevArgs;
 
   // ---------------------------------------------------------------------------
   // DevTool Overrides
@@ -75,16 +75,16 @@ class WebdevServeTool extends DevTool {
             'options.');
 
   @override
-  String description = 'Run a local web development server and a file system '
+  String? description = 'Run a local web development server and a file system '
       'watcher that rebuilds on changes.';
 
   @override
-  FutureOr<int> run([DevToolExecutionContext context]) {
+  FutureOr<int> run([DevToolExecutionContext? context]) {
     context ??= DevToolExecutionContext();
     final execution = buildExecution(context,
         configuredBuildArgs: buildArgs, configuredWebdevArgs: webdevArgs);
-    return execution.exitCode ??
-        runProcessAndEnsureExit(execution.process, log: _log);
+    return (execution.exitCode ??
+        runProcessAndEnsureExit(execution.process!, log: _log)) as FutureOr<int>;
   }
 }
 
@@ -105,13 +105,13 @@ class WebdevServeExecution {
   /// should exit with this code.
   ///
   /// If null, there is more work to do.
-  final int exitCode;
+  final int? exitCode;
 
   /// A declarative representation of the webdev process that should be run.
   ///
   /// This process' result should become the final result of the
   /// [WebdevServeTool].
-  final ProcessDeclaration process;
+  final ProcessDeclaration? process;
 }
 
 /// Builds and returns the full list of args for the webdev serve process that
@@ -132,10 +132,10 @@ class WebdevServeExecution {
 /// If [verbose] is true, both the webdev args and the build args portions of
 /// the returned list will include the `-v` verbose flag.
 List<String> buildArgs(
-    {ArgResults argResults,
-    List<String> configuredBuildArgs,
-    List<String> configuredWebdevArgs,
-    bool verbose}) {
+    {ArgResults? argResults,
+    List<String>? configuredBuildArgs,
+    List<String>? configuredWebdevArgs,
+    bool? verbose}) {
   verbose ??= false;
   final webdevArgs = <String>[
     // Combine all args that should be passed through to the webdev serve
@@ -143,7 +143,7 @@ List<String> buildArgs(
     // 1. Statically configured args from [WebdevServeTool.webdevArgs]
     ...?configuredWebdevArgs,
     // 2. The -r|--release flag
-    if (argResults != null && argResults['release'] ?? false) '--release',
+    if (argResults != null && argResults['release']) '--release',
     // 3. Args passed to --webdev-args
     ...?splitSingleOptionValue(argResults, 'webdev-args'),
   ];
@@ -199,13 +199,13 @@ List<String> buildArgs(
 /// on the declarative output.
 WebdevServeExecution buildExecution(
   DevToolExecutionContext context, {
-  List<String> configuredBuildArgs,
-  List<String> configuredWebdevArgs,
-  Map<String, String> environment,
+  List<String>? configuredBuildArgs,
+  List<String>? configuredWebdevArgs,
+  Map<String, String>? environment,
 }) {
   if (context.argResults != null) {
     assertNoPositionalArgsNorArgsAfterSeparator(
-        context.argResults, context.usageException,
+        context.argResults!, context.usageException,
         commandName: context.commandName,
         usageFooter: 'Arguments can be passed to the webdev process via the '
             '--webdev-args option.\n'
@@ -215,10 +215,10 @@ WebdevServeExecution buildExecution(
   if (!globalPackageIsActiveAndCompatible(
       'webdev', VersionConstraint.parse('^2.0.0'),
       environment: environment)) {
-    _log.severe(red.wrap(styleBold.wrap('webdev serve') +
-            ' could not run for this project.\n') +
+    _log.severe(red.wrap(styleBold.wrap('webdev serve')! +
+            ' could not run for this project.\n')! +
         yellow.wrap('You must have `webdev` globally activated:\n'
-            '  dart pub global activate webdev ^2.0.0'));
+            '  dart pub global activate webdev ^2.0.0')!);
     return WebdevServeExecution.exitEarly(ExitCode.config.code);
   }
   final args = buildArgs(

--- a/lib/src/utils/arg_results_utils.dart
+++ b/lib/src/utils/arg_results_utils.dart
@@ -1,6 +1,6 @@
 import 'package:args/args.dart';
 
-bool flagValue(ArgResults argResults, String name) {
+bool? flagValue(ArgResults? argResults, String name) {
   if (argResults == null || argResults[name] == null) {
     return null;
   }
@@ -10,7 +10,7 @@ bool flagValue(ArgResults argResults, String name) {
   return argResults[name];
 }
 
-Iterable<String> multiOptionValue(ArgResults argResults, String name) {
+Iterable<String>? multiOptionValue(ArgResults? argResults, String name) {
   if (argResults == null || argResults[name] == null) {
     return null;
   }
@@ -20,7 +20,7 @@ Iterable<String> multiOptionValue(ArgResults argResults, String name) {
   return List<String>.from(argResults[name]);
 }
 
-String singleOptionValue(ArgResults argResults, String name) {
+String? singleOptionValue(ArgResults? argResults, String name) {
   if (argResults == null || argResults[name] == null) {
     return null;
   }
@@ -30,5 +30,5 @@ String singleOptionValue(ArgResults argResults, String name) {
   return argResults[name];
 }
 
-Iterable<String> splitSingleOptionValue(ArgResults argResults, String name) =>
+Iterable<String>? splitSingleOptionValue(ArgResults? argResults, String name) =>
     singleOptionValue(argResults, name)?.split(' ');

--- a/lib/src/utils/assert_dir_is_dart_package.dart
+++ b/lib/src/utils/assert_dir_is_dart_package.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:path/path.dart' as p;
 
-void assertDirIsDartPackage({String path}) {
+void assertDirIsDartPackage({String? path}) {
   path ??= p.current;
   final pubspec = File(p.join(path, 'pubspec.yaml'));
   if (!pubspec.existsSync()) {

--- a/lib/src/utils/assert_no_args_after_separator.dart
+++ b/lib/src/utils/assert_no_args_after_separator.dart
@@ -4,7 +4,7 @@ import 'has_args_after_separator.dart';
 
 void assertNoArgsAfterSeparator(
     ArgResults argResults, void Function(String msg) usageException,
-    {String commandName, String usageFooter}) {
+    {String? commandName, String? usageFooter}) {
   if (hasArgsAfterSeparator(argResults)) {
     usageException('${commandName != null ? 'The "$commandName"' : 'This'} '
         'command does not support args after a separator.'

--- a/lib/src/utils/assert_no_positional_args_before_separator.dart
+++ b/lib/src/utils/assert_no_positional_args_before_separator.dart
@@ -6,7 +6,7 @@ void assertNoPositionalArgs(
   String name,
   ArgResults argResults,
   void usageException(String message), {
-  bool beforeSeparator,
+  bool? beforeSeparator,
 }) {
   beforeSeparator ??= false;
   if (hasAnyPositionalArgsBeforeSeparator(argResults)) {

--- a/lib/src/utils/assert_no_positional_args_nor_args_after_separator.dart
+++ b/lib/src/utils/assert_no_positional_args_nor_args_after_separator.dart
@@ -4,7 +4,7 @@ import 'has_args_after_separator.dart';
 
 void assertNoPositionalArgsNorArgsAfterSeparator(
     ArgResults argResults, void Function(String msg) usageException,
-    {String commandName, String usageFooter, bool allowRest = false}) {
+    {String? commandName, String? usageFooter, bool allowRest = false}) {
   if ((argResults.rest.isNotEmpty && !allowRest) ||
       hasArgsAfterSeparator(argResults)) {
     usageException('${commandName != null ? 'The "$commandName"' : 'This'} '

--- a/lib/src/utils/cached_pubspec.dart
+++ b/lib/src/utils/cached_pubspec.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:path/path.dart' as p;
 import 'package:pubspec_parse/pubspec_parse.dart';
 
-Pubspec cachedPubspec({String path}) {
+Pubspec? cachedPubspec({String? path}) {
   final sourceUrl = p.join(path ?? p.current, 'pubspec.yaml');
   _cachedPubspecs.putIfAbsent(
       sourceUrl,

--- a/lib/src/utils/dart_dev_paths.dart
+++ b/lib/src/utils/dart_dev_paths.dart
@@ -5,9 +5,9 @@ import 'package:path/path.dart' as p;
 class DartDevPaths {
   final p.Context _context;
 
-  DartDevPaths({p.Context context}) : _context = context ?? p.context;
+  DartDevPaths({p.Context? context}) : _context = context ?? p.context;
 
-  String cache([String subPath]) => _context.normalize(
+  String cache([String? subPath]) => _context.normalize(
       _context.joinAll([..._cacheParts, if (subPath != null) subPath]));
 
   String get _cacheForDart => p.url.joinAll(_cacheParts);

--- a/lib/src/utils/dart_tool_cache.dart
+++ b/lib/src/utils/dart_tool_cache.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:dart_dev/src/utils/dart_dev_paths.dart';
 
-void createCacheDir({String subPath}) {
+void createCacheDir({String? subPath}) {
   final dir = Directory(DartDevPaths().cache(subPath));
   if (!dir.existsSync()) {
     dir.createSync(recursive: true);

--- a/lib/src/utils/ensure_process_exit.dart
+++ b/lib/src/utils/ensure_process_exit.dart
@@ -16,9 +16,11 @@ import 'exit_process_signals.dart';
 /// process will be forwarded via [process.kill]. This is only needed if the
 /// given [process] was started in either the [ProcessStartMode.detached] or
 /// [ProcessStartMode.detachedWithStdio] modes.
-void ensureProcessExit(Process process, {bool? forwardExitSignals, Logger? log}) {
+void ensureProcessExit(Process process,
+    {bool? forwardExitSignals, Logger? log}) {
   forwardExitSignals ??= false;
-  StreamSubscription<ProcessSignal>? signalsSub = exitProcessSignals.listen((signal) async {
+  StreamSubscription<ProcessSignal>? signalsSub =
+      exitProcessSignals.listen((signal) async {
     log?.info('Waiting for subprocess to exit...');
     if (forwardExitSignals!) {
       process.kill(signal);

--- a/lib/src/utils/ensure_process_exit.dart
+++ b/lib/src/utils/ensure_process_exit.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:logging/logging.dart';
@@ -15,11 +16,11 @@ import 'exit_process_signals.dart';
 /// process will be forwarded via [process.kill]. This is only needed if the
 /// given [process] was started in either the [ProcessStartMode.detached] or
 /// [ProcessStartMode.detachedWithStdio] modes.
-void ensureProcessExit(Process process, {bool forwardExitSignals, Logger log}) {
+void ensureProcessExit(Process process, {bool? forwardExitSignals, Logger? log}) {
   forwardExitSignals ??= false;
-  var signalsSub = exitProcessSignals.listen((signal) async {
+  StreamSubscription<ProcessSignal>? signalsSub = exitProcessSignals.listen((signal) async {
     log?.info('Waiting for subprocess to exit...');
-    if (forwardExitSignals) {
+    if (forwardExitSignals!) {
       process.kill(signal);
     }
   });

--- a/lib/src/utils/format_tool_builder.dart
+++ b/lib/src/utils/format_tool_builder.dart
@@ -1,5 +1,6 @@
 import 'package:analyzer/dart/ast/ast.dart';
 import 'package:analyzer/dart/ast/visitor.dart';
+import 'package:collection/collection.dart' show IterableExtension;
 import 'package:dart_dev/src/tools/over_react_format_tool.dart';
 
 import '../../dart_dev.dart';
@@ -22,7 +23,7 @@ import 'logging.dart';
 /// };
 /// ```
 class FormatToolBuilder extends GeneralizingAstVisitor<void> {
-  DevTool formatDevTool;
+  DevTool? formatDevTool;
 
   bool failedToDetectAKnownFormatter = false;
 
@@ -43,23 +44,23 @@ class FormatToolBuilder extends GeneralizingAstVisitor<void> {
     }
 
     if (formatterInvocation is CascadeExpression) {
-      AssignmentExpression getCascadeByProperty(String property) {
+      AssignmentExpression? getCascadeByProperty(String property) {
         return formatterInvocation.cascadeSections
             .whereType<AssignmentExpression>()
-            .firstWhere((assignment) {
+            .firstWhereOrNull((assignment) {
           final lhs = assignment.leftHandSide;
           return lhs is PropertyAccess && lhs.propertyName.name == property;
-        }, orElse: () => null);
+        });
       }
 
       if (formatDevTool is FormatTool) {
-        FormatTool typedFormatDevTool = formatDevTool;
+        FormatTool? typedFormatDevTool = formatDevTool as FormatTool?;
 
         final formatter = getCascadeByProperty('formatter');
         if (formatter != null) {
           final formatterType = formatter.rightHandSide;
           if (formatterType is PrefixedIdentifier) {
-            typedFormatDevTool.formatter =
+            typedFormatDevTool!.formatter =
                 detectFormatterForFormatTool(formatterType.identifier);
           } else {
             logWarningMessageFor(KnownErrorOutcome.failedToParseFormatter);
@@ -74,7 +75,7 @@ class FormatToolBuilder extends GeneralizingAstVisitor<void> {
                 .whereType<StringLiteral>()
                 .map((e) => e.stringValue)
                 .toList();
-            typedFormatDevTool.formatterArgs = stringArgs;
+            typedFormatDevTool!.formatterArgs = stringArgs;
 
             if (stringArgs.length < argList.elements.length) {
               logWarningMessageFor(
@@ -85,12 +86,12 @@ class FormatToolBuilder extends GeneralizingAstVisitor<void> {
           }
         }
       } else if (formatDevTool is OverReactFormatTool) {
-        OverReactFormatTool typedFormatDevTool = formatDevTool;
+        OverReactFormatTool? typedFormatDevTool = formatDevTool as OverReactFormatTool?;
         final lineLengthAssignment = getCascadeByProperty('lineLength');
         if (lineLengthAssignment != null) {
           final lengthExpression = lineLengthAssignment.rightHandSide;
           if (lengthExpression is IntegerLiteral) {
-            typedFormatDevTool.lineLength = lengthExpression.value;
+            typedFormatDevTool!.lineLength = lengthExpression.value;
           } else {
             logWarningMessageFor(KnownErrorOutcome.failedToParseLineLength);
           }
@@ -108,7 +109,7 @@ enum KnownErrorOutcome {
 }
 
 void logWarningMessageFor(KnownErrorOutcome outcome) {
-  String errorMessage;
+  String? errorMessage;
 
   switch (outcome) {
     case KnownErrorOutcome.failedToParseFormatter:
@@ -141,8 +142,8 @@ This is likely because assignment does not use an IntegerLiteral.
   log.warning(errorMessage);
 }
 
-Formatter detectFormatterForFormatTool(SimpleIdentifier formatterIdentifier) {
-  Formatter formatter;
+Formatter? detectFormatterForFormatTool(SimpleIdentifier formatterIdentifier) {
+  Formatter? formatter;
 
   switch (formatterIdentifier.name) {
     case 'dartfmt':
@@ -161,9 +162,9 @@ Formatter detectFormatterForFormatTool(SimpleIdentifier formatterIdentifier) {
   return formatter;
 }
 
-DevTool detectFormatter(AstNode formatterNode) {
-  String detectedFormatterName;
-  DevTool tool;
+DevTool? detectFormatter(AstNode formatterNode) {
+  String? detectedFormatterName;
+  DevTool? tool;
 
   if (formatterNode is MethodInvocation) {
     detectedFormatterName = formatterNode.methodName.name;

--- a/lib/src/utils/format_tool_builder.dart
+++ b/lib/src/utils/format_tool_builder.dart
@@ -86,7 +86,8 @@ class FormatToolBuilder extends GeneralizingAstVisitor<void> {
           }
         }
       } else if (formatDevTool is OverReactFormatTool) {
-        OverReactFormatTool? typedFormatDevTool = formatDevTool as OverReactFormatTool?;
+        OverReactFormatTool? typedFormatDevTool =
+            formatDevTool as OverReactFormatTool?;
         final lineLengthAssignment = getCascadeByProperty('lineLength');
         if (lineLengthAssignment != null) {
           final lengthExpression = lineLengthAssignment.rightHandSide;

--- a/lib/src/utils/get_dart_version_comment.dart
+++ b/lib/src/utils/get_dart_version_comment.dart
@@ -2,5 +2,5 @@
 /// or `null` if one does not exist.
 ///
 /// Uses regex over the analyzer for performance.
-String getDartVersionComment(String source) =>
+String? getDartVersionComment(String source) =>
     RegExp(r'^//\s*@dart\s*=.+$', multiLine: true).firstMatch(source)?.group(0);

--- a/lib/src/utils/global_package_is_active_and_compatible.dart
+++ b/lib/src/utils/global_package_is_active_and_compatible.dart
@@ -17,7 +17,7 @@ import 'executables.dart' as exe;
 /// passed to the [Process] that is run by this function.
 bool globalPackageIsActiveAndCompatible(
     String packageName, VersionConstraint constraint,
-    {Map<String, String> environment}) {
+    {Map<String, String>? environment}) {
   final args = ['pub', 'global', 'list'];
   final result = Process.runSync(exe.dart, args,
       environment: environment, stderrEncoding: utf8, stdoutEncoding: utf8);

--- a/lib/src/utils/logging.dart
+++ b/lib/src/utils/logging.dart
@@ -36,7 +36,7 @@ void attachLoggerToStdio(List<String> args) {
   Logger.root.onRecord.listen(stdIOLogListener(verbose: verbose));
 }
 
-StringBuffer colorLog(LogRecord record, {bool verbose}) {
+StringBuffer colorLog(LogRecord record, {bool? verbose}) {
   verbose ??= false;
 
   AnsiCode color;
@@ -49,7 +49,7 @@ StringBuffer colorLog(LogRecord record, {bool verbose}) {
   }
   final level = color.wrap('[${record.level}]');
   final eraseLine = ansiOutputEnabled && !verbose ? '\x1b[2K\r' : '';
-  final lines = <Object>[
+  final lines = <Object?>[
     '$eraseLine$level ${_loggerName(record, verbose)}${record.message}'
   ];
 
@@ -58,7 +58,7 @@ StringBuffer colorLog(LogRecord record, {bool verbose}) {
   }
 
   if (record.stackTrace != null && verbose) {
-    final trace = Trace.from(record.stackTrace).terse;
+    final trace = Trace.from(record.stackTrace!).terse;
     lines.add(trace);
   }
 
@@ -102,12 +102,12 @@ String humanReadable(Duration duration) {
   return '${hours}h ${remaining.inMinutes}m';
 }
 
-void logSubprocessHeader(Logger logger, String command, {Level level}) {
+void logSubprocessHeader(Logger logger, String command, {Level? level}) {
   level ??= Level.INFO;
   logger.log(
       level,
       'Running subprocess:\n' +
-          magenta.wrap(command) +
+          magenta.wrap(command)! +
           '\n' +
           '-' * (io.stdout.hasTerminal ? io.stdout.terminalColumns : 79) +
           '\n');
@@ -120,7 +120,7 @@ Future<T> logTimedAsync<T>(
   Logger logger,
   String description,
   Future<T> action(), {
-  Level level,
+  Level? level,
 }) async {
   level ??= Level.INFO;
   final watch = Stopwatch()..start();
@@ -150,7 +150,7 @@ T logTimedSync<T>(
   return result;
 }
 
-void Function(LogRecord) stdIOLogListener({bool verbose}) =>
+void Function(LogRecord) stdIOLogListener({bool? verbose}) =>
     (record) => io.stdout.write(record.message.trim().isEmpty
         ? '\n' * (record.message.split('\n').length - 1)
         : colorLog(record, verbose: verbose));

--- a/lib/src/utils/organize_directives/namespace.dart
+++ b/lib/src/utils/organize_directives/namespace.dart
@@ -18,24 +18,24 @@ class Namespace {
   List<Token> afterComments = [];
 
   /// The file being imported/exported.
-  String get target {
+  String? get target {
     return directive.uri.stringValue;
   }
 
   /// If the namespace is a dart namespace. Memoized for performance.
-  bool _isDart;
+  bool? _isDart;
   bool get isDart {
-    return _isDart ??= target.startsWith('dart:');
+    return _isDart ??= target!.startsWith('dart:');
   }
 
   /// If the namespace is an external package namespace. Memoized for performance.
-  bool _isExternalPkg;
+  bool? _isExternalPkg;
   bool get isExternalPkg {
-    return _isExternalPkg ??= target.startsWith('package:');
+    return _isExternalPkg ??= target!.startsWith('package:');
   }
 
   /// If the namespace is a relative namespace. Memoized for performance.
-  bool _isRelative;
+  bool? _isRelative;
   bool get isRelative {
     return _isRelative ??= !isExternalPkg && !isDart;
   }

--- a/lib/src/utils/organize_directives/namespace_collector.dart
+++ b/lib/src/utils/organize_directives/namespace_collector.dart
@@ -9,13 +9,13 @@ class NamespaceCollector extends SimpleAstVisitor<List<NamespaceDirective>> {
   List<NamespaceDirective> _namespaces = [];
 
   @override
-  List<NamespaceDirective> visitExportDirective(ExportDirective node) {
+  List<NamespaceDirective>? visitExportDirective(ExportDirective node) {
     _namespaces.add(node);
     return null;
   }
 
   @override
-  List<NamespaceDirective> visitImportDirective(ImportDirective node) {
+  List<NamespaceDirective>? visitImportDirective(ImportDirective node) {
     _namespaces.add(node);
     return null;
   }

--- a/lib/src/utils/organize_directives/organize_directives.dart
+++ b/lib/src/utils/organize_directives/organize_directives.dart
@@ -12,7 +12,7 @@ import 'namespace_collector.dart';
 String organizeDirectives(String sourceFileContents) {
   final directives = parseString(content: sourceFileContents)
       .unit
-      .accept(NamespaceCollector());
+      .accept(NamespaceCollector())!;
 
   if (directives.isEmpty) {
     return sourceFileContents;
@@ -94,7 +94,7 @@ List<Namespace> _assignCommentsInFileToNamespaceDirective(
 ) {
   final namespaces = <Namespace>[];
 
-  Namespace prevNamespace;
+  Namespace? prevNamespace;
   for (var directive in directives) {
     final currNamespace = Namespace(directive);
     namespaces.add(currNamespace);
@@ -112,7 +112,7 @@ List<Namespace> _assignCommentsInFileToNamespaceDirective(
   // Assign comments after the last directive to the last directive if they are
   // on the same line.
   _assignCommentsBeforeTokenToNamespace(
-    prevNamespace.directive.endToken.next,
+    prevNamespace!.directive.endToken.next!,
     sourceFileContents,
     prevNamespace,
   );
@@ -124,18 +124,18 @@ List<Namespace> _assignCommentsInFileToNamespaceDirective(
 void _assignCommentsBeforeTokenToNamespace(
   Token token,
   String sourceFileContents,
-  Namespace prevNamespace, {
-  Namespace currNamespace,
+  Namespace? prevNamespace, {
+  Namespace? currNamespace,
 }) {
   // `precedingComments` returns the first comment before token.
   // Calling `comment.next` returns the next comment.
   // Returns null when there are no more comments left.
-  for (Token comment = token.precedingComments;
+  for (Token? comment = token.precedingComments;
       comment != null;
       comment = comment.next) {
     if (_commentIsOnSameLineAsNamespace(
         comment, prevNamespace, sourceFileContents)) {
-      prevNamespace.afterComments.add(comment);
+      prevNamespace!.afterComments.add(comment);
     } else if (currNamespace != null) {
       currNamespace.beforeComments.add(comment);
     }
@@ -145,7 +145,7 @@ void _assignCommentsBeforeTokenToNamespace(
 /// Checks if a given comment is on the same line as a directive.
 /// It's expected that directive end is before comment start.
 bool _commentIsOnSameLineAsNamespace(
-    Token comment, Namespace namespace, String sourceFileContents) {
+    Token comment, Namespace? namespace, String sourceFileContents) {
   return namespace != null &&
       !sourceFileContents
           .substring(namespace.directive.endToken.end, comment.charOffset)
@@ -189,7 +189,7 @@ String _getSortedNamespaceString(
 /// then relative directives.
 int _namespaceComparator(Namespace first, Namespace second) {
   if (first.isDart && second.isDart) {
-    return first.target.compareTo(second.target);
+    return first.target!.compareTo(second.target!);
   }
 
   if (first.isDart && !second.isDart) {
@@ -204,7 +204,7 @@ int _namespaceComparator(Namespace first, Namespace second) {
   final firstIsPkg = first.isExternalPkg;
   final secondIsPkg = second.isExternalPkg;
   if (firstIsPkg && secondIsPkg) {
-    return first.target.compareTo(second.target);
+    return first.target!.compareTo(second.target!);
   }
 
   if (firstIsPkg && !secondIsPkg) {
@@ -216,5 +216,5 @@ int _namespaceComparator(Namespace first, Namespace second) {
   }
 
   // Neither are dart directives or pkg directives. Must be relative path directives...
-  return first.target.compareTo(second.target);
+  return first.target!.compareTo(second.target!);
 }

--- a/lib/src/utils/organize_directives/organize_directives_in_paths.dart
+++ b/lib/src/utils/organize_directives/organize_directives_in_paths.dart
@@ -7,7 +7,7 @@ import 'organize_directives.dart';
 /// Organizes imports/exports in a list of files and directories.
 int organizeDirectivesInPaths(
   Iterable<String> paths, {
-  bool check = false,
+  bool? check = false,
   bool verbose = false,
 }) {
   final allFiles = _getAllFiles(paths);
@@ -48,7 +48,7 @@ Iterable<String> _getAllFiles(Iterable<String> paths) {
 int _organizeDirectivesInFiles(
   Iterable<String> paths, {
   bool verbose = false,
-  bool check = false,
+  bool? check = false,
 }) {
   var exitCode = 0;
   for (final path in paths) {
@@ -65,7 +65,7 @@ int _organizeDirectivesInFiles(
 int _organizeDirectivesInFile(
   String filePath, {
   bool verbose = false,
-  bool check = false,
+  bool? check = false,
 }) {
   final file = File(filePath);
   final fileContents = _safelyReadFileContents(file);
@@ -83,7 +83,7 @@ int _organizeDirectivesInFile(
   }
 
   final fileChanged = fileWithOrganizedDirectives != fileContents;
-  if (fileChanged && check) {
+  if (fileChanged && check!) {
     return _fail('$filePath has imports/exports that need to be organized.');
   } else if (fileChanged &&
       !_safelyWriteFile(file, fileWithOrganizedDirectives)) {
@@ -92,7 +92,7 @@ int _organizeDirectivesInFile(
     );
   }
 
-  if (verbose && !check) {
+  if (verbose && !check!) {
     print(green.wrap('$filePath successfully organized imports/exports'));
   }
 
@@ -104,7 +104,7 @@ int _fail(String message) {
   return 1;
 }
 
-String _safelyReadFileContents(File file) {
+String? _safelyReadFileContents(File file) {
   try {
     return file.readAsStringSync();
   } on FileSystemException {
@@ -112,7 +112,7 @@ String _safelyReadFileContents(File file) {
   }
 }
 
-String _safelyOrganizeDirectives(String fileContents) {
+String? _safelyOrganizeDirectives(String fileContents) {
   try {
     return organizeDirectives(fileContents);
   } on ArgumentError {

--- a/lib/src/utils/package_is_immediate_dependency.dart
+++ b/lib/src/utils/package_is_immediate_dependency.dart
@@ -14,8 +14,8 @@ import 'cached_pubspec.dart';
 /// - [packageName] is a dependency
 /// - [packageName] is a dev dependency
 /// - [packageName] is a dependency override
-bool packageIsImmediateDependency(String packageName, {String path}) {
-  final pubspec = cachedPubspec(path: path);
+bool packageIsImmediateDependency(String packageName, {String? path}) {
+  final pubspec = cachedPubspec(path: path)!;
   return pubspec.name == packageName ||
       pubspec.devDependencies.keys.any((d) => d == packageName) ||
       pubspec.dependencies.keys.any((d) => d == packageName) ||

--- a/lib/src/utils/parse_flag_from_args.dart
+++ b/lib/src/utils/parse_flag_from_args.dart
@@ -1,5 +1,5 @@
 bool parseFlagFromArgs(List<String> args, String name,
-    {String abbr, bool defaultsTo, bool negatable}) {
+    {String? abbr, bool? defaultsTo, bool? negatable}) {
   defaultsTo ??= false;
   negatable ??= false;
 

--- a/lib/src/utils/process_declaration.dart
+++ b/lib/src/utils/process_declaration.dart
@@ -1,10 +1,10 @@
 import 'dart:io';
 
 class ProcessDeclaration {
-  final List<String> args;
+  final List<String?> args;
   final String executable;
-  final ProcessStartMode mode;
-  final String workingDirectory;
+  final ProcessStartMode? mode;
+  final String? workingDirectory;
 
   ProcessDeclaration(this.executable, this.args,
       {this.mode, this.workingDirectory});

--- a/lib/src/utils/run_process_and_ensure_exit.dart
+++ b/lib/src/utils/run_process_and_ensure_exit.dart
@@ -6,9 +6,9 @@ import 'ensure_process_exit.dart';
 import 'process_declaration.dart';
 
 Future<int> runProcessAndEnsureExit(ProcessDeclaration processDeclaration,
-    {Logger log}) async {
+    {Logger? log}) async {
   final process = await Process.start(
-      processDeclaration.executable, processDeclaration.args,
+      processDeclaration.executable, processDeclaration.args as List<String>,
       mode: processDeclaration.mode ?? ProcessStartMode.normal,
       workingDirectory: processDeclaration.workingDirectory);
   ensureProcessExit(process, log: log);

--- a/lib/src/utils/start_process_and_ensure_exit.dart
+++ b/lib/src/utils/start_process_and_ensure_exit.dart
@@ -6,9 +6,9 @@ import 'ensure_process_exit.dart';
 import 'process_declaration.dart';
 
 Future<Process> startProcessAndEnsureExit(ProcessDeclaration processDeclaration,
-    {Logger log}) async {
+    {Logger? log}) async {
   final process = await Process.start(
-      processDeclaration.executable, processDeclaration.args,
+      processDeclaration.executable, processDeclaration.args as List<String>,
       mode: processDeclaration.mode ?? ProcessStartMode.normal,
       workingDirectory: processDeclaration.workingDirectory);
   ensureProcessExit(process, log: log);

--- a/lib/src/utils/verbose_enabled.dart
+++ b/lib/src/utils/verbose_enabled.dart
@@ -1,4 +1,4 @@
 import 'package:args/command_runner.dart';
 
 bool verboseEnabled(Command<dynamic> command) =>
-    command.globalResults['verbose'] ?? false;
+    command.globalResults!['verbose'] ?? false;

--- a/lib/src/utils/version.dart
+++ b/lib/src/utils/version.dart
@@ -10,7 +10,7 @@ import 'package:yaml/yaml.dart';
 ///
 /// This is a semantic version, optionally followed by a space and additional
 /// data about its source.
-final String dartDevVersion = (() {
+final String? dartDevVersion = (() {
   dynamic lockfile;
   try {
     lockfile = loadYaml(File('pubspec.lock').readAsStringSync());
@@ -29,7 +29,7 @@ final String dartDevVersion = (() {
   var source = package['source'];
   if (source is! String) return null;
 
-  switch (source as String) {
+  switch (source) {
     case 'hosted':
       var version = package['version'];
       return (version is String) ? version : null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.1
+version: 3.8.2
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,18 +4,17 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: '>=2.13.0 <3.0.0'
+ sdk: '>=2.14.0 <3.0.0'
 
 dependencies:
   analyzer: '>=1.7.2 <6.0.0'
   args: ^2.0.0
   async: ^2.3.0
-  build_runner: '>=1.0.0 <3.0.0'
+  build_runner: ^2.0.0
   glob: ^2.0.0
   io: ^1.0.0
   logging: ^1.0.0
   path: ^1.6.2
-  pedantic: ^1.7.0
   pub_semver: ^2.0.0
   pubspec_parse: ^1.0.0
   stack_trace: ^1.9.3

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: '>=2.18.0 <3.0.0'
+ sdk: '>=2.13.0 <3.0.0'
 
 dependencies:
   analyzer: '>=1.7.2 <6.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.3
+version: 3.8.4
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: '>=2.12.0 <3.0.0'
+ sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   analyzer: '>=1.7.2 <6.0.0'
@@ -12,15 +12,15 @@ dependencies:
   async: ^2.3.0
   build_runner: '>=1.0.0 <3.0.0'
   glob: ^2.0.0
-  io: '>=0.3.5 <2.0.0'
+  io: ^1.0.0
   logging: ^1.0.0
   path: ^1.6.2
   pedantic: ^1.7.0
   pub_semver: ^2.0.0
-  pubspec_parse: '>=0.1.8 <2.0.0'
+  pubspec_parse: ^1.0.0
   stack_trace: ^1.9.3
   yaml: ^3.0.0
-  collection: ^1.15.0-nullsafety.4
+  collection: ^1.15.0
 
 dev_dependencies:
   dependency_validator: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.0
+version: 3.8.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 dev_dependencies:
   dependency_validator: ^3.0.0
-  lints: ^2.0.1
+  lints: '>=1.0.1 <3.0.0'
   matcher: ^0.12.5
   test: ^1.15.7
   test_descriptor: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: ">=2.11.0 <3.0.0"
+ sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   analyzer: '>=1.0.0 <3.0.0'
@@ -20,6 +20,7 @@ dependencies:
   pubspec_parse: '>=0.1.8 <2.0.0'
   stack_trace: ^1.9.3
   yaml: ^3.0.0
+  collection: ^1.15.0-nullsafety.4
 
 dev_dependencies:
   dependency_validator: ^3.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 dev_dependencies:
   dependency_validator: ^3.0.0
-  lints: ^1.0.1
+  lints: ^2.0.1
   matcher: ^0.12.5
   test: ^1.15.7
   test_descriptor: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.5
+version: 3.8.6
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.2
+version: 3.8.3
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.6
+version: 3.8.7
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 3.8.4
+version: 3.8.5
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,20 +4,20 @@ description: Centralized tooling for Dart projects. Consistent interface across 
 homepage: https://github.com/Workiva/dart_dev
 
 environment:
- sdk: '>=2.14.0 <3.0.0'
+ sdk: '>=2.18.0 <3.0.0'
 
 dependencies:
   analyzer: '>=1.7.2 <6.0.0'
   args: ^2.0.0
-  async: ^2.3.0
+  async: ^2.5.0
   build_runner: ^2.0.0
   glob: ^2.0.0
   io: ^1.0.0
   logging: ^1.0.0
-  path: ^1.6.2
+  path: ^1.8.0
   pub_semver: ^2.0.0
   pubspec_parse: ^1.0.0
-  stack_trace: ^1.9.3
+  stack_trace: ^1.10.0
   yaml: ^3.0.0
   collection: ^1.15.0
 

--- a/test/functional.dart
+++ b/test/functional.dart
@@ -8,7 +8,7 @@ import 'package:test_process/test_process.dart';
 
 Future<TestProcess> runDevToolFunctionalTest(
     String command, String projectTemplatePath,
-    {List<String> args, bool verbose}) async {
+    {List<String>? args, bool? verbose}) async {
   // Setup a temporary directory on which this tool will be run, using the given
   // project template as a starting point.
   final templateDir = Directory(projectTemplatePath);

--- a/test/functional/documentation_test.dart
+++ b/test/functional/documentation_test.dart
@@ -50,18 +50,18 @@ Iterable<DartBlock> getDartBlocks() sync* {
     final source = file.readAsStringSync();
     var i = 1;
     for (final match in dartBlockPattern.allMatches(source)) {
-      final params = match.group(1).split(' ');
+      final params = match.group(1)!.split(' ');
       if (params.contains('test=false')) continue;
-      yield DartBlock.fromSource(match.group(1), file.path, i++);
+      yield DartBlock.fromSource(match.group(1)!, file.path, i++);
     }
   }
 }
 
-String pubspecWithPackages(Set<String> packages) {
+String pubspecWithPackages(Set<String?> packages) {
   final buffer = StringBuffer()
     ..writeln('name: doc_test')
     ..writeln('environment:')
-    ..writeln('  sdk: ">=2.7.0 <3.0.0"')
+    ..writeln('  sdk: ">=2.12.0 <3.0.0"')
     ..writeln('dependencies:');
   for (final package in packages) {
     var constraint =
@@ -73,14 +73,14 @@ String pubspecWithPackages(Set<String> packages) {
 
 class DartBlock {
   final int index;
-  final Set<String> packages;
+  final Set<String?> packages;
   final String source;
   final String sourceUrl;
 
   DartBlock.fromSource(this.source, this.sourceUrl, this.index)
       : packages = parsePackagesFromSource(source);
 
-  static Set<String> parsePackagesFromSource(String source) {
+  static Set<String?> parsePackagesFromSource(String source) {
     final packagePattern = RegExp(r'''['"]package:(\w+)\/.*['"]''');
     return Set.of(
         packagePattern.allMatches(source).map((match) => match.group(1)));

--- a/test/functional/fixtures/analyze/failure/pubspec.yaml
+++ b/test/functional/fixtures/analyze/failure/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_dev_test_functional_analyze_failure
 version: 0.0.0
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../..

--- a/test/functional/fixtures/analyze/success/pubspec.yaml
+++ b/test/functional/fixtures/analyze/success/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_dev_test_functional_analyze_success
 version: 0.0.0
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../..

--- a/test/functional/fixtures/format/unsorted_imports/organize_directives_off/pubspec.yaml
+++ b/test/functional/fixtures/format/unsorted_imports/organize_directives_off/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_dev_test_functional_format_organize_directives_off
 version: 0.0.0
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../../../

--- a/test/functional/fixtures/format/unsorted_imports/organize_directives_on/pubspec.yaml
+++ b/test/functional/fixtures/format/unsorted_imports/organize_directives_on/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dart_dev_test_functional_format_organize_directives_on
 version: 0.0.0
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   dart_dev:
     path: ../../../../../../

--- a/test/tools/analyze_tool_test.dart
+++ b/test/tools/analyze_tool_test.dart
@@ -22,7 +22,7 @@ void main() {
     test('provides an argParser', () {
       final argParser = AnalyzeTool().argParser;
       expect(argParser.options, contains('analyzer-args'));
-      expect(argParser.options['analyzer-args'].type, OptionType.single);
+      expect(argParser.options['analyzer-args']!.type, OptionType.single);
     });
   });
 

--- a/test/tools/compound_tool_test.dart
+++ b/test/tools/compound_tool_test.dart
@@ -10,14 +10,14 @@ void main() {
   group('CompoundTool', () {
     sharedDevToolTests(() => CompoundTool());
 
-    int currentTool;
-    List<int> toolsRan;
+    late int currentTool;
+    late List<int> toolsRan;
     setUp(() {
       currentTool = 0;
       toolsRan = [];
     });
 
-    DevTool tool({ArgParser argParser, Function callback, int exitCode}) {
+    DevTool tool({ArgParser? argParser, Function? callback, int? exitCode}) {
       final toolNum = currentTool++;
       return DevTool.fromFunction((_) {
         if (callback != null) {
@@ -61,15 +61,15 @@ void main() {
 
     test('runs tools with their own ArgResults by default', () async {
       final tool1 = DevTool.fromFunction((context) {
-        expect(context.argResults['foo'], isTrue);
-        expect(() => context.argResults['bar'], throwsArgumentError);
-        expect(context.argResults.rest, isEmpty);
+        expect(context.argResults!['foo'], isTrue);
+        expect(() => context.argResults!['bar'], throwsArgumentError);
+        expect(context.argResults!.rest, isEmpty);
         return 0;
       }, argParser: ArgParser()..addFlag('foo'));
       final tool2 = DevTool.fromFunction((context) {
-        expect(context.argResults['bar'], isTrue);
-        expect(() => context.argResults['foo'], throwsArgumentError);
-        expect(context.argResults.rest, isEmpty);
+        expect(context.argResults!['bar'], isTrue);
+        expect(() => context.argResults!['foo'], throwsArgumentError);
+        expect(context.argResults!.rest, isEmpty);
         return 0;
       }, argParser: ArgParser()..addFlag('bar'));
 
@@ -80,8 +80,8 @@ void main() {
 
     test('runs tools with a custom ArgMapper, if provided', () async {
       final tool = DevTool.fromFunction((context) {
-        expect(context.argResults['foo'], isTrue);
-        expect(context.argResults.rest, orderedEquals(['bar', 'baz']));
+        expect(context.argResults!['foo'], isTrue);
+        expect(context.argResults!.rest, orderedEquals(['bar', 'baz']));
         return 0;
       }, argParser: ArgParser()..addFlag('foo'));
 
@@ -99,8 +99,8 @@ void main() {
           ..addCommand('has-parser', ArgParser()..addFlag('foo'));
         final cap = CompoundArgParser()..addParser(parser);
         expect(cap.commands.keys, containsAll(['no-parser', 'has-parser']));
-        expect(cap.commands['no-parser'].options, isEmpty);
-        expect(cap.commands['has-parser'].options.keys, contains('foo'));
+        expect(cap.commands['no-parser']!.options, isEmpty);
+        expect(cap.commands['has-parser']!.options.keys, contains('foo'));
       });
 
       test('adds all options', () {
@@ -185,7 +185,7 @@ void main() {
       final spec = DevToolSpec(RunWhen.passing, fooTool);
       final result = contextForTool(baseContext, spec);
       expect(result, isNot(same(baseContext)));
-      expect(result.argResults.options, unorderedEquals(['foo']));
+      expect(result.argResults!.options, unorderedEquals(['foo']));
     });
   });
 

--- a/test/tools/fixtures/format/has_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/has_dart_style/pubspec.yaml
@@ -1,6 +1,6 @@
 name: has_dart_style
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   dart_style: any
 

--- a/test/tools/fixtures/format/missing_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/missing_dart_style/pubspec.yaml
@@ -1,6 +1,6 @@
 name: missing_dart_style
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   test: any
 

--- a/test/tools/fixtures/tuneup_check/has_tuneup/pubspec.yaml
+++ b/test/tools/fixtures/tuneup_check/has_tuneup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: has_tuneup
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
   tuneup: any
 

--- a/test/tools/fixtures/tuneup_check/missing_tuneup/pubspec.yaml
+++ b/test/tools/fixtures/tuneup_check/missing_tuneup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: missing_tuneup
 environment:
- sdk: ">=2.7.0 <3.0.0"
+ sdk: ">=2.12.0 <3.0.0"
 
 workiva:
   disable_core_checks: true

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -24,19 +24,19 @@ void main() {
       expect(argParser.options.keys,
           containsAll(['overwrite', 'dry-run', 'check', 'formatter-args']));
 
-      expect(argParser.options['overwrite'].type, OptionType.flag);
-      expect(argParser.options['overwrite'].abbr, 'w');
-      expect(argParser.options['overwrite'].negatable, isFalse);
+      expect(argParser.options['overwrite']!.type, OptionType.flag);
+      expect(argParser.options['overwrite']!.abbr, 'w');
+      expect(argParser.options['overwrite']!.negatable, isFalse);
 
-      expect(argParser.options['dry-run'].type, OptionType.flag);
-      expect(argParser.options['dry-run'].abbr, 'n');
-      expect(argParser.options['dry-run'].negatable, isFalse);
+      expect(argParser.options['dry-run']!.type, OptionType.flag);
+      expect(argParser.options['dry-run']!.abbr, 'n');
+      expect(argParser.options['dry-run']!.negatable, isFalse);
 
-      expect(argParser.options['check'].type, OptionType.flag);
-      expect(argParser.options['check'].abbr, 'c');
-      expect(argParser.options['check'].negatable, isFalse);
+      expect(argParser.options['check']!.type, OptionType.flag);
+      expect(argParser.options['check']!.abbr, 'c');
+      expect(argParser.options['check']!.negatable, isFalse);
 
-      expect(argParser.options['formatter-args'].type, OptionType.single);
+      expect(argParser.options['formatter-args']!.type, OptionType.single);
     });
 
     group('getInputs', () {
@@ -233,9 +233,9 @@ void main() {
           argResults: argResults, commandName: 'hackFastFormat');
       final execution = buildExecution(context);
       expect(execution.exitCode, isNull);
-      expect(execution.formatProcess.executable, exe.dartfmt);
-      expect(execution.formatProcess.args, orderedEquals(['a/random/path']));
-      expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+      expect(execution.formatProcess!.executable, exe.dartfmt);
+      expect(execution.formatProcess!.args, orderedEquals(['a/random/path']));
+      expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
       expect(execution.directiveOrganization, isNull);
     });
 
@@ -336,9 +336,9 @@ void main() {
         final context = DevToolExecutionContext();
         final execution = buildExecution(context);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dartfmt);
-        expect(execution.formatProcess.args, orderedEquals(['.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.executable, exe.dartfmt);
+        expect(execution.formatProcess!.args, orderedEquals(['.']));
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
       });
 
@@ -347,9 +347,9 @@ void main() {
         final execution =
             buildExecution(context, defaultMode: FormatMode.dryRun);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dartfmt);
-        expect(execution.formatProcess.args, orderedEquals(['-n', '.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.executable, exe.dartfmt);
+        expect(execution.formatProcess!.args, orderedEquals(['-n', '.']));
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
       });
 
@@ -357,9 +357,9 @@ void main() {
         final context = DevToolExecutionContext();
         final execution = buildExecution(context, formatter: Formatter.dartfmt);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dartfmt);
-        expect(execution.formatProcess.args, orderedEquals(['.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.executable, exe.dartfmt);
+        expect(execution.formatProcess!.args, orderedEquals(['.']));
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
       });
 
@@ -368,9 +368,9 @@ void main() {
         final execution =
             buildExecution(context, formatter: Formatter.dartFormat);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dart);
-        expect(execution.formatProcess.args, orderedEquals(['format', '.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.executable, exe.dart);
+        expect(execution.formatProcess!.args, orderedEquals(['format', '.']));
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
       });
 
       test('with dart_style:format', () {
@@ -379,10 +379,10 @@ void main() {
             formatter: Formatter.dartStyle,
             path: 'test/tools/fixtures/format/has_dart_style');
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dart);
-        expect(execution.formatProcess.args,
+        expect(execution.formatProcess!.executable, exe.dart);
+        expect(execution.formatProcess!.args,
             orderedEquals(['run', 'dart_style:format', '.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
       });
 
@@ -395,12 +395,12 @@ void main() {
             configuredFormatterArgs: ['--fix', '--follow-links'],
             formatter: Formatter.dartfmt);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dartfmt);
+        expect(execution.formatProcess!.executable, exe.dartfmt);
         expect(
-            execution.formatProcess.args,
+            execution.formatProcess!.args,
             orderedEquals(
                 ['-w', '--fix', '--follow-links', '--indent', '2', '.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
         expect(execution.directiveOrganization, isNull);
       });
 
@@ -412,12 +412,12 @@ void main() {
             configuredFormatterArgs: ['--fix', '--follow-links'],
             formatter: Formatter.dartFormat);
         expect(execution.exitCode, isNull);
-        expect(execution.formatProcess.executable, exe.dart);
+        expect(execution.formatProcess!.executable, exe.dart);
         expect(
-            execution.formatProcess.args,
+            execution.formatProcess!.args,
             orderedEquals(
                 ['format', '--fix', '--follow-links', '--indent', '2', '.']));
-        expect(execution.formatProcess.mode, ProcessStartMode.inheritStdio);
+        expect(execution.formatProcess!.mode, ProcessStartMode.inheritStdio);
       });
 
       test('and logs the test subprocess by default', () {
@@ -441,8 +441,8 @@ void main() {
         expect(execution.exitCode, isNull);
         expect(execution.formatProcess, isNotNull);
         expect(execution.directiveOrganization, isNotNull);
-        expect(execution.directiveOrganization.inputs, equals(['.']));
-        expect(execution.directiveOrganization.check, isFalse);
+        expect(execution.directiveOrganization!.inputs, equals(['.']));
+        expect(execution.directiveOrganization!.check, isFalse);
       });
 
       test('sorts imports in check mode when organizeImports is true', () {
@@ -455,8 +455,8 @@ void main() {
         expect(execution.exitCode, isNull);
         expect(execution.formatProcess, isNotNull);
         expect(execution.directiveOrganization, isNotNull);
-        expect(execution.directiveOrganization.inputs, equals(['.']));
-        expect(execution.directiveOrganization.check, isTrue);
+        expect(execution.directiveOrganization!.inputs, equals(['.']));
+        expect(execution.directiveOrganization!.check, isTrue);
       });
     });
   });
@@ -509,8 +509,8 @@ void main() {
   });
 
   group('validateAndParseMode', () {
-    ArgParser argParser;
-    Function usageException;
+    late ArgParser argParser;
+    late Function usageException;
 
     setUp(() {
       argParser = FormatTool().toCommand('test_format').argParser;
@@ -522,7 +522,7 @@ void main() {
       final argResults =
           argParser.parse(['--check', '--dry-run', '--overwrite']);
       expect(
-          () => validateAndParseMode(argResults, usageException),
+          () => validateAndParseMode(argResults, usageException as void Function(String)),
           throwsA(isA<UsageException>()
             ..having((e) => e.message, 'command name', 'test_format')
             ..having((e) => e.message, 'usage footer',
@@ -532,7 +532,7 @@ void main() {
     test('--check and --dry-run throws UsageException', () {
       final argResults = argParser.parse(['--check', '--dry-run']);
       expect(
-          () => validateAndParseMode(argResults, usageException),
+          () => validateAndParseMode(argResults, usageException as void Function(String)),
           throwsA(isA<UsageException>()
             ..having((e) => e.message, 'command name', 'test_format')
             ..having((e) => e.message, 'usage footer',
@@ -542,7 +542,7 @@ void main() {
     test('--check and --overwrite throws UsageException', () {
       final argResults = argParser.parse(['--check', '--overwrite']);
       expect(
-          () => validateAndParseMode(argResults, usageException),
+          () => validateAndParseMode(argResults, usageException as void Function(String)),
           throwsA(isA<UsageException>()
             ..having((e) => e.message, 'command name', 'test_format')
             ..having((e) => e.message, 'usage footer',
@@ -552,7 +552,7 @@ void main() {
     test('--dry-run and --overwrite throws UsageException', () {
       final argResults = argParser.parse(['--dry-run', '--overwrite']);
       expect(
-          () => validateAndParseMode(argResults, usageException),
+          () => validateAndParseMode(argResults, usageException as void Function(String)),
           throwsA(isA<UsageException>()
             ..having((e) => e.message, 'command name', 'test_format')
             ..having((e) => e.message, 'usage footer',
@@ -562,24 +562,24 @@ void main() {
     test('--check', () {
       final argResults = argParser.parse(['--check']);
       expect(
-          validateAndParseMode(argResults, usageException), FormatMode.check);
+          validateAndParseMode(argResults, usageException as void Function(String)), FormatMode.check);
     });
 
     test('--dry-run', () {
       final argResults = argParser.parse(['--dry-run']);
       expect(
-          validateAndParseMode(argResults, usageException), FormatMode.dryRun);
+          validateAndParseMode(argResults, usageException as void Function(String)), FormatMode.dryRun);
     });
 
     test('--overwrite', () {
       final argResults = argParser.parse(['--overwrite']);
-      expect(validateAndParseMode(argResults, usageException),
+      expect(validateAndParseMode(argResults, usageException as void Function(String)),
           FormatMode.overwrite);
     });
 
     test('no mode flag', () {
       final argResults = argParser.parse([]);
-      expect(validateAndParseMode(argResults, usageException), isNull);
+      expect(validateAndParseMode(argResults, usageException as void Function(String)), isNull);
     });
   });
 }

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -250,7 +250,7 @@ void main() {
           () => buildExecution(context),
           throwsA(isA<UsageException>()
               .having(
-                (e) => e.message, 'command name', contains('hackFastFormat'))
+                  (e) => e.message, 'command name', contains('hackFastFormat'))
               .having((e) => e.message, 'usage',
                   contains('must specify targets'))));
     });
@@ -526,7 +526,7 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
-                contains('--check and --dry-run and --overwrite'))));
+              contains('--check and --dry-run and --overwrite'))));
     });
 
     test('--check and --dry-run throws UsageException', () {
@@ -534,7 +534,7 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
-                contains('--check and --dry-run'))));
+              contains('--check and --dry-run'))));
     });
 
     test('--check and --overwrite throws UsageException', () {
@@ -542,7 +542,7 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
-                contains('--check and --overwrite'))));
+              contains('--check and --overwrite'))));
     });
 
     test('--dry-run and --overwrite throws UsageException', () {
@@ -550,7 +550,7 @@ void main() {
       expect(
           () => validateAndParseMode(argResults, usageException),
           throwsA(isA<UsageException>().having((e) => e.message, 'usage footer',
-                contains('--dry-run and --overwrite'))));
+              contains('--dry-run and --overwrite'))));
     });
 
     test('--check', () {

--- a/test/tools/function_tool_test.dart
+++ b/test/tools/function_tool_test.dart
@@ -29,7 +29,7 @@ void main() {
     test('accepts a custom ArgParser', () async {
       final parser = ArgParser()..addFlag('flag');
       final tool = DevTool.fromFunction((context) {
-        expect(context.argResults['flag'], isTrue);
+        expect(context.argResults!['flag'], isTrue);
         return 0;
       }, argParser: parser);
       await tool

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -1,11 +1,11 @@
 @TestOn('vm')
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/dart_dev.dart';
 import 'package:logging/logging.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:test/test.dart';
 
 import '../log_matchers.dart';

--- a/test/tools/process_tool_test.dart
+++ b/test/tools/process_tool_test.dart
@@ -25,7 +25,7 @@ void main() {
           as ProcessTool;
       expect(await tool.run(), isZero);
       final stdout =
-          (await tool.process.stdout.transform(utf8.decoder).join('')).trim();
+          (await tool.process!.stdout.transform(utf8.decoder).join('')).trim();
       expect(stdout, endsWith('/dart_dev/lib'));
     });
 
@@ -53,7 +53,7 @@ void main() {
       var processHasExited = false;
       final tool = BackgroundProcessTool('sleep', ['5']);
       expect(await tool.starter.run(), isZero);
-      unawaited(tool.process.exitCode.then((_) => processHasExited = true));
+      unawaited(tool.process!.exitCode.then((_) => processHasExited = true));
       await Future<void>.delayed(Duration.zero);
       expect(processHasExited, isFalse);
       await tool.stopper.run();
@@ -64,7 +64,7 @@ void main() {
       final tool = BackgroundProcessTool('sleep', ['5']);
       final stopwatch = Stopwatch()..start();
       expect(await tool.starter.run(), isZero);
-      unawaited(tool.process.exitCode.then((_) => processHasExited = true));
+      unawaited(tool.process!.exitCode.then((_) => processHasExited = true));
       await Future<void>.delayed(Duration(seconds: 1));
       expect(processHasExited, isFalse);
       expect(await tool.stopper.run(), isZero);
@@ -90,7 +90,7 @@ void main() {
           workingDirectory: 'lib', delayAfterStart: Duration(seconds: 1));
       expect(await tool.starter.run(), isZero);
       final stdout =
-          (await tool.process.stdout.transform(utf8.decoder).join('')).trim();
+          (await tool.process!.stdout.transform(utf8.decoder).join('')).trim();
       expect(stdout, endsWith('/dart_dev/lib'));
     });
 

--- a/test/tools/test_tool_test.dart
+++ b/test/tools/test_tool_test.dart
@@ -30,23 +30,23 @@ void main() {
             'build-args',
           ]));
 
-      expect(argParser.options['name'].type, OptionType.multiple);
-      expect(argParser.options['name'].abbr, 'n');
-      expect(argParser.options['name'].splitCommas, isFalse);
+      expect(argParser.options['name']!.type, OptionType.multiple);
+      expect(argParser.options['name']!.abbr, 'n');
+      expect(argParser.options['name']!.splitCommas, isFalse);
 
-      expect(argParser.options['plain-name'].type, OptionType.multiple);
-      expect(argParser.options['plain-name'].abbr, 'N');
-      expect(argParser.options['plain-name'].splitCommas, isFalse);
+      expect(argParser.options['plain-name']!.type, OptionType.multiple);
+      expect(argParser.options['plain-name']!.abbr, 'N');
+      expect(argParser.options['plain-name']!.splitCommas, isFalse);
 
-      expect(argParser.options['preset'].type, OptionType.multiple);
-      expect(argParser.options['preset'].abbr, 'P');
-      expect(argParser.options['preset'].splitCommas, isTrue);
+      expect(argParser.options['preset']!.type, OptionType.multiple);
+      expect(argParser.options['preset']!.abbr, 'P');
+      expect(argParser.options['preset']!.splitCommas, isTrue);
 
-      expect(argParser.options['release'].type, OptionType.flag);
-      expect(argParser.options['release'].abbr, isNull);
+      expect(argParser.options['release']!.type, OptionType.flag);
+      expect(argParser.options['release']!.abbr, isNull);
 
-      expect(argParser.options['test-args'].type, OptionType.single);
-      expect(argParser.options['build-args'].type, OptionType.single);
+      expect(argParser.options['test-args']!.type, OptionType.single);
+      expect(argParser.options['build-args']!.type, OptionType.single);
     });
   });
 
@@ -231,7 +231,7 @@ void main() {
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_test: any
   test: any
@@ -253,7 +253,7 @@ dev_dependencies:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_runner: any
   test: any
@@ -278,7 +278,7 @@ dev_dependencies:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 ''').create();
       final context = DevToolExecutionContext();
       expect(buildExecution(context, path: d.sandbox).exitCode,
@@ -299,7 +299,7 @@ environment:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_test: any
   test: any
@@ -326,7 +326,7 @@ dev_dependencies:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_runner: any
   test: any
@@ -346,7 +346,7 @@ dev_dependencies:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_test: any
   test: any
@@ -357,8 +357,8 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args, orderedEquals(['test']));
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args, orderedEquals(['test']));
         });
 
         test('with args', () {
@@ -368,8 +368,8 @@ dev_dependencies:
           final execution = buildExecution(context,
               configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args,
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args,
               orderedEquals(['test', '-P', 'unit', '-n', 'foo']));
         });
 
@@ -379,8 +379,8 @@ dev_dependencies:
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args, orderedEquals(['test', '-j1']));
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args, orderedEquals(['test', '-j1']));
         });
 
         test(
@@ -416,7 +416,7 @@ dev_dependencies:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_runner: any
   test: any
@@ -427,8 +427,8 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args, orderedEquals(['test']));
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args, orderedEquals(['test']));
         });
 
         test('with args', () {
@@ -438,8 +438,8 @@ dev_dependencies:
           final execution = buildExecution(context,
               configuredTestArgs: ['-P', 'unit'], path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args,
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args,
               orderedEquals(['test', '-P', 'unit', '-n', 'foo']));
         });
 
@@ -449,8 +449,8 @@ dev_dependencies:
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args, orderedEquals(['test', '-j1']));
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args, orderedEquals(['test', '-j1']));
         });
 
         test(
@@ -486,7 +486,7 @@ dev_dependencies:
 name: _test
 publish_to: none
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dev_dependencies:
   build_runner: any
   build_test: any
@@ -498,8 +498,8 @@ dev_dependencies:
           final context = DevToolExecutionContext();
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
-          expect(execution.process.args,
+          expect(execution.process!.executable, exe.dart);
+          expect(execution.process!.args,
               orderedEquals(['run', 'build_runner', 'test']));
         });
 
@@ -513,9 +513,9 @@ dev_dependencies:
               configuredTestArgs: ['-P', 'unit'],
               path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
+          expect(execution.process!.executable, exe.dart);
           expect(
-              execution.process.args,
+              execution.process!.args,
               orderedEquals([
                 'run',
                 'build_runner',
@@ -537,9 +537,9 @@ dev_dependencies:
           final context = DevToolExecutionContext(argResults: argResults);
           final execution = buildExecution(context, path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
+          expect(execution.process!.executable, exe.dart);
           expect(
-              execution.process.args,
+              execution.process!.args,
               orderedEquals([
                 'run',
                 'build_runner',
@@ -560,9 +560,9 @@ dev_dependencies:
               configuredTestArgs: ['-P', 'unit'],
               path: d.sandbox);
           expect(execution.exitCode, isNull);
-          expect(execution.process.executable, exe.dart);
+          expect(execution.process!.executable, exe.dart);
           expect(
-              execution.process.args,
+              execution.process!.args,
               orderedEquals([
                 'run',
                 'build_runner',

--- a/test/tools/tuneup_check_tool_test.dart
+++ b/test/tools/tuneup_check_tool_test.dart
@@ -20,7 +20,7 @@ void main() {
     test('provides an argParser', () {
       final argParser = TuneupCheckTool().argParser;
       expect(argParser.options, contains('ignore-infos'));
-      expect(argParser.options['ignore-infos'].type, OptionType.flag);
+      expect(argParser.options['ignore-infos']!.type, OptionType.flag);
     });
   });
 
@@ -74,10 +74,10 @@ void main() {
       test('(default)', () {
         final execution = buildExecution(DevToolExecutionContext(), path: path);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, exe.dart);
+        expect(execution.process!.executable, exe.dart);
         expect(
-            execution.process.args, orderedEquals(['run', 'tuneup', 'check']));
-        expect(execution.process.mode, ProcessStartMode.inheritStdio);
+            execution.process!.args, orderedEquals(['run', 'tuneup', 'check']));
+        expect(execution.process!.mode, ProcessStartMode.inheritStdio);
       });
 
       test('with args', () {
@@ -87,12 +87,12 @@ void main() {
             DevToolExecutionContext(argResults: argResults, verbose: true);
         final execution = buildExecution(context, path: path);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, exe.dart);
+        expect(execution.process!.executable, exe.dart);
         expect(
-            execution.process.args,
+            execution.process!.args,
             orderedEquals(
                 ['run', 'tuneup', 'check', '--ignore-infos', '--verbose']));
-        expect(execution.process.mode, ProcessStartMode.inheritStdio);
+        expect(execution.process!.mode, ProcessStartMode.inheritStdio);
       });
 
       test('and logs the subprocess header', () {

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -22,12 +22,12 @@ void main() {
       expect(argParser.options.keys,
           containsAll(['release', 'webdev-args', 'build-args']));
 
-      expect(argParser.options['release'].type, OptionType.flag);
-      expect(argParser.options['release'].abbr, 'r');
-      expect(argParser.options['release'].negatable, isTrue);
+      expect(argParser.options['release']!.type, OptionType.flag);
+      expect(argParser.options['release']!.abbr, 'r');
+      expect(argParser.options['release']!.negatable, isTrue);
 
-      expect(argParser.options['webdev-args'].type, OptionType.single);
-      expect(argParser.options['build-args'].type, OptionType.single);
+      expect(argParser.options['webdev-args']!.type, OptionType.single);
+      expect(argParser.options['build-args']!.type, OptionType.single);
     });
   });
 
@@ -133,8 +133,8 @@ void main() {
   });
 
   group('buildExecution', () {
-    TempPubCache pubCacheWithWebdev;
-    TempPubCache pubCacheWithoutWebdev;
+    late TempPubCache pubCacheWithWebdev;
+    late TempPubCache pubCacheWithoutWebdev;
 
     setUpAll(() {
       pubCacheWithWebdev = TempPubCache();
@@ -195,8 +195,8 @@ void main() {
         final execution = buildExecution(DevToolExecutionContext(),
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, exe.dart);
-        expect(execution.process.args,
+        expect(execution.process!.executable, exe.dart);
+        expect(execution.process!.args,
             orderedEquals(['pub', 'global', 'run', 'webdev', 'serve']));
       });
 
@@ -210,9 +210,9 @@ void main() {
             configuredWebdevArgs: ['web:9000', 'example:9001'],
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, exe.dart);
+        expect(execution.process!.executable, exe.dart);
         expect(
-            execution.process.args,
+            execution.process!.args,
             orderedEquals([
               'pub',
               'global',
@@ -242,9 +242,9 @@ void main() {
             configuredWebdevArgs: ['web:9000', 'example:9001'],
             environment: pubCacheWithWebdev.envOverride);
         expect(execution.exitCode, isNull);
-        expect(execution.process.executable, exe.dart);
+        expect(execution.process!.executable, exe.dart);
         expect(
-            execution.process.args,
+            execution.process!.args,
             orderedEquals([
               'pub',
               'global',

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -18,7 +18,7 @@ class TempPubCache {
 /// way to override certain things like the `PUB_CACHE` var that points pub to
 /// the global pub-cache directory.
 void globalActivate(String packageName, String constraint,
-    {Map<String, String> environment}) {
+    {Map<String, String>? environment}) {
   final result = Process.runSync(
     exe.dart,
     ['pub', 'global', 'activate', packageName, constraint],

--- a/test/utils/assert_no_positional_args_before_separator_test.dart
+++ b/test/utils/assert_no_positional_args_before_separator_test.dart
@@ -6,7 +6,7 @@ import 'package:test/test.dart';
 void main() {
   final commandName = 'test';
   bool beforeSeparator = false;
-  bool usageExceptionCalled;
+  late bool usageExceptionCalled;
   void usageException(String msg) {
     usageExceptionCalled = true;
     expect(msg, contains('The "$commandName" command'));

--- a/test/utils/dart_dev_paths_test.dart
+++ b/test/utils/dart_dev_paths_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('DartDevPaths', () {
     group('posix', () {
-      DartDevPaths paths;
+      late DartDevPaths paths;
 
       setUp(() {
         paths = DartDevPaths(context: p.posix);
@@ -38,7 +38,7 @@ void main() {
     });
 
     group('windows', () {
-      DartDevPaths paths;
+      late DartDevPaths paths;
 
       setUp(() {
         paths = DartDevPaths(context: p.windows);

--- a/test/utils/rest_args_with_separator_test.dart
+++ b/test/utils/rest_args_with_separator_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('restArgsWithSeparator', () {
-    ArgParser parser;
+    late ArgParser parser;
 
     setUp(() {
       parser = ArgParser()


### PR DESCRIPTION
Converts to null safety.

QA by using it in other packages. Tests should pass on Dart 2.18, 2.19. Tests won't pass on Dart 3 yet because we have tests that run on non-null safe packages.