### PR TITLE
format_tool: optimization pass

### DIFF
--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -155,7 +155,7 @@ Future<void> runWithConfig(
           ' but it either does not exist or threw unexpectedly:')
       ..writeln('  $error')
       ..writeln()
-      ..writeln('For more info: http://github.com/Workiva/dart_dev#TODO');
+      ..writeln('For more info: https://github.com/Workiva/dart_dev');
     exitCode = ExitCode.config.code;
     return;
   }

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -465,11 +465,6 @@ FormatExecution buildExecution(
     return FormatExecution.exitEarly(ExitCode.config.code);
   }
 
-  if (inputs.skippedLinks?.isNotEmpty ?? false) {
-    _log.fine('Excluding these links from formatting:\n  '
-        '${inputs.skippedLinks!.join('\n  ')}');
-  }
-
   final dartFormatter = buildFormatProcess(formatter);
   Iterable<String> args;
   if (formatter == Formatter.dartFormat) {

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -183,7 +183,6 @@ class FormatTool extends DevTool {
     followLinks ??= false;
 
     final includedFiles = <String>{};
-    final skippedLinks = <String>{};
     exclude ??= <Glob>[];
 
     if (exclude.isEmpty && !expandCwd) {
@@ -199,7 +198,6 @@ class FormatTool extends DevTool {
 
       if (entry is Link) {
         _log.finer('skipping link $filename\n');
-        skippedLinks.add(filename);
         continue;
       }
 
@@ -211,18 +209,33 @@ class FormatTool extends DevTool {
       if (exclude.any((glob) => glob.matches(filename))) {
         _log.finer('excluding $filename\n');
       } else if (entry is File) {
-        _log.finest("adding $filename\n");
+        _log.finest('adding $filename\n');
         includedFiles.add(filename);
       }
     }
 
-    return FormatterInputs(includedFiles, skippedLinks: skippedLinks);
+    return FormatterInputs(includedFiles);
   }
 }
 
 class FormatterInputs {
-  FormatterInputs(this.includedFiles, {this.skippedLinks});
+  FormatterInputs(this.includedFiles,
+      {@deprecated this.excludedFiles,
+      @deprecated this.hiddenDirectories,
+      @deprecated this.skippedLinks});
+
   final Set<String> includedFiles;
+
+  // These fields are deprecated and are likely to be empty, due to
+  // performance optimizations made in
+  // https://github.com/Workiva/dart_dev/pull/424
+  @deprecated
+  final Set<String>? excludedFiles;
+
+  @deprecated
+  final Set<String>? hiddenDirectories;
+
+  @deprecated
   final Set<String>? skippedLinks;
 }
 

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -45,8 +45,6 @@ void main() {
       test('no excludes', () {
         final formatterInputs = FormatTool.getInputs(root: root);
         expect(formatterInputs.includedFiles, unorderedEquals({'.'}));
-        expect(formatterInputs.excludedFiles, null);
-        expect(formatterInputs.hiddenDirectories, null);
         expect(formatterInputs.skippedLinks, null);
       });
 
@@ -64,43 +62,10 @@ void main() {
               p.join('other', 'file.dart'),
             }));
 
-        expect(formatterInputs.excludedFiles,
-            unorderedEquals({'should_exclude.dart'}));
-        expect(formatterInputs.hiddenDirectories,
-            unorderedEquals({'.dart_tool_test'}));
         expect(
             formatterInputs.skippedLinks,
             unorderedEquals(
                 {p.join('links', 'lib-link'), p.join('links', 'link.dart')}));
-      });
-
-      test('custom excludes with collapseDirectories', () {
-        FormatterInputs formatterInputs = FormatTool.getInputs(
-          exclude: [Glob('*_exclude.dart')],
-          root: root,
-          collapseDirectories: true,
-        );
-
-        expect(
-          formatterInputs.includedFiles,
-          unorderedEquals({
-            'file.dart',
-            'lib',
-            'linked.dart',
-            'other',
-            'links',
-          }),
-        );
-
-        expect(
-          formatterInputs.excludedFiles,
-          unorderedEquals({'should_exclude.dart'}),
-        );
-        expect(
-          formatterInputs.hiddenDirectories,
-          unorderedEquals({'.dart_tool_test'}),
-        );
-        expect(formatterInputs.skippedLinks, isEmpty);
       });
 
       test('empty inputs due to excludes config', () async {
@@ -123,7 +88,6 @@ void main() {
               p.join('other', 'file.dart'),
               'should_exclude.dart',
             }));
