### PR TITLE
RM-291603 Release dart_dev 4.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.2.2
+- For Dart 3x, use webdev ^3 for the serve task
+
 ## 4.2.1
 
 - Update `hackFastFormat` to detect and respect the project's

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 4.2.1
+version: 4.2.2
 description: >
   Centralized tooling for Dart projects. 
   Consistent interface across projects. 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Fix webdev version check for Dart 3](https://github.com/Workiva/dart_dev/pull/442)


Requested by: @robbecker-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/4.2.1...Workiva:release_dart_dev_4.2.2
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/4.2.1...4.2.2

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?repo_name=Workiva%2Fdart_dev&pull_number=443)