### PR TITLE
Help unblock Analyzer 2

### DIFF
--- a/test/tools/fixtures/format/has_dart_style/pubspec.yaml
+++ b/test/tools/fixtures/format/has_dart_style/pubspec.yaml
@@ -2,7 +2,7 @@ name: has_dart_style
 environment:
  sdk: ">=2.12.0 <3.0.0"
 dev_dependencies:
-  dart_style: any
+  dart_style: <3.0.0
 
 workiva:
   disable_core_checks: true


### PR DESCRIPTION
Summary
---
Frontend Frameworks is updating dependencies!

This batch raises the maximum for some dev dependencies to allow for analyzer 2.
No action from you is needed. In mamy places, we won't
start resolving to these higher allowed versions until json_serializable 4.0.0 is unblocked.
Someone from FEF will address any CI problems and get these merged.

The most interesting change is LOWERing the minimum for built_value from 
^8.5.0 to ^8.4.4 in doc_plat_client, binder_experience, home, esg_ui.
The reason here is that there's a specific combination of built_value 8.4.4, 
built_value_generator 8.4.0 and analyzer 2.8.0. 8.5.0 is too new to allow
analyzer 2!

If you have questions or concerns, visit `#support-frontend-dx` in Slack.

[_Created by Sourcegraph batch change `Workiva/help_unblock_analyzer2`._](https://sourcegraph.plat.workiva.net/organizations/Workiva/batch-changes/help_unblock_analyzer2)