### PR TITLE
RM-281924 Release dart_dev 4.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 4.2.1
+
+- Update `hackFastFormat` to detect and respect the project's
+`organizeDirectives` configuration.
+
 ## 4.2.0
 
 - Add a `clean` command by default that removes temporary files used by

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 4.2.0
+version: 4.2.1
 description: >
   Centralized tooling for Dart projects. 
   Consistent interface across projects. 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [FEDX-1595: implemented gha-dart-oss publish](https://github.com/Workiva/dart_dev/pull/434)
	* [FEDX-1727: Support `organizeDirectives` config via `hackFastFormat`](https://github.com/Workiva/dart_dev/pull/438)


Requested by: @evanweible-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/4.2.0...Workiva:release_dart_dev_4.2.1
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/4.2.0...4.2.1

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?repo_name=Workiva%2Fdart_dev&pull_number=440)