### PR TITLE
FEDX-518 Now that dart_dev itself is null-safe, it should be able to generate a null-safe run script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.0.3
+
+- Fix generation of the run script that the `dart_dev` CLI uses so that it can
+run with sound null safety (and thus run on Dart 3).
+
 ## 4.0.1
 
 - Fix type mismatch between the expected return type of the function passed to

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -107,9 +107,6 @@ bool get shouldWriteRunScript =>
     !_runScript.existsSync() ||
     _runScript.readAsStringSync() != buildDartDevRunScriptContents();
 
-/// Whether dart_dev itself has opted into null-safety.
-const _isDartDevNullSafe = false;
-
 String buildDartDevRunScriptContents() {
   final hasCustomToolDevDart = File(paths.config).existsSync();
   // If the config has a dart version comment (e.g., if it opts out of null safety),
@@ -117,11 +114,6 @@ String buildDartDevRunScriptContents() {
   var dartVersionComment = hasCustomToolDevDart
       ? getDartVersionComment(File(paths.config).readAsStringSync())
       : null;
-  // If dart_dev itself is not null-safe, opt the entrypoint out of null-safety
-  // so the entrypoint doesn't fail to run in packages that have opted into null-safety.
-  if (!_isDartDevNullSafe && dartVersionComment == null) {
-    dartVersionComment = '// @dart=2.9';
-  }
 
   return '''
 ${dartVersionComment ?? ''}


### PR DESCRIPTION
## Problem

When we migrated this package to null-safe, we missed some logic in our run script generation that would include a Dart language comment to set the language version to 2.9 by default. This prevents the null-safe dart_dev from being able to run on Dart 3 where null-safety is required.

## Solution

Remove this logic as it's no longer needed. We'll still copy over a language comment from `tool/dart_dev/config.dart` if one exists, otherwise we omit it which will allow dart_dev to run on Dart 3.