### PR TITLE
RM-295281 Release dart_dev 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 4.2.3
+
+- Fixed bug where `organizeDirectives` would incorrectly sort directives when `// @dart=x.xx` 
+was at the start of the file
+- Fixed analyzer issues cased by args 2.7.0
+
 ## 4.2.2
 - For Dart 3x, use webdev ^3 for the serve task
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: dart_dev
-version: 4.2.2
+version: 4.2.3
 description: >
   Centralized tooling for Dart projects. 
   Consistent interface across projects. 


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Bump lints from 4.0.0 to 5.0.0 in the major group](https://github.com/Workiva/dart_dev/pull/439)
	* [Bump Workiva/gha-dart-oss from 0.1.5 to 0.1.7 in the gha group across 1 directory](https://github.com/Workiva/dart_dev/pull/441)
	* [FEDX-1952: Fixed bug with organizeDirectives and LanguageVersion comment](https://github.com/Workiva/dart_dev/pull/444)
	* [Work around invalid override error when args 2.7.0 is pulled in (Dart 3.3+ only issue)](https://github.com/Workiva/dart_dev/pull/448)


Requested by: @matthewnitschke-wk

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/dart_dev/compare/4.2.2...Workiva:release_dart_dev_4.2.3
Diff Between Last Tag and New Tag: https://github.com/Workiva/dart_dev/compare/4.2.2...4.2.3

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/6691996821356544/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/6691996821356544/?repo_name=Workiva%2Fdart_dev&pull_number=450)