### PR TITLE
no_entrypoint_imports

### DIFF
--- a/lib/src/core_config.dart
+++ b/lib/src/core_config.dart
@@ -3,7 +3,7 @@
 /// command-line usage across Dart projects.
 library dart_dev.src.core_config;
 
-import 'package:dart_dev/dart_dev.dart';
+
 
 Map<String, DevTool> get coreConfig => {
       'analyze': AnalyzeTool(),

--- a/lib/src/dart_dev_runner.dart
+++ b/lib/src/dart_dev_runner.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:dart_dev/dart_dev.dart';
+
 
 import 'dart_dev_tool.dart';
 import 'events.dart' as events;

--- a/lib/src/dart_dev_tool.dart
+++ b/lib/src/dart_dev_tool.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
-import 'package:dart_dev/dart_dev.dart';
+
 
 import 'tools/function_tool.dart';
 import 'utils/verbose_enabled.dart';

--- a/lib/src/executable.dart
+++ b/lib/src/executable.dart
@@ -6,7 +6,7 @@ import 'package:analyzer/dart/analysis/utilities.dart';
 import 'package:args/command_runner.dart';
 import 'package:collection/collection.dart';
 import 'package:crypto/crypto.dart';
-import 'package:dart_dev/dart_dev.dart';
+
 import 'package:dart_dev/src/utils/parse_imports.dart';
 import 'package:dart_dev/src/utils/pubspec_lock.dart';
 import 'package:glob/glob.dart';

--- a/lib/src/tools/analyze_tool.dart
+++ b/lib/src/tools/analyze_tool.dart
@@ -22,7 +22,7 @@ final _log = Logger('Analyze');
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'analyze': AnalyzeTool() ..useDartAnalyze = true,
@@ -33,7 +33,7 @@ final _log = Logger('Analyze');
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'analyze': AnalyzeTool()

--- a/lib/src/tools/compound_tool.dart
+++ b/lib/src/tools/compound_tool.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:args/args.dart';
-import 'package:dart_dev/dart_dev.dart';
+
 import 'package:logging/logging.dart';
 
 import '../dart_dev_tool.dart';
@@ -32,7 +32,7 @@ ArgResults takeOptionArgs(ArgParser parser, ArgResults results) =>
 /// positional args given to the compound target.
 ///
 ///     // tool/dart_dev/config.dart
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'test': CompoundTool()

--- a/lib/src/tools/format_tool.dart
+++ b/lib/src/tools/format_tool.dart
@@ -25,7 +25,7 @@ final _log = Logger('Format');
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'format': FormatTool(),
@@ -36,7 +36,7 @@ final _log = Logger('Format');
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'format': FormatTool()

--- a/lib/src/tools/over_react_format_tool.dart
+++ b/lib/src/tools/over_react_format_tool.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:dart_dev/dart_dev.dart';
-import 'package:dart_dev/utils.dart';
+
+
 
 import '../utils/executables.dart' as exe;
 import 'format_tool.dart';

--- a/lib/src/tools/process_tool.dart
+++ b/lib/src/tools/process_tool.dart
@@ -17,7 +17,7 @@ final _log = Logger('Process');
 /// process, waits for it to complete, and forwards its exit code.
 ///
 /// To create a [ProcessTool], all that is needed is an executable and args:
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'github': ProcessTool(

--- a/lib/src/tools/test_tool.dart
+++ b/lib/src/tools/test_tool.dart
@@ -25,7 +25,7 @@ final _log = Logger('Test');
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'test': TestTool(),
@@ -36,7 +36,7 @@ final _log = Logger('Test');
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'test': TestTool()

--- a/lib/src/tools/tuneup_check_tool.dart
+++ b/lib/src/tools/tuneup_check_tool.dart
@@ -21,7 +21,7 @@ final _log = Logger('TuneupCheck');
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'analyze': TuneupCheckTool(),
@@ -32,7 +32,7 @@ final _log = Logger('TuneupCheck');
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'analyze': TuneupCheckTool()

--- a/lib/src/tools/webdev_serve_tool.dart
+++ b/lib/src/tools/webdev_serve_tool.dart
@@ -24,7 +24,7 @@ final _log = Logger('WebdevServe');
 ///
 /// To use this tool in your project, include it in the dart_dev config in
 /// `tool/dart_dev/config.dart`:
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'serve': WebdevServeTool(),
@@ -35,7 +35,7 @@ final _log = Logger('WebdevServe');
 ///
 /// This tool can be configured by modifying any of its fields:
 ///     // tool/dart_dev/config.dart
-///     import 'package:dart_dev/dart_dev.dart';
+///     
 ///
 ///     final config = {
 ///       'serve': WebdevServeTool()


### PR DESCRIPTION
## Problem

An entrypoint import can be defined as an import within `lib/src` that imports a file within `lib/*.dart` (the entrypoints of a dart package). These imports are always unnecessary, and can contribute to slower dart build performance.

## Solution

This PR naively removes every entrypoint import within the repo, and updates the `gha-dart/.../checks.yaml` to the latest version. In order to merge this PR a few manual changes must be performed:

- Navigate to every file which has analysis errors caused from the missing import. Rely on intellisense to import the necessary symbol from the specific file, not the entrypoint import
- Implement the `no_entrypoint_imports` additional-checks option in `gha-dart@v2.10.13` that was added in [this PR](https://github.com/Workiva/gha-dart/pull/716). This will prevent new entrypoint imports from getting added once this PR merges

Our request to teams is to perform the above tasks, so we can default enable the `no_entrypoint_imports` check for all gha-dart consumers. Please reach out to [#support-frontend-dx](https://workiva.enterprise.slack.com/archives/C03ESR91BNU) for any questions or issues

## QA

- [ ] This pr is heavily dependant on the analysis server, and as such CI passes should be sufficient

[_Created by Sourcegraph batch change `Workiva/no_entrypoint_imports`._](https://workiva.sourcegraphcloud.com/organizations/Workiva/batch-changes/no_entrypoint_imports)