### PR TITLE
Make run return nonnullable FutureOr<int>

### DIFF
--- a/.github/workflows/dart_ci.yml
+++ b/.github/workflows/dart_ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        sdk: [ 2.18.7, stable ]
+        sdk: [ 2.18.7, 2.19.6 ]
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
         with:
-          sdk: stable
+          sdk: 2.18.7
 
       - id: install
         name: Install dependencies

--- a/lib/src/dart_dev_tool.dart
+++ b/lib/src/dart_dev_tool.dart
@@ -47,7 +47,7 @@ abstract class DevTool {
   /// will provide a fully-populated [DevToolExecutionContext] here.
   ///
   /// This is the one API member that subclasses need to implement.
-  FutureOr<int?> run([DevToolExecutionContext? context]);
+  FutureOr<int> run([DevToolExecutionContext? context]);
 
   /// Converts this tool to a [Command] that can be added directly to a
   /// [CommandRunner], therefore making it executable from the command-line.
@@ -150,7 +150,7 @@ class DevToolCommand extends Command<int> {
   final String name;
 
   @override
-  FutureOr<int>? run() async =>
+  FutureOr<int> run() async =>
       (await devTool.run(
         DevToolExecutionContext(
           argResults: argResults,
@@ -158,6 +158,5 @@ class DevToolCommand extends Command<int> {
           usageException: usageException,
           verbose: verboseEnabled(this),
         ),
-      )) ??
-      0;
+      ));
 }

--- a/lib/src/dart_dev_tool.dart
+++ b/lib/src/dart_dev_tool.dart
@@ -150,8 +150,7 @@ class DevToolCommand extends Command<int> {
   final String name;
 
   @override
-  FutureOr<int> run() async =>
-      (await devTool.run(
+  FutureOr<int> run() async => (await devTool.run(
         DevToolExecutionContext(
           argResults: argResults,
           commandName: name,

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -117,6 +117,11 @@ String buildDartDevRunScriptContents() {
   var dartVersionComment = hasCustomToolDevDart
       ? getDartVersionComment(File(paths.config).readAsStringSync())
       : null;
+  // If dart_dev itself is not null-safe, opt the entrypoint out of null-safety
+  // so the entrypoint doesn't fail to run in packages that have opted into null-safety.
+  if (!_isDartDevNullSafe && dartVersionComment == null) {
+    dartVersionComment = '// @dart=2.9';
+  }
 
   return '''
 ${dartVersionComment ?? ''}

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -117,11 +117,6 @@ String buildDartDevRunScriptContents() {
   var dartVersionComment = hasCustomToolDevDart
       ? getDartVersionComment(File(paths.config).readAsStringSync())
       : null;
-  // If dart_dev itself is not null-safe, opt the entrypoint out of null-safety
-  // so the entrypoint doesn't fail to run in packages that have opted into null-safety.
-  if (!_isDartDevNullSafe && dartVersionComment == null) {
-    dartVersionComment = '// @dart=2.9';
-  }
 
   return '''
 ${dartVersionComment ?? ''}

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -74,7 +74,7 @@ class AnalyzeTool extends DevTool {
   String? description = 'Run static analysis on dart files in this package.';
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) {
+  FutureOr<int> run([DevToolExecutionContext? context]) {
     return runProcessAndEnsureExit(
         buildProcess(
           context ?? DevToolExecutionContext(),

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -74,10 +74,10 @@ mixin CompoundToolMixin on DevTool {
   }
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
 
-    int? code = 0;
+    int code = 0;
     for (var i = 0; i < _specs.length; i++) {
       if (!shouldRunTool(_specs[i].when, code)) continue;
       final newCode =

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -106,7 +106,7 @@ class FormatTool extends DevTool {
   String? description = 'Format dart files in this package.';
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     if (formatter == Formatter.dartfmt && !dartVersionHasDartfmt) {
       formatter = Formatter.dartFormat;
@@ -120,7 +120,7 @@ class FormatTool extends DevTool {
       organizeDirectives: organizeDirectives,
     );
     if (formatExecution.exitCode != null) {
-      return formatExecution.exitCode;
+      return formatExecution.exitCode!;
     }
     var exitCode = await runProcessAndEnsureExit(
       formatExecution.formatProcess!,

--- a/lib/src/tools/function_tool.dart
+++ b/lib/src/tools/function_tool.dart
@@ -29,7 +29,7 @@ class FunctionTool extends DevTool {
   final ArgParser? _argParser;
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     final argResults = context.argResults;
     if (argResults != null) {

--- a/lib/src/tools/over_react_format_tool.dart
+++ b/lib/src/tools/over_react_format_tool.dart
@@ -18,7 +18,7 @@ class OverReactFormatTool extends DevTool {
       'Format dart files in this package with over_react_format.';
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     Iterable<String> paths = context.argResults?.rest ?? [];
     if (paths.isEmpty) {

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -43,7 +43,7 @@ class ProcessTool extends DevTool {
   Process? _process;
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     final argResults = context.argResults;
     if (argResults != null) {

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -115,7 +115,7 @@ class TestTool extends DevTool {
   List<String>? testArgs;
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     final execution = buildExecution(context,
         configuredBuildArgs: buildArgs, configuredTestArgs: testArgs);

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -58,7 +58,7 @@ class TuneupCheckTool extends DevTool {
       'using the tuneup tool.';
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     final execution = buildExecution(context ?? DevToolExecutionContext(),
         configuredIgnoreInfos: ignoreInfos);
     return execution.exitCode ??

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -80,7 +80,7 @@ class WebdevServeTool extends DevTool {
       'watcher that rebuilds on changes.';
 
   @override
-  FutureOr<int?> run([DevToolExecutionContext? context]) async {
+  FutureOr<int> run([DevToolExecutionContext? context]) async {
     context ??= DevToolExecutionContext();
     final execution = buildExecution(context,
         configuredBuildArgs: buildArgs, configuredWebdevArgs: webdevArgs);


### PR DESCRIPTION
When migrating to null safety we missed making the run method return a non nullable FutureOr<int> ... and that is causing weird casts and slight type mismatches in other tools.  This fixes that since the exit code is either zero pass and non-zero for fail but should never be null.