### PR TITLE
FEDX-1952: Fixed bug with organizeDirectives and LanguageVersion comment

### DIFF
--- a/lib/src/utils/organize_directives/organize_directives.dart
+++ b/lib/src/utils/organize_directives/organize_directives.dart
@@ -133,8 +133,15 @@ void _assignCommentsBeforeTokenToNamespace(
   for (Token? comment = token.precedingComments;
       comment != null;
       comment = comment.next) {
+    // the LanguageVersionToken (`// @dart=2.11`) must stay where it is at
+    // the top of the file. Do not assign this to any namespace
+    if (comment is LanguageVersionToken) continue;
+
     if (_commentIsOnSameLineAsNamespace(
-        comment, prevNamespace, sourceFileContents)) {
+      comment,
+      prevNamespace,
+      sourceFileContents,
+    )) {
       prevNamespace!.afterComments.add(comment);
     } else if (currNamespace != null) {
       currNamespace.beforeComments.add(comment);

--- a/test/tools/fixtures/organize_directives/directives.dart
+++ b/test/tools/fixtures/organize_directives/directives.dart
@@ -569,11 +569,11 @@ const unorganized19 = '''
 /* Multi-line comment 3 */
 import 'dart:html';
 /* Multi-line comment 4 */
-/* 
-Multi-line comment 5 
+/*
+Multi-line comment 5
 */
 import 'dart:typed_data';
-/* 
+/*
  Multi-line comment 1
 */
 /* Multi-line comment 2 */
@@ -585,7 +585,7 @@ void main() {
 ''';
 
 const organized19 = '''
-/* 
+/*
  Multi-line comment 1
 */
 /* Multi-line comment 2 */
@@ -593,8 +593,8 @@ import 'dart:async';
 /* Multi-line comment 3 */
 import 'dart:html';
 /* Multi-line comment 4 */
-/* 
-Multi-line comment 5 
+/*
+Multi-line comment 5
 */
 import 'dart:typed_data';
 
@@ -868,4 +868,19 @@ export 'package:dart_dev/dart_dev.dart'
         Type2, // comment
         Type3, // comment
         Type4;
+''';
+
+const unorganized32 = '''
+// @dart=2.11
+
+import 'package:c_package/c_package.dart';
+
+import 'package:a_package/a_package.dart';
+''';
+
+const organized32 = '''
+// @dart=2.11
+
+import 'package:a_package/a_package.dart';
+import 'package:c_package/c_package.dart';
 ''';

--- a/test/utils/organize_imports/organize_directives_test.dart
+++ b/test/utils/organize_imports/organize_directives_test.dart
@@ -108,6 +108,7 @@ void main() {
       organized30,
     ),
     _TestCase('31. comments with exports', unorganized31, organized31),
+    _TestCase('32. with dart version comment', unorganized32, organized32),
   ];
 
   group('organizeDirectives', () {


### PR DESCRIPTION
# [FEDX-1952](https://jira.atl.workiva.net/browse/FEDX-1952)
![Issue Status](https://h.plat-dev.workiva.org/s/wk-backend/jira/status/FEDX-1952)

## Issue
An issue with `organizeDirectives` and the `// @dart=2.11` comment was discovered:

Given the following input:
```dart
// @dart=2.11
import 'package:c_package/c_package.dart';
import 'package:a_package/a_package.dart';
```

The result would be

```dart
import 'package:a_package/a_package.dart';
// @dart=2.11
import 'package:c_package/c_package.dart';
```

This is a problem as the `// @dart=2.11` header _must_ be at the top of the file

## Reason
When `organizeDirectives` runs, it tries to figure out what comments are linked with which directives. It does this using each token's `precedingComments`, which essentially just selects all whitespace/comments before a line

When the above example is ran, the `// @dart=2.11` comment is considered apart of `c_package` and moved along with it

## Solution
This pr simply ignores this "language version comment" from being included in the list of comments that organize directives can include with a directive
