### PR TITLE
Compile the `dart_dev` run script for better performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 4.2.0
+
+- Add a `clean` command by default that removes temporary files used by
+dart_dev, like the compiled version of the run script.
+- Use `dart compile exe` to compile the `.dart_tool/dart_dev/run.dart` script
+for better startup performance on subsequent runs. This compilation step will be
+cached until `tool/dart_dev/config.dart`, the installed packages, or the current
+Dart SDK is changed.
+
+## 4.1.1
+
+- Optimization pass to reduce filesystem iteration.
+
 ## 4.1.0
 
 - Raise maximum SDK to include Dart 3.

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -2,14 +2,20 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
+import 'package:dart_dev/dart_dev.dart';
 
 import 'dart_dev_tool.dart';
 import 'events.dart' as events;
+import 'tools/clean_tool.dart';
 import 'utils/version.dart';
 
 class DartDevRunner extends CommandRunner<int> {
   DartDevRunner(Map<String, DevTool> commands)
       : super('dart_dev', 'Dart tool runner.') {
+    // For backwards-compatibility, only add the `clean` command if it doesn't
+    // conflict with any configured command.
+    commands.putIfAbsent('clean', () => CleanTool());
+
     commands.forEach((name, builder) {
       final command = builder.toCommand(name);
       if (command.name != name) {
@@ -17,6 +23,7 @@ class DartDevRunner extends CommandRunner<int> {
       }
       addCommand(command);
     });
+
     argParser
       ..addFlag('verbose',
           abbr: 'v', negatable: false, help: 'Enables verbose logging.')

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -14,7 +14,14 @@ class DartDevRunner extends CommandRunner<int> {
       : super('dart_dev', 'Dart tool runner.') {
     // For backwards-compatibility, only add the `clean` command if it doesn't
     // conflict with any configured command.
-    commands.putIfAbsent('clean', () => CleanTool());
+    if (!commands.containsKey('clean')) {
+      // Construct a new commands map here, to work around a runtime typecheck
+      // failure:
+      // `type 'CleanTool' is not a subtype of type 'FormatTool' of 'value'`
+      // As seen in this CI run:
+      // https://github.com/Workiva/dart_dev/actions/runs/8161855516/job/22311519665?pr=426#step:8:295
+      commands = <String, DevTool>{...commands, 'clean': CleanTool()};
+    }
 
     commands.forEach((name, builder) {
       final command = builder.toCommand(name);

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -192,7 +192,8 @@ List<String> generateRunScript() {
   }
 
   return runExecutable.existsSync()
-      ? [runExecutable.path]
+      // Using the absolute path is necessary for Windows to find the executable.
+      ? [runExecutable.absolute.path]
       : [Platform.executable, 'run', _paths.runScript];
 }
 

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -118,7 +118,7 @@ bool _allPackagesAreImportedImmutably(Iterable<String> packageNames) {
   final pubSpecLock = loadYamlDocument(pubspecLockFile.readAsStringSync());
   return getDependencySources(pubSpecLock, packageNames)
       .values
-      .every((source) => source == 'hosted');
+      .every((source) => source == 'hosted' || source == 'git');
 }
 
 /// Return null iff it is not possible to account for all

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -150,7 +150,7 @@ List<String> generateRunScript() {
     final packageConfig = File(_paths.packageConfig);
 
     final digest = md5.convert([
-      ...packageConfig.readAsBytesSync(),
+      if (packageConfig.existsSync()) ...packageConfig.readAsBytesSync(),
       if (configFile.existsSync()) ...configFile.readAsBytesSync(),
       if (configHasRelativeImports)
         for (final file in Glob('tool/**.dart', recursive: true)

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -128,9 +128,10 @@ List<String> generateRunScript() {
           RegExp(r'''^import ['"][^:]+$''', multiLine: true).hasMatch(contents);
       final currentPackageName =
           Pubspec.parse(File('pubspec.yaml').readAsStringSync()).name;
-      configHasSamePackageImports =
-          RegExp('''^import ['"]package:$currentPackageName\/''', multiLine: true)
-              .hasMatch(contents);
+      configHasSamePackageImports = RegExp(
+              '''^import ['"]package:$currentPackageName\/''',
+              multiLine: true)
+          .hasMatch(contents);
     }
 
     if (configHasSamePackageImports) {

--- a/lib/src/tools/clean_tool.dart
+++ b/lib/src/tools/clean_tool.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:io/io.dart';
+
+import '../dart_dev_tool.dart';
+import '../utils/dart_dev_paths.dart' show DartDevPaths;
+
+class CleanTool extends DevTool {
+  @override
+  final String? description = 'Cleans up temporary files used by dart_dev.';
+
+  @override
+  FutureOr<int?> run([DevToolExecutionContext? context]) {
+    final cache = Directory(DartDevPaths().cache());
+    if (cache.existsSync()) {
+      cache.deleteSync(recursive: true);
+    }
+    return ExitCode.success.code;
+  }
+}

--- a/lib/src/tools/clean_tool.dart
+++ b/lib/src/tools/clean_tool.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:dart_dev/src/utils/logging.dart';
 import 'package:io/io.dart';
 
 import '../dart_dev_tool.dart';
@@ -14,7 +15,10 @@ class CleanTool extends DevTool {
   FutureOr<int?> run([DevToolExecutionContext? context]) {
     final cache = Directory(DartDevPaths().cache());
     if (cache.existsSync()) {
+      log.info('Deleting ${cache.path}');
       cache.deleteSync(recursive: true);
+    } else {
+      log.info('Nothing to do: no ${cache.path} found');
     }
     return ExitCode.success.code;
   }

--- a/lib/src/utils/dart_dev_paths.dart
+++ b/lib/src/utils/dart_dev_paths.dart
@@ -28,4 +28,8 @@ class DartDevPaths {
   String get legacyConfig => _context.join('tool', 'dev.dart');
 
   String get runScript => cache('run.dart');
+
+  String get runExecutable => cache('run');
+
+  String get runExecutableDigest => cache('run.digest');
 }

--- a/lib/src/utils/dart_dev_paths.dart
+++ b/lib/src/utils/dart_dev_paths.dart
@@ -25,6 +25,8 @@ class DartDevPaths {
         from: p.url.absolute(_cacheForDart),
       );
 
+  String get packageConfig => _context.join('.dart_tool', 'package_config.json');
+
   String get legacyConfig => _context.join('tool', 'dev.dart');
 
   String get runScript => cache('run.dart');

--- a/lib/src/utils/dart_dev_paths.dart
+++ b/lib/src/utils/dart_dev_paths.dart
@@ -25,7 +25,8 @@ class DartDevPaths {
         from: p.url.absolute(_cacheForDart),
       );
 
-  String get packageConfig => _context.join('.dart_tool', 'package_config.json');
+  String get packageConfig =>
+      _context.join('.dart_tool', 'package_config.json');
 
   String get legacyConfig => _context.join('tool', 'dev.dart');
 

--- a/lib/src/utils/parse_imports.dart
+++ b/lib/src/utils/parse_imports.dart
@@ -4,7 +4,15 @@ import 'package:collection/collection.dart';
 /// file. Not 100% accurate, since we use regular expressions instead of the
 /// Dart AST to extract the imports.
 Iterable<String> parseImports(String fileContents) =>
-    RegExp(r'''^import ['"]([^'"]+)['"];?$''', multiLine: true)
-        .allMatches(fileContents)
-        .map((m) => m.group(1))
-        .whereNotNull();
+    _importRegex.allMatches(fileContents).map((m) => m.group(1)).whereNotNull();
+
+final _importRegex =
+    RegExp(r'''^import ['"]([^'"]+)['"];?$''', multiLine: true);
+
+/// Return a set of package names given a list of imports.
+Set<String> computePackageNamesFromImports(Iterable<String> imports) => imports
+    .map((i) => _packageNameFromImportRegex.matchAsPrefix(i)?.group(1))
+    .whereNotNull()
+    .toSet();
+
+final _packageNameFromImportRegex = RegExp(r'package:([^/]+)/.+');

--- a/lib/src/utils/parse_imports.dart
+++ b/lib/src/utils/parse_imports.dart
@@ -1,0 +1,10 @@
+import 'package:collection/collection.dart';
+
+/// Return the contents of the enquoted portion of the import statements in the
+/// file. Not 100% accurate, since we use regular expressions instead of the
+/// Dart AST to extract the imports.
+Iterable<String> parseImports(String fileContents) =>
+    RegExp(r'''^import ['"]([^'"]+)['"];?$''', multiLine: true)
+        .allMatches(fileContents)
+        .map((m) => m.group(1))
+        .whereNotNull();

--- a/lib/src/utils/pubspec_lock.dart
+++ b/lib/src/utils/pubspec_lock.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+
 import 'package:yaml/yaml.dart';
 
 /// Index into the pubspecLock to locate the 'source' field for the given

--- a/lib/src/utils/pubspec_lock.dart
+++ b/lib/src/utils/pubspec_lock.dart
@@ -1,0 +1,26 @@
+import 'dart:collection';
+import 'package:yaml/yaml.dart';
+
+/// Index into the pubspecLock to locate the 'source' field for the given
+/// package.
+String? _getPubSpecLockPackageSource(
+    YamlDocument pubSpecLock, String packageName) {
+  final contents = pubSpecLock.contents;
+  if (contents is YamlMap) {
+    final packages = contents['packages'];
+    if (packages is YamlMap) {
+      final specificDependency = packages[packageName];
+      if (specificDependency is YamlMap) return specificDependency['source'];
+    }
+  }
+  return null;
+}
+
+/// Return a mapping of package name to dependency 'type', using the pubspec
+/// lock document. If a package cannot be located in the pubspec lock document,
+/// it will map to null.
+HashMap<String, String?> getDependencySources(
+        YamlDocument pubspecLockDocument, Iterable<String> packageNames) =>
+    HashMap.fromIterable(packageNames,
+        value: (name) =>
+            _getPubSpecLockPackageSource(pubspecLockDocument, name));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   args: ^2.0.0
   async: ^2.5.0
   build_runner: ^2.0.0
+  crypto: ^3.0.1
   glob: ^2.0.0
   io: ^1.0.0
   logging: ^1.0.0

--- a/test/utils/parse_imports_test.dart
+++ b/test/utils/parse_imports_test.dart
@@ -1,0 +1,59 @@
+import 'package:dart_dev/src/utils/parse_imports.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group(
+      'parseImports',
+      () => {
+            test('correctly returns all imports', () {
+              final parsedImports = parseImports(sampleFile);
+              expect(
+                  parsedImports,
+                  equals([
+                    'dart:async',
+                    'dart:convert',
+                    'dart:io',
+                    'package:analyzer/dart/analysis/utilities.dart',
+                    'package:dart_dev/dart_dev.dart',
+                    'package:dart_dev/src/tools/over_react_format_tool.dart',
+                    'package:dart_dev/src/utils/format_tool_builder.dart',
+                    'package:test/test.dart',
+                    'utils/assert_dir_is_dart_package.dart',
+                    'utils/cached_pubspec.dart',
+                    'utils/dart_dev_paths.dart',
+                  ]));
+            })
+          });
+}
+
+const sampleFile = '''
+@TestOn('vm')
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:analyzer/dart/analysis/utilities.dart';
+import 'package:dart_dev/dart_dev.dart';
+import 'package:dart_dev/src/tools/over_react_format_tool.dart';
+import 'package:dart_dev/src/utils/format_tool_builder.dart';
+import 'package:test/test.dart';
+
+import 'utils/assert_dir_is_dart_package.dart';
+import 'utils/cached_pubspec.dart';
+import 'utils/dart_dev_paths.dart';
+
+void main() {
+  group('FormatToolBuilder', () {
+    group('detects an OverReactFormatTool correctly', () {
+      test('when the tool is a MethodInvocation', () {
+        final visitor = FormatToolBuilder();
+
+        parseString(content: orfNoCascadeSrc).unit.accept(visitor);
+
+        expect(visitor.formatDevTool, isNotNull);
+        expect(visitor.formatDevTool, isA<OverReactFormatTool>());
+      });
+    });
+  });
+}
+''';

--- a/test/utils/parse_imports_test.dart
+++ b/test/utils/parse_imports_test.dart
@@ -2,28 +2,30 @@ import 'package:dart_dev/src/utils/parse_imports.dart';
 import 'package:test/test.dart';
 
 void main() {
+  final expectedImportList = [
+    'dart:async',
+    'dart:convert',
+    'dart:io',
+    'package:analyzer/dart/analysis/utilities.dart',
+    'package:dart_dev/dart_dev.dart',
+    'package:dart_dev/src/tools/over_react_format_tool.dart',
+    'package:dart_dev/src/utils/format_tool_builder.dart',
+    'package:test/test.dart',
+    'utils/assert_dir_is_dart_package.dart',
+    'utils/cached_pubspec.dart',
+    'utils/dart_dev_paths.dart',
+  ];
   group(
       'parseImports',
-      () => {
-            test('correctly returns all imports', () {
-              final parsedImports = parseImports(sampleFile);
-              expect(
-                  parsedImports,
-                  equals([
-                    'dart:async',
-                    'dart:convert',
-                    'dart:io',
-                    'package:analyzer/dart/analysis/utilities.dart',
-                    'package:dart_dev/dart_dev.dart',
-                    'package:dart_dev/src/tools/over_react_format_tool.dart',
-                    'package:dart_dev/src/utils/format_tool_builder.dart',
-                    'package:test/test.dart',
-                    'utils/assert_dir_is_dart_package.dart',
-                    'utils/cached_pubspec.dart',
-                    'utils/dart_dev_paths.dart',
-                  ]));
-            })
-          });
+      () => test('correctly returns all imports',
+          () => expect(parseImports(sampleFile), equals(expectedImportList))));
+
+  group(
+      'computePackageNamesFromImports',
+      () => test(
+          'correctly computes package names from imports',
+          () => expect(computePackageNamesFromImports(expectedImportList),
+              equals(['analyzer', 'dart_dev', 'test']))));
 }
 
 const sampleFile = '''


### PR DESCRIPTION
This PR adapted from a 2021 PR by @evanweible-wf: https://github.com/Workiva/dart_dev/pull/363. See that PR for discussion and performance metrics.

My changes:
- Merge conflicts resolved.
- Most code review comments addressed.
- Misc cleanup and rearrangement to bring this branch in line with since-merged refactors (most notably the refactor of path usage performed in https://github.com/Workiva/dart_dev/pull/386; specifically 1ad8316217a1e2762fc32e1ca2abb60eb4e49e5d).

Functionality changes described below.

---

After compilation, the startup time for subsequent `dart run dart_dev` commands should be significantly improved.

This compiled exectuable is cached in `.dart_tool/dart_dev/` along with a digest that is used to determine when recompilation is needed.

Packages with `tool/dart_dev/config.dart` files that import from their own package's source files will be opted out of this compilation optimization because there is no efficient way to track those imports for the purpose of detecting the need to recompile.

This commit also adds a `clean` subcommand to `dart run dart_dev` that will remove the files in `.dart_tool/dart_dev/`, in case a bug is found in our compilation caching logic.