### PR TITLE
Migrate away from specifying deprecated strong mode options

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,11 +4,9 @@ analyzer:
   exclude:
     - test/**/fixtures/**
   language:
+    strict-casts: true
     strict-inference: true
     strict-raw-types: true
-  strong-mode:
-    implicit-casts: true
-    implicit-dynamic: true
 
 linter:
   rules:

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -38,7 +38,7 @@ class DartDevRunner extends CommandRunner<int> {
   @override
   Future<int> run(Iterable<String> args) async {
     final argResults = parse(args);
-    if (argResults['version'] ?? false) {
+    if (argResults['version'] as bool? ?? false) {
       print(dartDevVersion);
       return 0;
     }

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -155,7 +155,7 @@ class CompoundArgParser implements ArgParser {
         _compoundParser.addFlag(option.name,
             abbr: option.abbr,
             help: option.help,
-            defaultsTo: option.defaultsTo,
+            defaultsTo: option.defaultsTo as bool?,
             negatable: option.negatable!,
             callback: (bool value) => option.callback?.call(value),
             hide: option.hide);
@@ -166,7 +166,7 @@ class CompoundArgParser implements ArgParser {
             valueHelp: option.valueHelp,
             allowed: option.allowed,
             allowedHelp: option.allowedHelp,
-            defaultsTo: option.defaultsTo,
+            defaultsTo: option.defaultsTo as Iterable<String>?,
             callback: (List<String> values) => option.callback?.call(values),
             splitCommas: option.splitCommas,
             hide: option.hide);
@@ -177,7 +177,7 @@ class CompoundArgParser implements ArgParser {
             valueHelp: option.valueHelp,
             allowed: option.allowed,
             allowedHelp: option.allowedHelp,
-            defaultsTo: option.defaultsTo,
+            defaultsTo: option.defaultsTo as String?,
             callback: (String? value) => option.callback?.call(value),
             hide: option.hide);
       }

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -627,9 +627,9 @@ void logCommand(
 /// If none of the mode flags were enabled, this returns `null`.
 FormatMode? validateAndParseMode(
     ArgResults argResults, void Function(String message) usageException) {
-  final check = argResults['check'] ?? false;
-  final dryRun = argResults['dry-run'] ?? false;
-  final overwrite = argResults['overwrite'] ?? false;
+  final check = argResults['check'] as bool? ?? false;
+  final dryRun = argResults['dry-run'] as bool? ?? false;
+  final overwrite = argResults['overwrite'] as bool? ?? false;
 
   if (check && dryRun && overwrite) {
     usageException(

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -143,7 +143,8 @@ List<String> buildArgs(
     // 1. Statically configured args from [WebdevServeTool.webdevArgs]
     ...?configuredWebdevArgs,
     // 2. The -r|--release flag
-    if (argResults != null && argResults['release']) '--release',
+    if (argResults != null && (argResults['release'] as bool? ?? false))
+      '--release',
     // 3. Args passed to --webdev-args
     ...?splitSingleOptionValue(argResults, 'webdev-args'),
   ];

--- a/lib/src/utils/arg_results_utils.dart
+++ b/lib/src/utils/arg_results_utils.dart
@@ -1,33 +1,39 @@
 import 'package:args/args.dart';
 
 bool? flagValue(ArgResults? argResults, String name) {
-  if (argResults == null || argResults[name] == null) {
+  final result = argResults?[name];
+  if (result == null) {
     return null;
   }
-  if (argResults[name] is! bool) {
+
+  if (result is! bool) {
     throw ArgumentError('Option "$name" is not a flag.');
   }
-  return argResults[name];
+  return result;
 }
 
 Iterable<String>? multiOptionValue(ArgResults? argResults, String name) {
-  if (argResults == null || argResults[name] == null) {
+  final result = argResults?[name];
+  if (result == null) {
     return null;
   }
-  if (argResults[name] is! Iterable<String>) {
+
+  if (result is! Iterable<String>) {
     throw ArgumentError('Option "$name" is not a multi-option.');
   }
-  return List<String>.from(argResults[name]);
+  return List<String>.from(result);
 }
 
 String? singleOptionValue(ArgResults? argResults, String name) {
-  if (argResults == null || argResults[name] == null) {
+  final result = argResults?[name];
+  if (result == null) {
     return null;
   }
-  if (argResults[name] is! String) {
+
+  if (result is! String) {
     throw ArgumentError('Option "$name" is not a single option.');
   }
-  return argResults[name];
+  return result;
 }
 
 Iterable<String>? splitSingleOptionValue(ArgResults? argResults, String name) =>

--- a/lib/src/utils/global_package_is_active_and_compatible.dart
+++ b/lib/src/utils/global_package_is_active_and_compatible.dart
@@ -29,7 +29,9 @@ bool globalPackageIsActiveAndCompatible(
         result.exitCode);
   }
 
-  for (final line in result.stdout.split('\n')) {
+  final output = result.stdout as String;
+
+  for (final line in output.split('\n')) {
     // Example line: "webdev 2.5.1" or "dart_dev 3.0.0 at path ..."
     final parts = line.split(' ');
     if (parts.length < 2 || parts[0] != packageName) {

--- a/lib/src/utils/verbose_enabled.dart
+++ b/lib/src/utils/verbose_enabled.dart
@@ -1,4 +1,4 @@
 import 'package:args/command_runner.dart';
 
 bool verboseEnabled(Command<dynamic> command) =>
-    command.globalResults!['verbose'] ?? false;
+    command.globalResults!['verbose'] as bool? ?? false;


### PR DESCRIPTION
The old `strong-mode` options are deprecated and planned for removal (https://github.com/dart-lang/sdk/issues/50679#issuecomment-1591992440). This PR removes the mentions of them and enables `strict-casts` which replaces and augments `implicit-casts: false`.