### PR TITLE
RM-242322 Release dart_dev 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ dart_dev, like the compiled version of the run script.
 for better startup performance on subsequent runs. This compilation step will be
 cached until `tool/dart_dev/config.dart`, the installed packages, or the current
 Dart SDK is changed.
+- Updated dependencies to allow analyzer 6, lints 4
+- Require Dart SDK minimum of 2.19
 
 ## 4.1.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 4.1.1
+version: 4.2.0
 description: >
   Centralized tooling for Dart projects. 
   Consistent interface across projects. 


### PR DESCRIPTION

Pull Requests included in release:
* Minor changes:
	* [Compile the `dart_dev` run script for better performance](https://github.com/Workiva/dart_dev/pull/426)
* Patch changes:
	* [Minor pubspec and readme cleanup](https://github.com/Workiva/dart_dev/pull/411)
	* [FEDX-684 Finish GHA](https://github.com/Workiva/dart_dev/pull/427)
	* [FEDX-1094: Use full Apache 2.0 license text; move attributions to NOTICE](https://github.com/Workiva/dart_dev/pull/429)
	* [fedx_codeowners_file](https://github.com/Workiva/dart_dev/pull/430)
	* [Upgrade deps for Dart 3](https://github.com/Workiva/dart_dev/pull/432)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/4.1.1...Workiva:release_dart_dev_4.2.0
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/4.1.1...4.2.0

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?repo_name=Workiva%2Fdart_dev&pull_number=433)