### PR TITLE
Fix webdev version check for Dart 3

### DIFF
--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:dart_dev/src/utils/dart_semver_version.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
@@ -213,15 +214,19 @@ WebdevServeExecution buildExecution(
             'Arguments can be passed to the build process via the --build-args '
             'option.');
   }
+
+  final webdevVersion = dartSemverVersion.major == 2 ? '^2.0.0' : '^3.0.0';
+
   if (!globalPackageIsActiveAndCompatible(
-      'webdev', VersionConstraint.parse('^2.0.0'),
+      'webdev', VersionConstraint.parse(webdevVersion),
       environment: environment)) {
     _log.severe(red.wrap(
             '${styleBold.wrap('webdev serve')} could not run for this project.\n')! +
         yellow.wrap('You must have `webdev` globally activated:\n'
-            '  dart pub global activate webdev ^2.0.0')!);
+            '  dart pub global activate webdev ${webdevVersion}')!);
     return WebdevServeExecution.exitEarly(ExitCode.config.code);
   }
+
   final args = buildArgs(
       argResults: argResults,
       configuredBuildArgs: configuredBuildArgs,

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:dart_dev/src/utils/dart_semver_version.dart';
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
 import 'package:logging/logging.dart';
@@ -11,6 +10,7 @@ import 'package:pub_semver/pub_semver.dart';
 import '../dart_dev_tool.dart';
 import '../utils/arg_results_utils.dart';
 import '../utils/assert_no_positional_args_nor_args_after_separator.dart';
+import '../utils/dart_semver_version.dart';
 import '../utils/executables.dart' as exe;
 import '../utils/global_package_is_active_and_compatible.dart';
 import '../utils/logging.dart';

--- a/test/tools/webdev_serve_tool_test.dart
+++ b/test/tools/webdev_serve_tool_test.dart
@@ -3,6 +3,7 @@ import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:dart_dev/src/dart_dev_tool.dart';
 import 'package:dart_dev/src/tools/webdev_serve_tool.dart';
+import 'package:dart_dev/src/utils/dart_semver_version.dart';
 import 'package:dart_dev/src/utils/executables.dart' as exe;
 import 'package:io/ansi.dart';
 import 'package:io/io.dart';
@@ -138,7 +139,7 @@ void main() {
 
     setUpAll(() {
       pubCacheWithWebdev = TempPubCache();
-      globalActivate('webdev', '^2.0.0',
+      globalActivate('webdev', '^${dartSemverVersion.major}.0.0',
           environment: pubCacheWithWebdev.envOverride);
 
       pubCacheWithoutWebdev = TempPubCache();
@@ -180,7 +181,8 @@ void main() {
             Logger.root.onRecord,
             emitsThrough(severeLogOf(allOf(
                 contains('webdev serve could not run'),
-                contains('dart pub global activate webdev ^2.0.0')))));
+                contains(
+                    'dart pub global activate webdev ^${dartSemverVersion.major}.0.0')))));
 
         expect(
             buildExecution(DevToolExecutionContext(),


### PR DESCRIPTION
# Summary

When running dart run dart_dev serve under Dart 3, it checks that webdev is installed, but it insists on webdev ^2.0.0. Dor Dart 3, only webdev ^3.0.0 resolves. 

# Changes
Switch the version to check for based on the version of Dart being run. For Dart 2, use ^2.0.0 and Dart 3 use ^3.0.0 of webdev.