-        expect(formatterInputs.excludedFiles, isEmpty);
       });
 
       test('followLinks follows linked files and directories', () async {
@@ -295,25 +259,6 @@ void main() {
       final execution = buildExecution(context,
           exclude: [Glob('**')], path: 'test/tools/fixtures/format/globs');
       expect(execution.exitCode, ExitCode.config.code);
-    });
-
-    test('logs the excluded paths and hidden directories', () async {
-      var currentLevel = Logger.root.level;
-      Logger.root.level = Level.FINE;
-      expect(
-          Logger.root.onRecord,
-          emitsInOrder([
-            fineLogOf(allOf(contains('Excluding these paths'),
-                contains('should_exclude.dart'))),
-            fineLogOf(allOf(contains('Excluding these hidden directories'),
-                contains('.dart_tool_test'))),
-          ]));
-
-      buildExecution(DevToolExecutionContext(),
-          exclude: [Glob('*_exclude.dart')],
-          path: 'test/tools/fixtures/format/globs');
-
-      Logger.root.level = currentLevel;
     });
 
     test('logs the skipped links', () async {

--- a/test/tools/format_tool_test.dart
+++ b/test/tools/format_tool_test.dart
@@ -45,7 +45,6 @@ void main() {
       test('no excludes', () {
         final formatterInputs = FormatTool.getInputs(root: root);
         expect(formatterInputs.includedFiles, unorderedEquals({'.'}));
-        expect(formatterInputs.skippedLinks, null);
       });
 
       test('custom excludes', () {
@@ -61,11 +60,6 @@ void main() {
               'linked.dart',
               p.join('other', 'file.dart'),
             }));
-
-        expect(
-            formatterInputs.skippedLinks,
-            unorderedEquals(
-                {p.join('links', 'lib-link'), p.join('links', 'link.dart')}));
       });
 
       test('empty inputs due to excludes config', () async {
@@ -100,7 +94,6 @@ void main() {
               'not_link.dart',
               'link.dart',
             }));
-        expect(formatterInputs.skippedLinks, isEmpty);
       });
     });
   });
@@ -259,23 +252,6 @@ void main() {
       final execution = buildExecution(context,
           exclude: [Glob('**')], path: 'test/tools/fixtures/format/globs');
       expect(execution.exitCode, ExitCode.config.code);
-    });
-
-    test('logs the skipped links', () async {
-      var currentLevel = Logger.root.level;
-      Logger.root.level = Level.FINE;
-      expect(
-          Logger.root.onRecord,
-          emitsInOrder([
-            fineLogOf(allOf(contains('Excluding these links'),
-                contains('lib-link'), contains('link.dart'))),
-          ]));
-
-      buildExecution(DevToolExecutionContext(),
-          exclude: [Glob('*_exclude.dart')],
-          path: 'test/tools/fixtures/format/globs/links');
-
-      Logger.root.level = currentLevel;
     });
 
     group('returns a FormatExecution', () {


### PR DESCRIPTION
We can save a lot (~90%) of execution time of `dart_dev format` on some repos with two changes:

 - Not recursing into directories that are a priori excluded from the formatter's list (e.g., hidden directories like .git). Note that this means we no longer build and log a comprehensive list of excluded files. I think it's worth it to run so much faster.

 - Removing the `collapseDirectories` feature, to be replaced with batch parallel invocations. Computing the collapsible directories was some kind of superlinear deduplication. This could maybe be optimized in a way that would allow it to remain, but it seems it was intended as a stopgap solution for argv limitations in the first place.

This is technically a breaking change to the API since we no longer return a full list of excluded files and hidden directories.
I have retained the `collapseDirectories` parameter in the name of backward compatibility for now, but it's ignored and marked `@deprecated`.

This moves the responsibility for handling argv limitations into `FormatTool`.