### PR TITLE
Work around invalid override error when args 2.7.0 is pulled in (Dart 3.3+ only issue)

### DIFF
--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -266,12 +266,15 @@ class CompoundArgParser implements ArgParser {
           bool negatable = true,
           void Function(bool value)? callback,
           bool hide = false,
+          bool hideNegatedUsage = false,
           List<String> aliases = const []}) =>
       _compoundParser.addFlag(name,
           abbr: abbr,
           help: help,
           defaultsTo: defaultsTo,
           negatable: negatable,
+          // TODO once lower bound of args is 2.7.0 (requires Dart SDK 3.3.0), which adds hideNegatedUsage, forward this arg
+          // hideNegatedUsage: hideNegatedUsage,
           callback: callback,
           hide: hide,
           aliases: aliases);


### PR DESCRIPTION
## Motivation
The `args` package just released [2.7.0](https://pub.dev/packages/args/changelog#270), which adds an optional param in `ArgParser.flag`.

> Added option hideNegatedUsage to ArgParser.flag() allowing a flag to be negatable without showing it in the usage text.

This breaks dart_dev's override of this method, resulting in the following errors when attempting to analyze or run dart_dev code:
```
lib/src/tools/compound_tool.dart:262:8: Error: The method 'CompoundArgParser.addFlag' has fewer named arguments than those of overridden method 'ArgParser.addFlag'.
  void addFlag(String name,
       ^
/C:/Users/runneradmin/.pub-cache/hosted/pub.dev/args-2.7.0/lib/src/arg_parser.dart:134:8: Context: This is the overridden method ('addFlag').
  void addFlag(String name,
       ^
lib/src/tools/compound_tool.dart:262:8: Error: The method 'CompoundArgParser.addFlag' doesn't have the named parameter 'hideNegatedUsage' of overridden method 'ArgParser.addFlag'.
  void addFlag(String name,
       ^
/C:/Users/runneradmin/.pub-cache/hosted/pub.dev/args-2.7.0/lib/src/arg_parser.dart:[13](https://github.com/Workiva/dart_dev/actions/runs/13846410206/job/38745674756?pr=449#step:6:14)4:8: Context: This is the overridden method ('addFlag').
  void addFlag(String name,
```

This can be seen in the "Dart stable" CI runs here: https://github.com/Workiva/dart_dev/pull/449

Note that this version of `args` has an SDK constraint of `>=3.3.0`, so this only affects Dart 3 consumers.

## Solution
Add an arg of the same name to fix the analysis error.

Unless we want to constrain ourselves to args `>= 2.7.0` (and as a result Dart `>=3.3.0`), we're unable to forward this argument, but since this new argument isn't critical, ignoring it for now seemed like a worthwhile tradeoff

## Testing
CI passes in all Dart versions