### PR TITLE
FEDX-1727: Support `organizeDirectives` config via `hackFastFormat`

### DIFF
--- a/lib/src/tools/over_react_format_tool.dart
+++ b/lib/src/tools/over_react_format_tool.dart
@@ -13,6 +13,11 @@ class OverReactFormatTool extends DevTool {
   /// Default is 80.
   int? lineLength;
 
+  /// Whether or not to organize import/export directives.
+  ///
+  /// Default is false.
+  bool? organizeDirectives;
+
   @override
   String? description =
       'Format dart files in this package with over_react_format.';
@@ -31,7 +36,8 @@ class OverReactFormatTool extends DevTool {
     final args = [
       'run',
       'over_react_format',
-      if (lineLength != null) '--line-length=$lineLength'
+      if (lineLength != null) '--line-length=$lineLength',
+      if (organizeDirectives == true) '--organize-directives',
     ];
     final process = ProcessDeclaration(exe.dart, [...args, ...paths],
         mode: ProcessStartMode.inheritStdio);

--- a/lib/src/utils/format_tool_builder.dart
+++ b/lib/src/utils/format_tool_builder.dart
@@ -88,6 +88,17 @@ class FormatToolBuilder extends GeneralizingAstVisitor<void> {
             logWarningMessageFor(KnownErrorOutcome.failedToParseFormatterArgs);
           }
         }
+
+        final organizeDirectives = getCascadeByProperty('organizeDirectives');
+        if (organizeDirectives != null) {
+          final valueExpression = organizeDirectives.rightHandSide;
+          if (valueExpression is BooleanLiteral) {
+            typedFormatDevTool.organizeDirectives = valueExpression.value;
+          } else {
+            logWarningMessageFor(
+                KnownErrorOutcome.failedToParseOrganizeDirective);
+          }
+        }
       } else if (typedFormatDevTool is OverReactFormatTool) {
         final lineLengthAssignment = getCascadeByProperty('lineLength');
         if (lineLengthAssignment != null) {
@@ -96,6 +107,18 @@ class FormatToolBuilder extends GeneralizingAstVisitor<void> {
             typedFormatDevTool.lineLength = lengthExpression.value;
           } else {
             logWarningMessageFor(KnownErrorOutcome.failedToParseLineLength);
+          }
+        }
+
+        final organizeDirectivesAssignment =
+            getCascadeByProperty('organizeDirectives');
+        if (organizeDirectivesAssignment != null) {
+          final valueExpression = organizeDirectivesAssignment.rightHandSide;
+          if (valueExpression is BooleanLiteral) {
+            typedFormatDevTool.organizeDirectives = valueExpression.value;
+          } else {
+            logWarningMessageFor(
+                KnownErrorOutcome.failedToParseOrganizeDirective);
           }
         }
       }
@@ -108,6 +131,7 @@ enum KnownErrorOutcome {
   failedToReconstructFormatterArgs,
   failedToParseFormatterArgs,
   failedToParseLineLength,
+  failedToParseOrganizeDirective,
 }
 
 void logWarningMessageFor(KnownErrorOutcome outcome) {
@@ -137,6 +161,12 @@ This is likely because the list is not a ListLiteral.
       errorMessage = '''Failed to parse the line-length configuration.
 
 This is likely because assignment does not use an IntegerLiteral.
+''';
+      break;
+    case KnownErrorOutcome.failedToParseOrganizeDirective:
+      errorMessage = '''Failed to parse the organizeDirectives configuration.
+
+This is likely because assignment does not use an BooleanLiteral.
 ''';
       break;
   }


### PR DESCRIPTION
# [FEDX-1727](https://jira.atl.workiva.net/browse/FEDX-1727)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1727)

The `hackFastFormat` command is used by some of our dev tooling like IDE auto-formatting and precommit hooks. It does not currently support organizing directives, whereas the full `format` command does.

This PR updates `hackFastFormat` to check the project's ddev config to see if it has enabled `organizeDirectives`, and if so, it ensures that the format tool it sets up matches that configuration. In other words, `hackFastFormat` should now respect the `organizeDirectives` configuration of the project it is running in, which should allow IDE auto-formatting and precommit hooks that use `hackFastFormat` to match behavior of running `ddev format`.