### PR TITLE
FEDX-1595: implemented gha-dart-oss publish

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,19 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
 updates:
-  - package-ecosystem: "pub" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 2
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
+      interval: weekly
+    groups:
+      gha:
+        patterns: ["*"]
+
+  - package-ecosystem: pub
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      major:
+        update-types: ["major"]
+      minor:
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - 'master'
       - 'test_consume_*'
-  pull_request:
-    branches:
-      - '**'
 
 permissions:
   pull-requests: write
@@ -15,6 +13,12 @@ permissions:
   id-token: write
 
 jobs:
+  build:
+    uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
+
+  checks:
+    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
+
   dart:
     strategy:
       fail-fast: false
@@ -30,18 +34,5 @@ jobs:
           sdk: ${{ matrix.sdk }}
       - name: Install dependencies
         run: dart pub get
-      - name: Validate dependencies
-        run: dart run dependency_validator
-      - name: Analysis
-        run: dart run dart_dev analyze
-      - name: Formatting
-        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
-        run: dart run dart_dev format --check
       - name: Tests
         run: dart run dart_dev test ${{ matrix.sdk != '2.19.6' && '--test-args="--exclude-tags dart2"' || '' }}
-      - name: SBOM
-        if: ${{ matrix.sdk == '2.19.6' && matrix.os == 'ubuntu' }}
-        uses: anchore/sbom-action@v0
-        with:
-          path: ./  # Assuming actions/checkout default location
-          format: cyclonedx-json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
   build:
     uses: Workiva/gha-dart-oss/.github/workflows/build.yaml@v0.1.5
 
-  checks:
-    uses: Workiva/gha-dart-oss/.github/workflows/checks.yaml@v0.1.5
-
   dart:
     strategy:
       fail-fast: false
@@ -34,5 +31,12 @@ jobs:
           sdk: ${{ matrix.sdk }}
       - name: Install dependencies
         run: dart pub get
+      - name: Validate dependencies
+        run: dart run dependency_validator
+      - name: Analysis
+        run: dart run dart_dev analyze
+      - name: Formatting
+        if: ${{ matrix.sdk == 'stable' && matrix.os == 'ubuntu' }}
+        run: dart run dart_dev format --check
       - name: Tests
         run: dart run dart_dev test ${{ matrix.sdk != '2.19.6' && '--test-args="--exclude-tags dart2"' || '' }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,15 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+  id-token: write
+  pull-requests: write
+
+jobs:
+  publish:
+    uses: Workiva/gha-dart-oss/.github/workflows/publish.yaml@v0.1.5


### PR DESCRIPTION
# [FEDX-1595](https://jira.atl.workiva.net/browse/FEDX-1595)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1595)

Implements gha-dart-oss for publish and other stuff

Notably checks and tests are not implemented because gha-dart-oss wont correctly use dart_dev to run analysis within dart_dev itself