### PR TITLE
Release dart_dev 4.0.1

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 4.0.0
+version: 4.0.1
 description: Centralized tooling for Dart projects. Consistent interface across projects. Easily configurable.
 homepage: https://github.com/Workiva/dart_dev
 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Fix type mismatch between `DevTool.fromFunction()` and `DevTool.run()`](https://github.com/Workiva/dart_dev/pull/407)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/4.0.0...Workiva:release_dart_dev_4.0.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/4.0.0...4.0.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)