### PR TITLE
Fix type mismatch between `DevTool.fromFunction()` and `DevTool.run()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.0.1
+
+- Fix type mismatch between the expected return type of the function passed to
+`DevTool.fromFunction()` and the `DevTool.run()` method. The updated type is
+more permissive and so should not be breaking.
+
 ## 4.0.0
 
 - Migrated to null safety. The new SDK minimum is 2.18

--- a/lib/src/dart_dev_tool.dart
+++ b/lib/src/dart_dev_tool.dart
@@ -12,7 +12,7 @@ abstract class DevTool {
   DevTool();
 
   factory DevTool.fromFunction(
-          FutureOr<int>? Function(DevToolExecutionContext context) function,
+          FutureOr<int?> Function(DevToolExecutionContext context) function,
           {ArgParser? argParser}) =>
       FunctionTool(function, argParser: argParser);
 

--- a/lib/src/tools/function_tool.dart
+++ b/lib/src/tools/function_tool.dart
@@ -13,12 +13,12 @@ import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
 /// Use [DevTool.fromFunction] to create [FunctionTool] instances.
 class FunctionTool extends DevTool {
   FunctionTool(
-      FutureOr<int>? Function(DevToolExecutionContext context) function,
+      FutureOr<int?> Function(DevToolExecutionContext context) function,
       {ArgParser? argParser})
       : _argParser = argParser,
         _function = function;
 
-  final FutureOr<int>? Function(DevToolExecutionContext context) _function;
+  final FutureOr<int?> Function(DevToolExecutionContext context) _function;
 
   // ---------------------------------------------------------------------------
   // DevTool Overrides


### PR DESCRIPTION
## Motivation
The `DevTool` interface defines a `run()` method that must return `FutureOr<int?>`. The `DevTool.fromFunction()` factory expects a function with a return type of `FutureOr<int>?`. As a result, functions that would be valid implementations of `DevTool.run()` are disallowed by the typing of `DevTool.fromFunction()`.

## Changes
Update the typing of `DevTool.fromFunction()` to match that of `DevTool.run()`. The updated type is more permissive and should not be breaking. To illustrate:

```dart
FutureOr<int?> fnTest1(DevToolExecutionContext context) {}
FutureOr<int?> fnTest2(DevToolExecutionContext context) async {}
FutureOr<int>? fnTest3(DevToolExecutionContext context) {}
FutureOr<int>? fnTest4(DevToolExecutionContext context) async => 0;

void tests() {
  DevTool.fromFunction(fnTest1); // Previously a type error, now works.
  DevTool.fromFunction(fnTest2); // Previously a type error, now works.
  DevTool.fromFunction(fnTest3);
  DevTool.fromFunction(fnTest4);
}
```